### PR TITLE
Fixed editor launch.

### DIFF
--- a/gui/OpenDungeons.layout
+++ b/gui/OpenDungeons.layout
@@ -95,61 +95,8 @@
             <Property name="Area" value="{{0,0},{1,-133},{1,0},{1,0}}" />
             <Property name="TabHeight" value="{0,30}" />
             <Property name="RiseOnClickEnabled" value="False" />
-            <Window type="DefaultWindow" name="Rooms" >
-                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
-                <Property name="Text" value="Rooms" />
-                <Property name="MaxSize" value="{{1,0},{1,0}}" />
-                <Property name="RiseOnClickEnabled" value="False" />
-                <Window type="OD/ImageButton" name="TreasuryButton" >
-                    <Property name="Area" value="{{0,20},{0,20},{0,80},{0,80}}" />
-                    <Property name="NormalImage" value="OpenDungeonsIcons/TreasuryButton" />
-                    <Property name="TooltipText" value="Build a treasury" />
-                    <Property name="InheritsAlpha" value="False" />
-                </Window>
-                <Window type="OD/ImageButton" name="DormitoryButton" >
-                    <Property name="Area" value="{{0,80},{0,20},{0,140},{0,80}}" />
-                    <Property name="NormalImage" value="OpenDungeonsIcons/DormitoryButton" />
-                    <Property name="TooltipText" value="Build sleeping places for your creatures" />
-                    <Property name="InheritsAlpha" value="False" />
-                </Window>
-                <Window type="OD/ImageButton" name="HatcheryButton" >
-                    <Property name="Area" value="{{0,140},{0,20},{0,200},{0,80}}" />
-                    <Property name="NormalImage" value="OpenDungeonsIcons/HatcheryButton" />
-                    <Property name="TooltipText" value="Build a Hatchery" />
-                    <Property name="InheritsAlpha" value="False" />
-                </Window>
-                <Window type="OD/ImageButton" name="TrainingHallButton" >
-                    <Property name="Area" value="{{0,200},{0,20},{0,260},{0,80}}" />
-                    <Property name="NormalImage" value="OpenDungeonsIcons/TrainingHallButton" />
-                    <Property name="TooltipText" value="Build a Training Hall" />
-                    <Property name="InheritsAlpha" value="False" />
-                </Window>
-                <Window type="OD/ImageButton" name="ForgeButton" >
-                    <Property name="Area" value="{{0,260},{0,20},{0,320},{0,80}}" />
-                    <Property name="NormalImage" value="OpenDungeonsIcons/ForgeButton" />
-                    <Property name="TooltipText" value="Build a Forge" />
-                    <Property name="InheritsAlpha" value="False" />
-                </Window>
-                <Window type="OD/ImageButton" name="LibraryButton" >
-                    <Property name="Area" value="{{0,320},{0,20},{0,380},{0,80}}" />
-                    <Property name="NormalImage" value="OpenDungeonsIcons/LibraryButton" />
-                    <Property name="TooltipText" value="Build a Hatchery" />
-                    <Property name="InheritsAlpha" value="False" />
-                </Window>
-            </Window>
-            <Window type="DefaultWindow" name="Traps" >
-                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
-                <Property name="Text" value="Traps" />
-                <Property name="MaxSize" value="{{1,0},{1,0}}" />
-                <Property name="Visible" value="False" />
-                <Property name="RiseOnClickEnabled" value="False" />
-                <Window type="OD/ImageButton" name="CannonButton" >
-                    <Property name="Area" value="{{0,20},{0,20},{0,80},{0,80}}" />
-                    <Property name="NormalImage" value="OpenDungeonsIcons/CannonButton" />
-                    <Property name="TooltipText" value="Buid a cannon" />
-                    <Property name="InheritsAlpha" value="False" />
-                </Window>
-            </Window>
+            <LayoutImport type="DefaultWindow" filename="OpenDungeonsMenuRooms.layout" name="RoomsImport" />
+            <LayoutImport type="DefaultWindow" filename="OpenDungeonsMenuTraps.layout" name="RoomsImport" />
             <Window type="DefaultWindow" name="Creatures" >
                 <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="Text" value="Creatures" />

--- a/gui/OpenDungeonsEditorMenu.layout
+++ b/gui/OpenDungeonsEditorMenu.layout
@@ -111,49 +111,8 @@
                     <Property name="InheritsAlpha" value="False" />
                 </Window>
             </Window>
-            <Window type="DefaultWindow" name="Rooms" >
-                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
-                <Property name="Text" value="Rooms" />
-                <Property name="MaxSize" value="{{1,0},{1,0}}" />
-                <Property name="RiseOnClickEnabled" value="False" />
-                <Window type="OD/ImageButton" name="DormitoryButton" >
-                    <Property name="Area" value="{{0,20},{0,20},{0,80},{0,80}}" />
-                    <Property name="NormalImage" value="OpenDungeonsIcons/DormitoryButton" />
-                    <Property name="TooltipText" value="Build sleeping places for your creatures" />
-                    <Property name="InheritsAlpha" value="False" />
-                </Window>
-                <Window type="OD/ImageButton" name="ForgeButton" >
-                    <Property name="Area" value="{{0,80},{0,20},{0,140},{0,80}}" />
-                    <Property name="NormalImage" value="OpenDungeonsIcons/ForgeButton" />
-                    <Property name="TooltipText" value="Build a Forge" />
-                    <Property name="InheritsAlpha" value="False" />
-                </Window>
-                <Window type="OD/ImageButton" name="TrainingHallButton" >
-                    <Property name="Area" value="{{0,140},{0,20},{0,200},{0,80}}" />
-                    <Property name="NormalImage" value="OpenDungeonsIcons/TrainingHallButton" />
-                    <Property name="TooltipText" value="Build a Training Hall" />
-                    <Property name="InheritsAlpha" value="False" />
-                </Window>
-                <Window type="OD/ImageButton" name="TreasuryButton" >
-                    <Property name="Area" value="{{0,200},{0,20},{0,260},{0,80}}" />
-                    <Property name="NormalImage" value="OpenDungeonsIcons/TreasuryButton" />
-                    <Property name="TooltipText" value="Build a treasury" />
-                    <Property name="InheritsAlpha" value="False" />
-                </Window>
-            </Window>
-            <Window type="DefaultWindow" name="Traps" >
-                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
-                <Property name="Text" value="Traps" />
-                <Property name="MaxSize" value="{{1,0},{1,0}}" />
-                <Property name="Visible" value="False" />
-                <Property name="RiseOnClickEnabled" value="False" />
-                <Window type="OD/ImageButton" name="CannonButton" >
-                    <Property name="Area" value="{{0,20},{0,20},{0,80},{0,80}}" />
-                    <Property name="NormalImage" value="OpenDungeonsIcons/CannonButton" />
-                    <Property name="TooltipText" value="Buid a cannon" />
-                    <Property name="InheritsAlpha" value="False" />
-                </Window>
-            </Window>
+            <LayoutImport type="DefaultWindow" filename="OpenDungeonsMenuRooms.layout" name="RoomsImport" />
+            <LayoutImport type="DefaultWindow" filename="OpenDungeonsMenuTraps.layout" name="RoomsImport" />
             <Window type="DefaultWindow" name="Creatures" >
                 <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="Text" value="Creatures" />

