### PR TITLE
Reset the creatures XP to 0 when leveling up.

### DIFF
--- a/source/Creature.cpp
+++ b/source/Creature.cpp
@@ -574,6 +574,9 @@ void Creature::doTurn()
     if(checkLevelUp())
     {
         setLevel(getLevel() + 1);
+
+        // Reset XP once the level has been acquired.
+        mExp = 0.0;
         //std::cout << "\n\n" << getName() << " has reached level " << getLevel() << "\n";
 
         if (mDefinition->isWorker())


### PR DESCRIPTION
This is part of the high-speed leveling problem.

Fixes #174
