### PR TITLE
Tweaked the cannon trap damage and range.

### DIFF
--- a/source/TrapCannon.cpp
+++ b/source/TrapCannon.cpp
@@ -28,9 +28,9 @@ TrapCannon::TrapCannon(GameMap* gameMap) :
 {
     mReloadTime = 5;
     mReloadTimeCounter = mReloadTime;
-    mRange = 12;
-    mMinDamage = 104;
-    mMaxDamage = 120;
+    mRange = 10;
+    mMinDamage = 5;
+    mMaxDamage = 10;
 }
 
 std::vector<GameEntity*> TrapCannon::aimEnemy()


### PR DESCRIPTION
This trap made any team or location invincible. Also, as they can't be destroyed, they are even more deadly.

Reducing their damage permits to fix part of this problem. I assume the rest will be done with #165