--- a/gui/OpenDungeonsMenuRooms.layout
+++ b/gui/OpenDungeonsMenuRooms.layout
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<GUILayout version="4" >
+   <Window type="DefaultWindow" name="Rooms" >
+       <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
+       <Property name="Text" value="Rooms" />
+       <Property name="MaxSize" value="{{1,0},{1,0}}" />
+       <Property name="RiseOnClickEnabled" value="False" />
+       <Window type="OD/ImageButton" name="TreasuryButton" >
+           <Property name="Area" value="{{0,20},{0,20},{0,80},{0,80}}" />
+           <Property name="NormalImage" value="OpenDungeonsIcons/TreasuryButton" />
+           <Property name="TooltipText" value="Build a treasury" />
+           <Property name="InheritsAlpha" value="False" />
+       </Window>
+       <Window type="OD/ImageButton" name="DormitoryButton" >
+           <Property name="Area" value="{{0,80},{0,20},{0,140},{0,80}}" />
+           <Property name="NormalImage" value="OpenDungeonsIcons/DormitoryButton" />
+           <Property name="TooltipText" value="Build sleeping places for your creatures" />
+           <Property name="InheritsAlpha" value="False" />
+       </Window>
+       <Window type="OD/ImageButton" name="HatcheryButton" >
+           <Property name="Area" value="{{0,140},{0,20},{0,200},{0,80}}" />
+           <Property name="NormalImage" value="OpenDungeonsIcons/HatcheryButton" />
+           <Property name="TooltipText" value="Build a Hatchery" />
+           <Property name="InheritsAlpha" value="False" />
+       </Window>
+       <Window type="OD/ImageButton" name="TrainingHallButton" >
+           <Property name="Area" value="{{0,200},{0,20},{0,260},{0,80}}" />
+           <Property name="NormalImage" value="OpenDungeonsIcons/TrainingHallButton" />
+           <Property name="TooltipText" value="Build a Training Hall" />
+           <Property name="InheritsAlpha" value="False" />
+       </Window>
+       <Window type="OD/ImageButton" name="ForgeButton" >
+           <Property name="Area" value="{{0,260},{0,20},{0,320},{0,80}}" />
+           <Property name="NormalImage" value="OpenDungeonsIcons/ForgeButton" />
+           <Property name="TooltipText" value="Build a Forge" />
+           <Property name="InheritsAlpha" value="False" />
+       </Window>
+       <Window type="OD/ImageButton" name="LibraryButton" >
+           <Property name="Area" value="{{0,320},{0,20},{0,380},{0,80}}" />
+           <Property name="NormalImage" value="OpenDungeonsIcons/LibraryButton" />
+           <Property name="TooltipText" value="Build a Hatchery" />
+           <Property name="InheritsAlpha" value="False" />
+       </Window>
+   </Window>
+</GUILayout>

--- a/gui/OpenDungeonsMenuTraps.layout
+++ b/gui/OpenDungeonsMenuTraps.layout
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<GUILayout version="4" >
+   <Window type="DefaultWindow" name="Traps" >
+       <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
+       <Property name="Text" value="Traps" />
+       <Property name="MaxSize" value="{{1,0},{1,0}}" />
+       <Property name="Visible" value="False" />
+       <Property name="RiseOnClickEnabled" value="False" />
+       <Window type="OD/ImageButton" name="CannonButton" >
+           <Property name="Area" value="{{0,20},{0,20},{0,80},{0,80}}" />
+           <Property name="NormalImage" value="OpenDungeonsIcons/CannonButton" />
+           <Property name="TooltipText" value="Buid a cannon" />
+           <Property name="InheritsAlpha" value="False" />
+       </Window>
+   </Window>
+</GUILayout>

--- a/source/AbstractApplicationMode.h
+++ b/source/AbstractApplicationMode.h
@@ -49,11 +49,10 @@ public:
     //! \brief Input methods
     enum DragType
     {
-        creature,
-        mapLight,
         tileSelection,
         addNewRoom,
         addNewTrap,
+        changeTile,
         nullDragType
     };
 

--- a/source/ClientNotification.cpp
+++ b/source/ClientNotification.cpp
@@ -50,6 +50,14 @@ std::string ClientNotification::typeString(ClientNotificationType type)
             return "ackNewTurn";
         case ClientNotificationType::askCreatureInfos:
             return "askCreatureInfos";
+        case ClientNotificationType::editorAskSaveMap:
+            return "editorAskSaveMap";
+        case ClientNotificationType::editorAskChangeTiles:
+            return "editorAskChangeTiles";
+        case ClientNotificationType::editorAskBuildRoom:
+            return "editorAskBuildRoom";
+        case ClientNotificationType::editorAskBuildTrap:
+            return "editorAskBuildTrap";
         default:
             LogManager::getSingleton().logMessage("ERROR: Unknown enum for ClientNotificationType="
                 + Ogre::StringConverter::toString(static_cast<int>(type)));

--- a/source/ClientNotification.h
+++ b/source/ClientNotification.h
@@ -46,7 +46,13 @@ public:
         askBuildRoom,
         askBuildTrap,
         ackNewTurn,
-        askCreatureInfos
+        askCreatureInfos,
+
+        //  Editor
+        editorAskSaveMap,
+        editorAskChangeTiles,
+        editorAskBuildRoom,
+        editorAskBuildTrap
     };
 
     ClientNotification(ClientNotificationType type);

--- a/source/Console_executePromptCommand.cpp
+++ b/source/Console_executePromptCommand.cpp
@@ -775,7 +775,7 @@ bool Console::executePromptCommand(const std::string& command, std::string argum
             // Make sure we are not already connected to a server or hosting a game.
             if (!frameListener->isConnected())
             {
-                if (ODServer::getSingleton().startServer(arguments, false))
+                if (ODServer::getSingleton().startServer(arguments, false, ODServer::ServerMode::ModeGame))
                 {
                     frameListener->mCommandOutput += "\nServer started successfully.\n";
 

--- a/source/Creature.cpp
+++ b/source/Creature.cpp
@@ -178,6 +178,14 @@ void Creature::createMeshLocal()
     request->vec    = static_cast<Creature*>(this)->getDefinition()->getScale();
     request->p = static_cast<void*>(this);
     RenderManager::queueRenderRequest(request);
+
+    // By default, we set the creature in idle state
+    request = new RenderRequest;
+    request->type = RenderRequest::setObjectAnimationState;
+    request->p = static_cast<void*>(this);
+    request->str = "Idle";
+    request->b = true;
+    RenderManager::queueRenderRequest(request);
 }
 
 void Creature::destroyMeshLocal()
@@ -218,7 +226,7 @@ std::string Creature::getFormat()
 {
     //NOTE:  When this format changes changes to RoomPortal::spawnCreature() may be necessary.
     return "className\tname\tposX\tposY\tposZ\tcolor\tweaponL"
-        + Weapon::getFormat() + "\tweaponR" + Weapon::getFormat() + "\tHP";
+        + Weapon::getFormat() + "\tweaponR" + Weapon::getFormat() + "\tHP\tLevel";
 }
 
 //! \brief A matched function to transport creatures between files and over the network.

--- a/source/EditorMode.cpp
+++ b/source/EditorMode.cpp
@@ -434,18 +434,16 @@ bool EditorMode::mousePressed(const OIS::MouseEvent &arg, OIS::MouseButtonID id)
             if (currentCreature == NULL)
                 continue;
 
-            if (currentCreature->getColor() == player->getSeat()->getColor())
+            // In editor mode, we allow pickup of all creatures. No need to test color
+            if (ODClient::getSingleton().isConnected())
             {
-                if (ODClient::getSingleton().isConnected())
-                {
-                    // Send a message to the server telling it we want to pick up this creature
-                    ClientNotification *clientNotification = new ClientNotification(
-                        ClientNotification::askCreaturePickUp);
-                    std::string name = currentCreature->getName();
-                    clientNotification->mPacket << name;
-                    ODClient::getSingleton().queueClientNotification(clientNotification);
-                    return true;
-                }
+                // Send a message to the server telling it we want to pick up this creature
+                ClientNotification *clientNotification = new ClientNotification(
+                    ClientNotification::askCreaturePickUp);
+                std::string name = currentCreature->getName();
+                clientNotification->mPacket << name;
+                ODClient::getSingleton().queueClientNotification(clientNotification);
+                return true;
             }
         }
     }

--- a/source/GameMap.cpp
+++ b/source/GameMap.cpp
@@ -788,7 +788,8 @@ void GameMap::updateAnimations(Ogre::Real timeSinceLastFrame)
         if (startY <= 0.0)
             startY = 0.0;
 
-        ODFrameListener::getSingleton().cm->setCameraPosition(Ogre::Vector3(startX, startY, MAX_CAMERA_Z));
+        if(!isServerGameMap())
+            ODFrameListener::getSingleton().cm->setCameraPosition(Ogre::Vector3(startX, startY, MAX_CAMERA_Z));
 
         // Create ogre entities for the tiles, rooms, and creatures
         createAllEntities();

--- a/source/GameMode.cpp
+++ b/source/GameMode.cpp
@@ -133,8 +133,8 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
     Player* player = mGameMap->getLocalPlayer();
     Room::RoomType selectedRoomType = player->getNewRoomType();
     Trap::TrapType selectedTrapType = player->getNewTrapType();
-    if (player && (selectedRoomType != Room::nullRoomType
-        || selectedTrapType != Trap::nullTrapType))
+    if (selectedRoomType != Room::nullRoomType ||
+        selectedTrapType != Trap::nullTrapType)
     {
         TextRenderer::getSingleton().moveText(ODApplication::POINTER_INFO_STRING,
             (Ogre::Real)(arg.state.X.abs + 30), (Ogre::Real)arg.state.Y.abs);
@@ -148,7 +148,7 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
             nbTile = buildableTiles.size();
         }
 
-        // TODO : the first treasury tile nshould be free. This should be shown here
+        // TODO : the first treasury tile should be free. This should be shown here
         if(selectedRoomType != Room::nullRoomType)
         {
             int price = Room::costPerTile(selectedRoomType) * nbTile;
@@ -338,10 +338,9 @@ bool GameMode::mousePressed(const OIS::MouseEvent &arg, OIS::MouseButtonID id)
                     ClientNotification::askCreatureDrop);
                 clientNotification->mPacket << curTile;
                 ODClient::getSingleton().queueClientNotification(clientNotification);
-                return true;
             }
 
-            mGameMap->getLocalPlayer()->dropCreature(curTile);
+            return true;
         }
     }
 
@@ -429,7 +428,8 @@ bool GameMode::mousePressed(const OIS::MouseEvent &arg, OIS::MouseButtonID id)
 
         std::string resultName = itr->movable->getName();
 
-        if (resultName.find("Level_") == std::string::npos)
+        int x, y;
+        if (!Tile::checkTileName(resultName, x, y))
             continue;
 
         // Start by assuming this is a tileSelection drag.
@@ -500,8 +500,6 @@ bool GameMode::mouseReleased(const OIS::MouseEvent &arg, OIS::MouseButtonID id)
     switch(dragType)
     {
         default:
-        case creature:
-        case mapLight:
             dragType = nullDragType;
             return true;
 

--- a/source/Gui.cpp
+++ b/source/Gui.cpp
@@ -209,6 +209,34 @@ void Gui::assignEventHandlers()
     sheets[editorMenu]->getChild(EDITOR_CLAIMED_BUTTON)->subscribeEvent(
         CEGUI:: Window::EventMouseClick,
         CEGUI::Event::Subscriber(&editorClaimedButtonPressed));
+    // Game Mode controls
+    sheets[editorMenu]->getChild(BUTTON_DORMITORY)->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&dormitoryButtonPressed));
+
+    sheets[editorMenu]->getChild(BUTTON_TREASURY)->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&treasuryButtonPressed));
+
+    sheets[editorMenu]->getChild(BUTTON_FORGE)->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&forgeButtonPressed));
+
+    sheets[editorMenu]->getChild(BUTTON_TRAININGHALL)->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&trainingHallButtonPressed));
+
+    sheets[editorMenu]->getChild(BUTTON_LIBRARY)->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&libraryButtonPressed));
+
+    sheets[editorMenu]->getChild(BUTTON_HATCHERY)->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&hatcheryButtonPressed));
+
+    sheets[editorMenu]->getChild(BUTTON_CANNON)->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&cannonButtonPressed));
 
     // Skirmish level select menu controls
     sheets[skirmishMenu]->getChild(SKM_BUTTON_LAUNCH)->subscribeEvent(
@@ -338,18 +366,8 @@ bool Gui::confirmExitYesButtonPressed(const CEGUI::EventArgs& e)
 
     SoundEffectsManager::getSingleton().playInterfaceSound(SoundEffectsManager::BUTTONCLICK);
     mm->requestUnloadToParentGameMode();
+    mm->shutdownGameMode();
 
-    if(ODClient::getSingleton().isConnected())
-        ODClient::getSingleton().disconnect();
-    if(ODServer::getSingleton().isConnected())
-        ODServer::getSingleton().stopServer();
-
-    // Now that the server is stopped, we can clear the client game map
-    // We process RenderRequests in case there is graphical things pending
-    RenderManager::getSingleton().processRenderRequests();
-    ODFrameListener::getSingleton().getClientGameMap()->clearAll();
-    // We process again RenderRequests to destroy/delete what clearAll has put in the queue
-    RenderManager::getSingleton().processRenderRequests();
     return true;
 }
 
@@ -451,6 +469,16 @@ bool Gui::mMMapEditorButtonPressed(const CEGUI::EventArgs& e)
     ModeManager* mm = ODFrameListener::getSingleton().getModeManager();
     if (!mm)
         return true;
+
+    // TODO : use a proper screen to choose level
+    if(!ODServer::getSingleton().startServer("levels/Test.level", true, ODServer::ServerMode::ModeEditor))
+    {
+        LogManager::getSingleton().logMessage("ERROR: Could not start server for editor !!!");
+    }
+    if(!ODClient::getSingleton().connect("", ODApplication::PORT_NUMBER))
+    {
+        LogManager::getSingleton().logMessage("ERROR: Could not start client for editor !!!");
+    }
 
     SoundEffectsManager::getSingleton().playInterfaceSound(SoundEffectsManager::BUTTONCLICK);
     mm->requestEditorMode();

--- a/source/MapLight.cpp
+++ b/source/MapLight.cpp
@@ -29,6 +29,7 @@
 #include <sstream>
 
 const std::string MapLight::MAPLIGHT_NAME_PREFIX = "Map_light_";
+const std::string MapLight::MAPLIGHT_INDICATOR_PREFIX = "MapLightIndicator_";
 
 void MapLight::setLocation(const Ogre::Vector3& nPosition)
 {
@@ -229,4 +230,24 @@ void MapLight::loadFromLine(const std::string& line, MapLight* m)
     m->mAttenuationConstant = Helper::toDouble(elems[10]);
     m->mAttenuationLinear = Helper::toDouble(elems[11]);
     m->mAttenuationQuadratic = Helper::toDouble(elems[12]);
+}
+
+std::ostream& operator<<(std::ostream& os, MapLight *m)
+{
+    os << m->mPosition.x << "\t" << m->mPosition.y << "\t" << m->mPosition.z;
+    os << "\t" << m->mDiffuseColor.r << "\t" << m->mDiffuseColor.g << "\t" << m->mDiffuseColor.b;
+    os << "\t" << m->mSpecularColor.r << "\t" << m->mSpecularColor.g << "\t" << m->mSpecularColor.b;
+    os << "\t" << m->mAttenuationRange << "\t" << m->mAttenuationConstant;
+    os << "\t" << m->mAttenuationLinear << "\t" << m->mAttenuationQuadratic;
+    return os;
+}
+
+std::istream& operator>>(std::istream& is, MapLight *m)
+{
+    is >> m->mPosition.x >> m->mPosition.y >> m->mPosition.z;
+    is >> m->mDiffuseColor.r >> m->mDiffuseColor.g >> m->mDiffuseColor.b;
+    is >> m->mSpecularColor.r >> m->mSpecularColor.g >> m->mSpecularColor.b;
+    is >> m->mAttenuationRange >> m->mAttenuationConstant;
+    is >> m->mAttenuationLinear >> m->mAttenuationQuadratic;
+    return is;
 }

--- a/source/MapLight.h
+++ b/source/MapLight.h
@@ -69,6 +69,7 @@ public:
     {}
 
     static const std::string MAPLIGHT_NAME_PREFIX;
+    static const std::string MAPLIGHT_INDICATOR_PREFIX;
 
     void setLocation(const Ogre::Vector3& nPosition);
     void setDiffuseColor(Ogre::Real red, Ogre::Real green, Ogre::Real blue);
@@ -119,6 +120,8 @@ public:
     static std::string getFormat();
     friend ODPacket& operator<<(ODPacket& os, MapLight *m);
     friend ODPacket& operator>>(ODPacket& is, MapLight *m);
+    friend std::ostream& operator<<(std::ostream& os, MapLight *m);
+    friend std::istream& operator>>(std::istream& is, MapLight *m);
 
     //! \brief Loads the map light data from a level line.
     static void loadFromLine(const std::string& line, MapLight* m);

--- a/source/MenuModeMultiplayer.cpp
+++ b/source/MenuModeMultiplayer.cpp
@@ -122,7 +122,10 @@ void MenuModeMultiplayer::serverButtonPressed()
 
     // We are a server
     std::string level = LEVEL_PATH + mListFiles[id] + LEVEL_EXTENSION;
-    ODServer::getSingleton().startServer(level, false);
+    if(!ODServer::getSingleton().startServer(level, false, ODServer::ServerMode::ModeGame))
+    {
+        LogManager::getSingleton().logMessage("ERROR: Could not start server for multi player game !!!");
+    }
 
     // We connect ourself
     if(ODClient::getSingleton().connect("", ODApplication::PORT_NUMBER))
@@ -131,7 +134,7 @@ void MenuModeMultiplayer::serverButtonPressed()
     }
     else
     {
-        LogManager::getSingleton().logMessage("ERROR: Could not connect to server for single player game !!!");
+        LogManager::getSingleton().logMessage("ERROR: Could not connect to server for multi player game !!!");
         tmpWin = Gui::getSingleton().getGuiSheet(Gui::multiplayerMenu)->getChild(Gui::MPM_TEXT_LOADING);
         tmpWin->setText("Error: Couldn't connect to local server!");
         tmpWin->show();

--- a/source/MenuModeSkirmish.cpp
+++ b/source/MenuModeSkirmish.cpp
@@ -98,7 +98,7 @@ void MenuModeSkirmish::launchSelectedButtonPressed()
 
     std::string level = LEVEL_PATH + mListFiles[id] + LEVEL_EXTENSION;
     // In single player mode, we act as a server
-    if(!ODServer::getSingleton().startServer(level, true))
+    if(!ODServer::getSingleton().startServer(level, true, ODServer::ServerMode::ModeGame))
     {
         LogManager::getSingleton().logMessage("ERROR: Could not start server for single player game !!!");
     }

--- a/source/ModeManager.cpp
+++ b/source/ModeManager.cpp
@@ -27,6 +27,10 @@
 #include "Console.h"
 #include "ConsoleMode.h"
 #include "FppMode.h"
+#include "ODClient.h"
+#include "ODServer.h"
+#include "RenderManager.h"
+#include "ODFrameListener.h"
 
 ModeManager::ModeManager()
 {
@@ -158,4 +162,19 @@ void ModeManager::checkModeChange()
 
     mRequestedMode = NONE;
     mDiscardActualMode = false;
+}
+
+void ModeManager::shutdownGameMode()
+{
+    if(ODClient::getSingleton().isConnected())
+        ODClient::getSingleton().disconnect();
+    if(ODServer::getSingleton().isConnected())
+        ODServer::getSingleton().stopServer();
+
+    // Now that the server is stopped, we can clear the client game map
+    // We process RenderRequests in case there is graphical things pending
+    RenderManager::getSingleton().processRenderRequests();
+    ODFrameListener::getSingleton().getClientGameMap()->clearAll();
+    // We process again RenderRequests to destroy/delete what clearAll has put in the queue
+    RenderManager::getSingleton().processRenderRequests();
 }

--- a/source/ModeManager.h
+++ b/source/ModeManager.h
@@ -109,6 +109,8 @@ public:
         mRequestedMode = PREV;
     }
 
+    void shutdownGameMode();
+
     //! \brief Actually change the game mode if needed
     void checkModeChange();
 

--- a/source/ODServer.cpp
+++ b/source/ODServer.cpp
@@ -593,7 +593,8 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             if ((creature != NULL) && (creature->getIsOnMap()))
             {
                 int color = creature->getColor();
-                if(color == player->getSeat()->getColor())
+                if((color == player->getSeat()->getColor()) ||
+                   (mServerMode = ServerMode::ModeEditor))
                 {
                     player->pickUpCreature(creature);
                     // We notify the player that he pickedup the creature

--- a/source/ODServer.cpp
+++ b/source/ODServer.cpp
@@ -24,6 +24,7 @@
 #include "MapLight.h"
 #include "ChatMessage.h"
 #include "ODConsoleCommand.h"
+#include "MapLoader.h"
 #include "LogManager.h"
 
 #include <SFML/Network.hpp>
@@ -44,7 +45,7 @@ ODServer::~ODServer()
     delete mGameMap;
 }
 
-bool ODServer::startServer(const std::string& levelFilename, bool replaceHumanPlayersByAi)
+bool ODServer::startServer(const std::string& levelFilename, bool replaceHumanPlayersByAi, ServerMode mode)
 {
     LogManager& logManager = LogManager::getSingleton();
 
@@ -64,6 +65,7 @@ bool ODServer::startServer(const std::string& levelFilename, bool replaceHumanPl
 
     // Read in the map. The map loading should be happen here and not in the server thread to
     // make sure it is valid before launching the server.
+    mServerMode = mode;
     GameMap* gameMap = mGameMap;
     if (!gameMap->loadLevel(levelFilename))
     {
@@ -250,9 +252,14 @@ void ODServer::startNewTurn(double timeSinceLastFrame)
         }
     }
 
-    gameMap->doTurn();
+    // We do not update turn in editor mode to not have creatures wande
+    if(mServerMode == ServerMode::ModeGame)
+    {
+        gameMap->doTurn();
+        gameMap->doPlayerAITurn(timeSinceLastFrame);
+    }
+
     gameMap->processDeletionQueues();
-    gameMap->doPlayerAITurn(timeSinceLastFrame);
 }
 
 void ODServer::serverThread()
@@ -628,7 +635,7 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 + "," + Ogre::StringConverter::toString(tmpTile.getY()));
             if(tile != NULL)
             {
-                if(player->isDropCreaturePossible(tile))
+                if(player->isDropCreaturePossible(tile, 0, mServerMode == ServerMode::ModeEditor))
                 {
                     player->dropCreature(tile);
                     int color = player->getSeat()->getColor();
@@ -785,6 +792,174 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             break;
         }
 
+        case ClientNotification::editorAskSaveMap:
+        {
+            Player* player = clientSocket->getPlayer();
+            if(player->numCreaturesInHand() == 0)
+            {
+                MapLoader::writeGameMapToFile(mLevelFilename + ".out", *gameMap);
+                ODPacket packet;
+                packet << ServerNotification::chatServer;
+                std::string msg = "Map saved successfully";
+                packet << msg;
+                sendToAllClients(packet);
+            }
+            else
+            {
+                // We cannot save the map
+                ODPacket packet;
+                packet << ServerNotification::chatServer;
+                std::string msg = "Map could not be saved because player hand is not empty";
+                packet << msg;
+                sendToAllClients(packet);
+            }
+            break;
+        }
+
+        case ClientNotification::editorAskChangeTiles:
+        {
+            int x1, y1, x2, y2;
+            int intTileType;
+            double tileFullness;
+
+            OD_ASSERT_TRUE(packetReceived >> x1 >> y1 >> x2 >> y2 >> intTileType >> tileFullness);
+            Tile::TileType tileType = static_cast<Tile::TileType>(intTileType);
+            std::vector<Tile*> selectedTiles = gameMap->rectangularRegion(x1, y1, x2, y2);
+            std::vector<Tile*> affectedTiles;
+            for(std::vector<Tile*>::iterator it = selectedTiles.begin(); it != selectedTiles.end(); ++it)
+            {
+                Tile* tile = *it;
+                if(tile == NULL)
+                    continue;
+
+                // We do not change tiles where there is something
+                if(tile->numCreaturesInCell() > 0)
+                    continue;
+                if(tile->getCoveringRoom() != NULL)
+                    continue;
+                if(tile->getCoveringTrap())
+                    continue;
+
+                affectedTiles.push_back(tile);
+                tile->setType(tileType);
+                tile->setFullness(tileFullness);
+            }
+            if(!affectedTiles.empty())
+            {
+                ODPacket packet;
+                int nbTiles = affectedTiles.size();
+                packet << ServerNotification::refreshTiles;
+                packet << nbTiles;
+                for(std::vector<Tile*>::iterator it = affectedTiles.begin(); it != affectedTiles.end(); ++it)
+                {
+                    Tile* tile = *it;
+                    packet << tile;
+                }
+                sendToAllClients(packet);
+            }
+            break;
+        }
+
+        case ClientNotification::editorAskBuildRoom:
+        {
+            int x1, y1, x2, y2;
+            int intType;
+
+            OD_ASSERT_TRUE(packetReceived >> x1 >> y1 >> x2 >> y2 >> intType);
+            Player* player = clientSocket->getPlayer();
+            int color = player->getSeat()->getColor();
+            std::vector<Tile*> selectedTiles = gameMap->rectangularRegion(x1, y1, x2, y2);
+            std::vector<Tile*> affectedTiles;
+            for(std::vector<Tile*>::iterator it = selectedTiles.begin(); it != selectedTiles.end(); ++it)
+            {
+                Tile* tile = *it;
+                if(tile == NULL)
+                    continue;
+
+                // We do not change tiles where there is something
+                if(tile->numCreaturesInCell() > 0)
+                    continue;
+                if(tile->getCoveringRoom() != NULL)
+                    continue;
+                if(tile->getCoveringTrap())
+                    continue;
+                affectedTiles.push_back(tile);
+
+                tile->setType(Tile::TileType::claimed);
+                tile->setColor(color);
+                tile->setFullness(0.0);
+            }
+
+            if(!affectedTiles.empty())
+            {
+                Room::RoomType type = static_cast<Room::RoomType>(intType);
+                Room* room = gameMap->buildRoomForPlayer(affectedTiles, type, player);
+                // We build the message for the new room creation here with the original room size because
+                // it may change if a room is absorbed
+                ODPacket packet;
+                packet << ServerNotification::buildRoom;
+                int nbTiles = affectedTiles.size();
+                const std::string& name = room->getName();
+                packet << name << intType << color << nbTiles;
+                for(std::vector<Tile*>::iterator it = affectedTiles.begin(); it != affectedTiles.end(); ++it)
+                {
+                    Tile* tile = *it;
+                    packet << tile;
+                }
+                sendToAllClients(packet);
+            }
+            break;
+        }
+
+        case ClientNotification::editorAskBuildTrap:
+        {
+            int x1, y1, x2, y2;
+            int intType;
+
+            OD_ASSERT_TRUE(packetReceived >> x1 >> y1 >> x2 >> y2 >> intType);
+            Player* player = clientSocket->getPlayer();
+            int color = player->getSeat()->getColor();
+            std::vector<Tile*> selectedTiles = gameMap->rectangularRegion(x1, y1, x2, y2);
+            std::vector<Tile*> affectedTiles;
+            for(std::vector<Tile*>::iterator it = selectedTiles.begin(); it != selectedTiles.end(); ++it)
+            {
+                Tile* tile = *it;
+                if(tile == NULL)
+                    continue;
+
+                // We do not change tiles where there is something
+                if(tile->numCreaturesInCell() > 0)
+                    continue;
+                if(tile->getCoveringRoom() != NULL)
+                    continue;
+                if(tile->getCoveringTrap())
+                    continue;
+                affectedTiles.push_back(tile);
+
+                tile->setType(Tile::TileType::claimed);
+                tile->setColor(color);
+                tile->setFullness(0.0);
+            }
+
+            if(!affectedTiles.empty())
+            {
+                Trap::TrapType type = static_cast<Trap::TrapType>(intType);
+                Trap* trap = gameMap->buildTrapForPlayer(affectedTiles, type, player);
+                ODPacket packet;
+                packet << ServerNotification::buildTrap;
+                int nbTiles = affectedTiles.size();
+                const std::string& name = trap->getName();
+                packet << name << intType << color << nbTiles;
+                for(std::vector<Tile*>::iterator it = affectedTiles.begin(); it != affectedTiles.end(); ++it)
+                {
+                    Tile* tile = *it;
+                    packet << tile;
+                }
+                sendToAllClients(packet);
+            }
+            break;
+        }
+
         default:
         {
             LogManager::getSingleton().logMessage("ERROR:  Unhandled command received from client:"
@@ -832,7 +1007,7 @@ bool ODServer::notifyClientMessage(ODSocketClient *clientSocket)
         }
         catch (std::bad_alloc&)
         {
-            Ogre::LogManager::getSingleton().logMessage("ERROR: bad alloc in ODServer::processClientNotifications", Ogre::LML_CRITICAL);
+            OD_ASSERT_TRUE(false);
             exit(1);
         }
         // TODO : wait at least 1 minute if the client reconnects

--- a/source/ODServer.h
+++ b/source/ODServer.h
@@ -48,10 +48,15 @@ class ODServer: public Ogre::Singleton<ODServer>,
     public ODSocketServer
 {
  public:
+     enum ServerMode
+     {
+         ModeGame,
+         ModeEditor
+     };
     ODServer();
     ~ODServer();
 
-    bool startServer(const std::string& levelFilename, bool replaceHumanPlayersByAi);
+    bool startServer(const std::string& levelFilename, bool replaceHumanPlayersByAi, ServerMode mode);
     void stopServer();
 
     //! \brief Adds a server notification to the server notification queue.
@@ -70,6 +75,7 @@ protected:
     void serverThread();
 
 private:
+    ServerMode mServerMode;
     GameMap *mGameMap;
     std::string mLevelFilename;
 

--- a/source/Player.cpp
+++ b/source/Player.cpp
@@ -117,7 +117,7 @@ void Player::removeCreatureFromHand(int i)
     mCreaturesInHand.erase(mCreaturesInHand.begin() + i);
 }
 
-bool Player::isDropCreaturePossible(Tile *t, unsigned int index)
+bool Player::isDropCreaturePossible(Tile *t, unsigned int index, bool isEditorMode)
 {
     // if we have a creature to drop
     if (mCreaturesInHand.empty())
@@ -128,11 +128,14 @@ bool Player::isDropCreaturePossible(Tile *t, unsigned int index)
     // if the tile is a valid place to drop a creature
 
     // check whether the tile is a ground tile ...
-    if (t->getFullness() >= 1.0)
+    if (t->getFullness() > 0.0)
         return false;
 
-    // ... and that the creature can dig, or we're putting it on a claimed tile of the team color.
-    if ((tempCreature->getDigRate() < 0.1 || (t->getType() != Tile::dirt && t->getType() != Tile::gold))
+    // In editor mode, we allow creatures to be dropped anywhere if they can walk
+    if(isEditorMode && t->canCreatureGoThroughTile(tempCreature->getDefinition()))
+        return true;
+
+    if ((!tempCreature->getDefinition()->isWorker() || (t->getType() != Tile::dirt && t->getType() != Tile::gold))
             && (t->getType() != Tile::claimed || t->getColor() != getSeat()->getColor()))
         return false;
 

--- a/source/Player.h
+++ b/source/Player.h
@@ -76,7 +76,7 @@ public:
     void pickUpCreature(Creature *c);
 
     //! \brief Check to see the first creatureInHand can be dropped on Tile t and do so if possible.
-    bool isDropCreaturePossible(Tile *t, unsigned int index = 0);
+    bool isDropCreaturePossible(Tile *t, unsigned int index = 0, bool isEditorMode = false);
 
     //! \brief Drops the creature on tile t
     void dropCreature(Tile *t, unsigned int index = 0);

--- a/source/RenderManager.cpp
+++ b/source/RenderManager.cpp
@@ -928,7 +928,7 @@ void RenderManager::rrCreateMapLight(const RenderRequest& renderRequest)
     if (renderRequest.b)
     {
         // Create the MapLightIndicator mesh so the light can be drug around in the map editor.
-        Ogre::Entity* lightEntity = mSceneManager->createEntity("MapLightIndicator_"
+        Ogre::Entity* lightEntity = mSceneManager->createEntity(MapLight::MAPLIGHT_INDICATOR_PREFIX
                                     + curMapLight->getName(), "Light.mesh");
         mapLightNode->attachObject(lightEntity);
     }
@@ -971,7 +971,7 @@ void RenderManager::rrDestroyMapLightVisualIndicator(const RenderRequest& render
     if (mSceneManager->hasLight(mapLightName))
     {
         Ogre::SceneNode* mapLightNode = mSceneManager->getSceneNode(mapLightName + "_node");
-        std::string mapLightIndicatorName = "MapLightIndicator_"
+        std::string mapLightIndicatorName = MapLight::MAPLIGHT_INDICATOR_PREFIX
                                             + curMapLight->getName();
         if (mSceneManager->hasEntity(mapLightIndicatorName))
         {

--- a/source/Room.cpp
+++ b/source/Room.cpp
@@ -634,7 +634,7 @@ std::ostream& operator<<(std::ostream& os, Room *r)
     if (r == NULL)
         return os;
 
-    os << r->getMeshName() << "\t" << r->getName() << "\t" << r->getColor() << "\n";
+    os << r->getMeshName() << "\t" << r->getColor() << "\n";
     os << r->mCoveredTiles.size() << "\n";
     for (unsigned int i = 0; i < r->mCoveredTiles.size(); ++i)
     {

--- a/source/Seat.cpp
+++ b/source/Seat.cpp
@@ -204,7 +204,7 @@ void Seat::goalsHasChanged()
 
 std::string Seat::getFormat()
 {
-    return "color\tfaction\tstartingX\tstartingY\tcolorR\tcolorG\tcolorB";
+    return "color\tfaction\tstartingX\tstartingY\tcolorR\tcolorG\tcolorB\tstartingGold";
 }
 
 ODPacket& operator<<(ODPacket& os, Seat *s)
@@ -253,4 +253,28 @@ void Seat::refreshFromSeat(Seat* s)
     mManaDelta = s->mManaDelta;
     mNumClaimedTiles = s->mNumClaimedTiles;
     mHasGoalsChanged = s->mHasGoalsChanged;
+}
+
+bool Seat::sortByColor(Seat* s1, Seat* s2)
+{
+    return s1->mColor < s2->mColor;
+}
+
+std::ostream& operator<<(std::ostream& os, Seat *s)
+{
+    os << s->mColor << "\t" << s->mFaction << "\t" << s->mStartingX
+       << "\t"<< s->mStartingY;
+    os << "\t" << s->mColorValue.r << "\t" << s->mColorValue.g
+       << "\t" << s->mColorValue.b;
+    os << "\t" << s->mStartingGold;
+    return os;
+}
+
+std::istream& operator>>(std::istream& is, Seat *s)
+{
+    is >> s->mColor >> s->mFaction >> s->mStartingX >> s->mStartingY;
+    is >> s->mColorValue.r >> s->mColorValue.g >> s->mColorValue.b;
+    is >> s->mStartingGold;
+    s->mColorValue.a = 1.0;
+    return is;
 }

--- a/source/Seat.h
+++ b/source/Seat.h
@@ -149,9 +149,13 @@ public:
 
     int mStartingGold;
 
+    static bool sortByColor(Seat* s1, Seat* s2);
+
     static std::string getFormat();
     friend ODPacket& operator<<(ODPacket& os, Seat *s);
     friend ODPacket& operator>>(ODPacket& is, Seat *s);
+    friend std::ostream& operator<<(std::ostream& os, Seat *s);
+    friend std::istream& operator>>(std::istream& is, Seat *s);
 
     static void loadFromLine(const std::string& line, Seat *s);
 

--- a/source/ServerNotification.cpp
+++ b/source/ServerNotification.cpp
@@ -108,6 +108,8 @@ std::string ServerNotification::typeString(ServerNotificationType type)
             return "notifyCreatureInfo";
         case ServerNotificationType::playCreatureSound:
             return "playCreatureSound";
+        case ServerNotificationType::refreshTiles:
+            return "refreshTiles";
         case ServerNotificationType::exit:
             return "exit";
         default:

--- a/source/ServerNotification.h
+++ b/source/ServerNotification.h
@@ -88,6 +88,8 @@ class ServerNotification
 
             playCreatureSound,
 
+            refreshTiles,
+
             exit
         };
 

--- a/source/Tile.cpp
+++ b/source/Tile.cpp
@@ -1235,3 +1235,10 @@ std::string Tile::displayAsString(Tile* tile)
     return "[" + Ogre::StringConverter::toString(tile->x) + ","
          + Ogre::StringConverter::toString(tile->y)+ "]";
 }
+
+void Tile::refreshFromTile(const Tile& tile)
+{
+    type = tile.type;
+    setFullness(tile.fullness);
+    // Note : There will be no visual change until the tile mesh is refreshed
+}

--- a/source/Tile.h
+++ b/source/Tile.h
@@ -283,6 +283,7 @@ public:
     void takeDamage(double damage, Tile *tileTakingDamage) {}
     double getHP(Tile *tile) {return 0;}
     std::vector<Tile*> getCoveredTiles() { return std::vector<Tile*>() ;}
+    void refreshFromTile(const Tile& tile);
 
 protected:
     virtual void createMeshLocal();


### PR DESCRIPTION
Fixed editor tile selector
Rooms and Traps layout is now shared between Editor and game.
Mouse handling copied/pasted from GameMap to have the same logic. For example, creatures can be picked up like ingame.
fixes #17
By default or when right mouse button is pressed, nothing is selected in editor mode. To add room/trap/tiles, you have to clic on the corresponding icon.
Added server messages for editor. In editor mode, if a room/trap is built on dirt tiles, gold tile or rock, they are claimed/digged automatically.
Rooms/traps cannot be built on tiles where there are already creatures/traps/rooms
Added a parameter to Server for him to know if we started editor or game mode. In editor mode, creatures have no turn :)
A map can be saved only if no creature is in the hand
Within the editor, creatures can be dropped everywhere they can walk (dirt, claimed - same color or not, water, lava).
Fixed a bug when reading map info (space is considered as a separator char by stringstream)
