### PR TITLE
Entities should be deleted by the gamemap on client side instead of the render manager

### DIFF
--- a/levels/multiplayer/TestMultiplayer.level
+++ b/levels/multiplayer/TestMultiplayer.level
@@ -5962,37 +5962,103 @@ Wizard
 
 [Creatures]
 # className	name	posX	posY	posZ	seatId	weaponLname	damage	range	defense	weaponRname	damage	range	defense	HP	Level
+[Creature]
 ConstructWorker	ConstructWorker1	193	206	0	1	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 Gnome	Gnome2	194	311	0	2	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 Goblin	Goblin3	161	201	0	3	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 PitDemon	PitDemon5	159	202	0	5	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 Wizard	Wizard7	199	311	0	2	Staff	7	10	3	none	1	4	0	125	1
+[/Creature]
+[Creature]
 Tentacle1	Tentacle18	162	198	0	3	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 Tentacle2	Tentacle29	158	201	0	4	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 Troll	Troll10	186	235	0	5	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 Knight	Knight_c2	192	311	0	2	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 Knight	Knight_c3	192	314	0	3	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 Knight	Knight_c4	196	315	0	4	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 Knight	Knight_c5	194	315	0	5	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 LizardMan	LizardMan_001	185	233	0	5	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 Kobold	Kobold	197	205	0	1	none	5	4	0	none	8	3	0	125	1
+[/Creature]
+[Creature]
 Kobold	Kobold_012	193	205	0	1	Roundshield	0	0	5	Longsword	14	3	0	125	1
+[/Creature]
+[Creature]
 Kobold	Kobold_007	195	205	0	1	none	5	4	0	none	8	3	0	125	1
+[/Creature]
+[Creature]
 Dwarf1	Dwarf1_001	221	189	0	2	Roundshield	0	0	5	Sabre	10	3	0	145	1
+[/Creature]
+[Creature]
 Dwarf2	Dwarf1_002	226	165	0	2	none	8	4	0	none	6	3	0	145	1
+[/Creature]
+[Creature]
 Dwarf3	Dwarf1_004	213	157	0	2	none	8	4	0	none	6	3	0	145	1
+[/Creature]
+[Creature]
 Dwarf2	Dwarf1_006	214	141	0	2	none	8	4	0	none	6	3	0	145	1
+[/Creature]
+[Creature]
 Dwarf3	Dwarf1_007	212	143	0	2	none	8	4	0	none	6	3	0	145	1
+[/Creature]
+[Creature]
 Dwarf3	Dwarf2_001	264	221	0	2	none	8	4	0	none	6	3	0	145	1
+[/Creature]
+[Creature]
 Dwarf2	Dwarf2_002	216	185	0	2	none	6	4	0	Longsword	14	4	0	145	1
+[/Creature]
+[Creature]
 Dwarf1	Dwarf3_001	217	187	0	2	Roundshield	0	0	5	Longsword	14	4	4	145	1
+[/Creature]
+[Creature]
 LizardMan	LizardMan_002	229	168	0	3	none	12	4	0	none	6	4	0	180	1
+[/Creature]
+[Creature]
 Kreatur	Kre	262	220	0	2	none	12	4	0	none	6	4	0	180	1
+[/Creature]
+[Creature]
 Orc	Orc_0001	228	166	0	2	none	8	4	0	Longsword	14	4	0	165	1
+[/Creature]
+[Creature]
 Orc	Orc_0002	262	222	0	2	none	8	4	0	Longsword	14	4	0	165	1
+[/Creature]
+[Creature]
 Kreatur	Kreatur_001	161	113	0	3	none	12	4	0	none	6	4	0	180	1
+[/Creature]
+[Creature]
 Kreatur	Kreatur_002	159	101	0	3	none	12	4	0	none	6	4	0	180	1
+[/Creature]
+[Creature]
 Kreatur	Kreatur_003	176	98	0	3	none	12	4	0	none	6	4	0	180	1
+[/Creature]
+[Creature]
 Kreatur	Kreatur_004	168	99	0	3	none	12	4	0	none	6	4	0	180	1
+[/Creature]
+[Creature]
 Kreatur	Kreatur_006	162	100	0	3	none	12	4	0	none	6	4	0	180	1
+[/Creature]
 [/Creatures]

--- a/levels/multiplayer/TestMultiplayerSmallAlliance.level
+++ b/levels/multiplayer/TestMultiplayerSmallAlliance.level
@@ -838,5 +838,7 @@ Wizard
 
 [Creatures]
 # className	name	posX	posY	posZ	seatId	weaponLname	damage	range	defense	weaponRname	damage	range	defense	HP	Level
+[Creature]
 ConstructWorker	ConstructWorker1	7	7	0	1	none	1	4	3	none	8	4	0	125	1
+[/Creature]
 [/Creatures]

--- a/levels/multiplayer/TestMultiplayerSmallFreeForAll.level
+++ b/levels/multiplayer/TestMultiplayerSmallFreeForAll.level
@@ -838,5 +838,7 @@ Wizard
 
 [Creatures]
 # className	name	posX	posY	posZ	seatId	weaponLname	damage	range	defense	weaponRname	damage	range	defense	HP	Level
+[Creature]
 ConstructWorker	ConstructWorker1	7	7	0	1	none	1	4	3	none	8	4	0	125	1
+[/Creature]
 [/Creatures]

--- a/levels/skirmish/Scream in the Dark.level
+++ b/levels/skirmish/Scream in the Dark.level
@@ -5346,8 +5346,16 @@ Wizard
 
 [Creatures]
 # className	name	posX	posY	posZ	seatId	weaponLname	damage	range	defense	weaponRname	damage	range	defense	HP	Level
+[Creature]
 Dragon	Dragon1	13	55	0	5	none	3	2	0	none	3	2	0	30	10
+[/Creature]
+[Creature]
 Dragon	Dragon2	13	54	0	5	none	3	2	0	none	3	2	0	30	10
+[/Creature]
+[Creature]
 Dragon	Dragon3	87	58	0	5	none	3	2	0	none	3	2	0	30	10
+[/Creature]
+[Creature]
 Dragon	Dragon4	87	57	0	5	none	3	2	0	none	3	2	0	30	10
+[/Creature]
 [/Creatures]

--- a/levels/skirmish/Stonekeep siege.level
+++ b/levels/skirmish/Stonekeep siege.level
@@ -4095,46 +4095,130 @@ Wizard
 
 [Creatures]
 # className	name	posX	posY	posZ	seatId	weaponLname	damage	range	defense	weaponRname	damage	range	defense	HP	Level
+[Creature]
 Kobold	Kobold90	51	16	0	1	none	1	1	0	none	0	1	0	5	1
+[/Creature]
+[Creature]
 Kobold	Kobold91	51	16	0	1	none	1	1	0	none	0	1	0	5	1
+[/Creature]
+[Creature]
 Kobold	Kobold92	7	55	0	2	none	1	1	0	none	0	1	0	5	1
+[/Creature]
+[Creature]
 Kobold	Kobold93	7	55	0	2	none	1	1	0	none	0	1	0	5	1
+[/Creature]
+[Creature]
 Kobold	Kobold94	91	55	0	3	none	1	1	0	none	0	1	0	5	1
+[/Creature]
+[Creature]
 Kobold	Kobold95	91	55	0	3	none	1	1	0	none	0	1	0	5	1
+[/Creature]
+[Creature]
 Kobold	Kobold96	47	94	0	4	none	1	1	0	none	0	1	0	5	1
+[/Creature]
+[Creature]
 Kobold	Kobold97	47	94	0	4	none	1	1	0	none	0	1	0	5	1
+[/Creature]
+[Creature]
 Dwarf3	Dwarf99	9	15	0	5	Roundshield	0	1	1	Longsword	2	2	0	30	1
+[/Creature]
+[Creature]
 Dwarf3	Dwarf98	9	16	0	5	Roundshield	0	1	1	Longsword	2	2	0	30	1
+[/Creature]
+[Creature]
 Dwarf3	Dwarf97	9	17	0	5	Roundshield	0	1	1	Longsword	2	2	0	30	1
+[/Creature]
+[Creature]
 Dwarf3	Dwarf96	9	18	0	5	Roundshield	0	1	1	Longsword	2	2	0	30	1
+[/Creature]
+[Creature]
 Dwarf3	Dwarf95	9	19	0	5	Roundshield	0	1	1	Longsword	2	2	0	30	1
+[/Creature]
+[Creature]
 Dwarf3	Dwarf94	9	20	0	5	Roundshield	0	1	1	Longsword	2	2	0	30	1
+[/Creature]
+[Creature]
 Dwarf3	Dwarf93	9	21	0	5	Roundshield	0	1	1	Longsword	2	2	0	30	1
+[/Creature]
+[Creature]
 Knight	Knight90	46	42	0	5	Roundshield	0	2	3	Longsword	2	2	0	40	1
+[/Creature]
+[Creature]
 Knight	Knight91	47	42	0	5	Roundshield	0	2	3	Longsword	2	2	0	40	1
+[/Creature]
+[Creature]
 Knight	Knight92	48	42	0	5	Roundshield	0	2	3	Sabre	2	2	0	40	1
+[/Creature]
+[Creature]
 Knight	Knight93	49	42	0	5	Roundshield	0	2	3	Sabre	2	2	0	40	1
+[/Creature]
+[Creature]
 Knight	Knight94	50	42	0	5	Roundshield	0	2	3	Sabre	2	2	0	40	1
+[/Creature]
+[Creature]
 Knight	Knight95	51	42	0	5	Roundshield	0	2	3	Longsword	2	2	0	40	1
+[/Creature]
+[Creature]
 Knight	Knight96	52	42	0	5	Longsword	2	2	0	Longsword	2	2	0	40	1
+[/Creature]
+[Creature]
 Knight	Knight97	49	41	0	5	Longsword	2	2	0	Longsword	2	2	0	40	1
+[/Creature]
+[Creature]
 Dragon	Dragon90	86	20	0	5	none	3	2	0	none	3	2	0	100	1
+[/Creature]
+[Creature]
 Dragon	Dragon91	92	20	0	5	none	3	2	0	none	3	2	0	100	1
+[/Creature]
+[Creature]
 Dragon	Dragon92	89	25	0	5	none	3	2	0	none	3	2	0	100	1
+[/Creature]
+[Creature]
 Dragon	Dragon93	96	18	0	5	none	3	2	0	none	3	2	0	100	1
+[/Creature]
+[Creature]
 Tentacle2	Tentacle90	73	23	0	5	none	1	2	0	none	1	2	0	20	1
+[/Creature]
+[Creature]
 Tentacle2	Tentacle91	73	23	0	5	none	1	2	0	none	1	2	0	20	1
+[/Creature]
+[Creature]
 Tentacle2	Tentacle92	73	23	0	5	none	1	2	0	none	1	2	0	20	1
+[/Creature]
+[Creature]
 Tentacle2	Tentacle93	73	23	0	5	none	1	2	0	none	1	2	0	20	1
+[/Creature]
+[Creature]
 Tentacle2	Tentacle94	75	12	0	5	none	1	2	0	none	1	2	0	20	1
+[/Creature]
+[Creature]
 Tentacle2	Tentacle95	75	12	0	5	none	1	2	0	none	1	2	0	20	1
+[/Creature]
+[Creature]
 Tentacle2	Tentacle96	75	12	0	5	none	1	2	0	none	1	2	0	20	1
+[/Creature]
+[Creature]
 Tentacle2	Tentacle97	75	12	0	5	none	1	2	0	none	1	2	0	20	1
+[/Creature]
+[Creature]
 Tentacle2	Tentacle98	72	5	0	5	none	1	2	0	none	1	2	0	20	1
+[/Creature]
+[Creature]
 Tentacle2	Tentacle99	72	5	0	5	none	1	2	0	none	1	2	0	20	1
+[/Creature]
+[Creature]
 Tentacle2	Tentacle100	69	37	0	5	none	1	2	0	none	1	2	0	20	1
+[/Creature]
+[Creature]
 Tentacle2	Tentacle101	69	37	0	5	none	1	2	0	none	1	2	0	20	1
+[/Creature]
+[Creature]
 Tentacle2	Tentacle102	69	37	0	5	none	1	2	0	none	1	2	0	20	1
+[/Creature]
+[Creature]
 PitDemon	PitDemon90	49	57	0	5	none	4	2	0	none	4	2	0	125	1
+[/Creature]
+[Creature]
 PitDemon	PitDemon91	49	57	0	5	none	4	2	0	none	4	2	0	125	10
+[/Creature]
 [/Creatures]

--- a/levels/skirmish/TestSingleplayer.level
+++ b/levels/skirmish/TestSingleplayer.level
@@ -5962,37 +5962,103 @@ Wizard
 
 [Creatures]
 # className	name	posX	posY	posZ	seatId	weaponLname	damage	range	defense	weaponRname	damage	range	defense	HP	Level
+[Creature]
 ConstructWorker	ConstructWorker1	193	206	0	1	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 Gnome	Gnome2	194	311	0	2	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 Goblin	Goblin3	161	201	0	3	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 PitDemon	PitDemon5	159	202	0	5	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 Wizard	Wizard7	199	311	0	2	Staff	7	10	3	none	1	4	0	125	1
+[/Creature]
+[Creature]
 Tentacle1	Tentacle18	162	198	0	3	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 Tentacle2	Tentacle29	158	201	0	4	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 Troll	Troll10	186	235	0	5	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 Knight	Knight_c2	192	311	0	2	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 Knight	Knight_c3	192	314	0	3	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 Knight	Knight_c4	196	315	0	4	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 Knight	Knight_c5	194	315	0	5	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 LizardMan	LizardMan_001	185	233	0	5	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 Kobold	Kobold	197	205	0	1	none	5	4	0	none	8	3	0	125	1
+[/Creature]
+[Creature]
 Kobold	Kobold_012	193	205	0	1	Roundshield	0	0	5	Longsword	14	3	0	125	1
+[/Creature]
+[Creature]
 Kobold	Kobold_007	195	205	0	1	none	5	4	0	none	8	3	0	125	1
+[/Creature]
+[Creature]
 Dwarf1	Dwarf1_001	221	189	0	2	Roundshield	0	0	5	Sabre	10	3	0	145	1
+[/Creature]
+[Creature]
 Dwarf2	Dwarf1_002	226	165	0	2	none	8	4	0	none	6	3	0	145	1
+[/Creature]
+[Creature]
 Dwarf3	Dwarf1_004	213	157	0	2	none	8	4	0	none	6	3	0	145	1
+[/Creature]
+[Creature]
 Dwarf2	Dwarf1_006	214	141	0	2	none	8	4	0	none	6	3	0	145	1
+[/Creature]
+[Creature]
 Dwarf3	Dwarf1_007	212	143	0	2	none	8	4	0	none	6	3	0	145	1
+[/Creature]
+[Creature]
 Dwarf3	Dwarf2_001	264	221	0	2	none	8	4	0	none	6	3	0	145	1
+[/Creature]
+[Creature]
 Dwarf2	Dwarf2_002	216	185	0	2	none	6	4	0	Longsword	14	4	0	145	1
+[/Creature]
+[Creature]
 Dwarf1	Dwarf3_001	217	187	0	2	Roundshield	0	0	5	Longsword	14	4	4	145	1
+[/Creature]
+[Creature]
 LizardMan	LizardMan_002	229	168	0	3	none	12	4	0	none	6	4	0	180	1
+[/Creature]
+[Creature]
 Kreatur	Kre	262	220	0	2	none	12	4	0	none	6	4	0	180	10
+[/Creature]
+[Creature]
 Orc	Orc_0001	228	166	0	2	none	8	4	0	Longsword	14	4	0	165	1
+[/Creature]
+[Creature]
 Orc	Orc_0002	262	222	0	2	none	8	4	0	Longsword	14	4	0	165	1
+[/Creature]
+[Creature]
 Kreatur	Kreatur_001	161	113	0	3	none	12	4	0	none	6	4	0	180	1
+[/Creature]
+[Creature]
 Kreatur	Kreatur_002	159	101	0	3	none	12	4	0	none	6	4	0	180	1
+[/Creature]
+[Creature]
 Kreatur	Kreatur_003	176	98	0	3	none	12	4	0	none	6	4	0	180	1
+[/Creature]
+[Creature]
 Kreatur	Kreatur_004	168	99	0	3	none	12	4	0	none	6	4	0	180	1
+[/Creature]
+[Creature]
 Kreatur	Kreatur_006	162	100	0	3	none	12	4	0	none	6	4	0	180	1
+[/Creature]
 [/Creatures]

--- a/levels/skirmish/TestSingleplayerSmall.level
+++ b/levels/skirmish/TestSingleplayerSmall.level
@@ -843,6 +843,10 @@ Wizard
 
 [Creatures]
 # className	name	posX	posY	posZ	seatId	weaponLname	damage	range	defense	weaponRname	damage	range	defense	HP	Level
+[Creature]
 BigKnight	BigKnight1	7	7	0	1	none	1	1	3	none	8	1	0	125	1
+[/Creature]
+[Creature]
 Adventurer	Adventurer2	7	8	0	1	none	1	3	3	none	8	3	0	125	1
+[/Creature]
 [/Creatures]

--- a/levels/skirmish/TestSingleplayerSmallEmpty.level
+++ b/levels/skirmish/TestSingleplayerSmallEmpty.level
@@ -2624,6 +2624,10 @@ Slime
 
 [Creatures]
 # className	name	posX	posY	posZ	seatId	weaponLname	damage	range	defense	weaponRname	damage	range	defense	HP	Level
+[Creature]
 ConstructWorker	ConstructWorker1	7	7	0	1	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 Scarab	Scarab1	37	42	0	2	none	0	0	0	none	0	0	0	125	1
+[/Creature]
 [/Creatures]

--- a/levels/skirmish/TestSingleplayerSmallPassability.level
+++ b/levels/skirmish/TestSingleplayerSmallPassability.level
@@ -184,7 +184,13 @@ config/creatures.cfg
 
 [Creatures]
 # className	name	posX	posY	posZ	seatId	weaponLname	damage	range	defense	weaponRname	damage	range	defense	HP	Level
+[Creature]
 ConstructWorker	ConstructWorker1	1	1	0	1	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 PitDemon	Lava	2	2	0	1	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 Slime	Water	2	2	0	1	none	1	4	3	none	8	4	0	125	1
+[/Creature]
 [/Creatures]

--- a/levels/skirmish/oldTest.level
+++ b/levels/skirmish/oldTest.level
@@ -6703,58 +6703,166 @@ Wizard
 
 [Creatures]
 # className	name	posX	posY	posZ	seatId	weaponLname	damage	range	defense	weaponRname	damage	range	defense	HP	Level
+[Creature]
 Adventurer	Adventurer_001	196	200	0	1	none	7	4	0	none	8	3	0	155	1
+[/Creature]
+[Creature]
 ConstructWorker	ConstructWorker1	196	230	0	1	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 Gnome	Gnome2	192	229	0	2	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 Goblin	Goblin3	183	229	0	3	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 PitDemon	PitDemon5	210	236	0	5	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 Spider	Spider6	198	231	0	1	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 CaveHornet	Hornet1	198	231	0	1	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 Wizard	Wizard7	190	229	0	2	Staff	7	10	3	none	1	4	0	125	1
+[/Creature]
+[Creature]
 Tentacle1	Tentacle18	186	229	0	3	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 Tentacle2	Tentacle29	203	230	0	4	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 Troll	Troll10	209	231	0	5	none	1	4	3	none	8	4	0	125	1
+[/Creature]
+[Creature]
 Troll	Troll11	193	214	0	1	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 Knight	Knight_c1	198	233	0	1	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 Knight	Knight_c2	192	233	0	2	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 Knight	Knight_c3	184	233	0	3	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 Knight	Knight_c4	204	233	0	4	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 Knight	Knight_c5	210	233	0	5	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 LizardMan	LizardMan_001	210	233	0	5	Roundshield	1	4	3	Longsword	8	4	0	125	1
+[/Creature]
+[Creature]
 Kobold	Kobold	195	202	0	1	none	5	4	0	none	8	3	0	125	1
+[/Creature]
+[Creature]
 Kobold	Kobold_012	188	200	0	1	Roundshield	0	0	5	Longsword	14	3	0	125	1
+[/Creature]
+[Creature]
 Kobold	Kobold_007	193	218	0	1	none	5	4	0	none	8	3	0	125	1
+[/Creature]
+[Creature]
 Wizard	Mage	193	213	0	1	Staff	7	9	0	none	8	3	0	80	1
+[/Creature]
+[Creature]
 Wizard	Wiz	193	213	0	1	Staff	7	9	0	none	8	3	0	80	1
+[/Creature]
+[Creature]
 BigKnight	King	191	216	0	1	Roundshield	0	0	5	Staff	10	3	7	180	1
+[/Creature]
+[Creature]
 Knight	Knight_005	229	138	0	1	Roundshield	0	0	5	Longsword	14	3	0	155	1
+[/Creature]
+[Creature]
 Knight	Knight_004	196	200	0	1	Longsword	7	4	0	none	8	3	0	155	1
+[/Creature]
+[Creature]
 Knight	Knight_006	199	204	0	1	Longsword	14	4	0	Sabre	10	3	0	155	1
+[/Creature]
+[Creature]
 Knight	Knight	188	198	0	1	none	8	4	0	Sabre	10	3	0	155	1
+[/Creature]
+[Creature]
 Knight	Knight_007	191	207	0	1	none	8	4	0	Sabre	10	3	0	155	1
+[/Creature]
+[Creature]
 Knight	Knight_003	184	201	0	1	none	14	4	0	Longsword	14	3	0	155	1
+[/Creature]
+[Creature]
 Dragon	Dragon_001	159	108	0	1	none	10	4	0	none	8	3	0	200	1
+[/Creature]
+[Creature]
 Dragon	Dragon_002	191	193	0	1	none	10	4	0	none	8	3	0	200	1
+[/Creature]
+[Creature]
 Dragon	Dragon_003	195	204	0	1	none	10	4	0	none	8	3	0	200	1
+[/Creature]
+[Creature]
 Dragon	Dragon_004	196	214	0	1	none	10	4	0	none	8	3	0	200	1
+[/Creature]
+[Creature]
 Wyvern	Wyvern_001	177	90	0	1	none	8	3	0	none	6	3	0	150	1
+[/Creature]
+[Creature]
 Wyvern	Wyvern_002	186	85	0	1	none	8	3	0	none	6	3	0	150	1
+[/Creature]
+[Creature]
 Wyvern	Wyvern_003	183	105	0	1	none	8	3	0	none	6	3	0	150	1
+[/Creature]
+[Creature]
 Dwarf1	Dwarf1_001	201	192	0	2	Roundshield	0	0	5	Sabre	10	3	0	145	1
+[/Creature]
+[Creature]
 Dwarf2	Dwarf1_002	206	168	0	2	none	8	4	0	none	6	3	0	145	1
+[/Creature]
+[Creature]
 Dwarf3	Dwarf1_004	213	157	0	2	none	8	4	0	none	6	3	0	145	1
+[/Creature]
+[Creature]
 Dwarf2	Dwarf1_006	214	141	0	2	none	8	4	0	none	6	3	0	145	1
+[/Creature]
+[Creature]
 Dwarf3	Dwarf1_007	212	143	0	2	none	8	4	0	none	6	3	0	145	1
+[/Creature]
+[Creature]
 Dwarf3	Dwarf2_001	213	213	0	2	none	8	4	0	none	6	3	0	145	1
+[/Creature]
+[Creature]
 Dwarf2	Dwarf2_002	202	191	0	2	none	6	4	0	Longsword	14	4	0	145	1
+[/Creature]
+[Creature]
 Dwarf1	Dwarf3_001	201	192	0	2	Roundshield	0	0	5	Longsword	14	4	4	145	1
+[/Creature]
+[Creature]
 LizardMan	LizardMan_002	206	172	0	3	none	12	4	0	none	6	4	0	180	1
+[/Creature]
+[Creature]
 Kreatur	Kre	215	216	0	2	none	12	4	0	none	6	4	0	180	1
+[/Creature]
+[Creature]
 Orc	Orc_0001	203	199	0	2	none	8	4	0	Longsword	14	4	0	165	1
+[/Creature]
+[Creature]
 Orc	Orc_0002	207	212	0	2	none	8	4	0	Longsword	14	4	0	165	1
+[/Creature]
+[Creature]
 Kreatur	Kreatur_001	155	110	0	3	none	12	4	0	none	6	4	0	180	1
+[/Creature]
+[Creature]
 Kreatur	Kreatur_002	159	112	0	3	none	12	4	0	none	6	4	0	180	1
+[/Creature]
+[Creature]
 Kreatur	Kreatur_003	158	103	0	3	none	12	4	0	none	6	4	0	180	1
+[/Creature]
+[Creature]
 Kreatur	Kreatur_004	156	106	0	3	none	12	4	0	none	6	4	0	180	1
+[/Creature]
+[Creature]
 Kreatur	Kreatur_006	163	112	0	3	none	12	4	0	none	6	4	0	180	1
+[/Creature]
 [/Creatures]

--- a/source/Console_executePromptCommand.cpp
+++ b/source/Console_executePromptCommand.cpp
@@ -417,25 +417,13 @@ bool Console::executePromptCommand(const std::string& command, std::string argum
             // Creature the creature and add it to the gameMap
             // TODO : ask the server to do that
             std::stringstream tempSS(arguments);
-            std::string className;
-            tempSS >> className;
-            CreatureDefinition *creatureClass = gameMap->getClassDescription(className);
-            if (creatureClass != NULL)
-            {
-                Creature *tempCreature = new Creature(gameMap, creatureClass);
-                tempSS >> tempCreature;
+            Creature *tempCreature = Creature::getCreatureFromStream(gameMap, tempSS);
 
-                tempCreature->createMesh();
-                tempCreature->getWeaponL()->createMesh();
-                tempCreature->getWeaponR()->createMesh();
-                gameMap->addCreature(tempCreature);
-                frameListener->mCommandOutput += "\nCreature added successfully\n";
-            }
-            else
-            {
-                frameListener->mCommandOutput
-                        += "\nInvalid creature class name, you need to first add a class with the \'addclass\' terminal command.\n";
-            }
+            tempCreature->createMesh();
+            tempCreature->getWeaponL()->createMesh();
+            tempCreature->getWeaponR()->createMesh();
+            gameMap->addCreature(tempCreature);
+            frameListener->mCommandOutput += "\nCreature added successfully\n";
         }
     }
 

--- a/source/Creature.h
+++ b/source/Creature.h
@@ -58,9 +58,8 @@ class Creature: public MovableGameEntity
     friend class CullingQuad;
     friend class ODClient;
 public:
-    //! \brief Constructor for creatures. If generateUniqueName is false, the name should be set with
-    //! setName()
-    Creature(GameMap* gameMap, CreatureDefinition* definition, bool forceName = false, const std::string& name = "");
+    //! \brief Constructor for creatures. It generates an unique name
+    Creature(GameMap* gameMap, CreatureDefinition* definition);
     virtual ~Creature();
 
     static const std::string CREATURE_PREFIX;
@@ -259,20 +258,15 @@ public:
 
     //! \FIXME Those functions are lacking parameters to be actually functional
     //! \brief Get the text format of creatures in level files (already spawned at startup).
-    //! \returns A string describing the IO format of the << and >> operators.
+    //! \returns A string describing the IO format the creatures need to have in file.
     static std::string getFormat();
-    //! \brief A function saving creatures already present in level when writing it.
-    friend std::ostream& operator<<(std::ostream& os, Creature *c);
-    //! \brief A function loading creatures already present in level when loading it.
-    friend std::istream& operator>>(std::istream& is, Creature *c);
-    //! \brief Loads the creature data from a level line.
-    static Creature* loadFromLine(const std::string& line, GameMap* gameMap);
 
-    //! \brief A function to transport the full creature's state between files and over the network.
-    //! Not used for level files.
-    friend ODPacket& operator<<(ODPacket& os, Creature *c);
-    friend ODPacket& operator>>(ODPacket& is, Creature *c);
-
+    static Creature* getCreatureFromStream(GameMap* gameMap, std::istream& is);
+    static Creature* getCreatureFromPacket(GameMap* gameMap, ODPacket& is);
+    virtual void exportToPacket(ODPacket& os);
+    virtual void importFromPacket(ODPacket& is);
+    virtual void exportToStream(std::ostream& os);
+    virtual void importFromStream(std::istream& is);
     inline void setQuad(CullingQuad* cq)
     { mTracingCullingQuad = cq; }
 

--- a/source/EditorMode.cpp
+++ b/source/EditorMode.cpp
@@ -868,4 +868,5 @@ void EditorMode::exitMode()
     ODFrameListener::getSingleton().getClientGameMap()->clearAll();
     // We process again RenderRequests to destroy/delete what clearAll has put in the queue
     RenderManager::getSingleton().processRenderRequests();
+    ODFrameListener::getSingleton().getClientGameMap()->processDeletionQueues();
 }

--- a/source/GameEntity.cpp
+++ b/source/GameEntity.cpp
@@ -57,12 +57,10 @@ void GameEntity::deleteYourself()
         return;
 
     mIsDeleteRequested = true;
+
     deleteYourselfLocal();
 
-    if(getGameMap()->isServerGameMap())
-    {
-        getGameMap()->queueEntityForDeletion(this);
-    }
+    getGameMap()->queueEntityForDeletion(this);
 }
 
 std::string GameEntity::getNodeNameWithoutPostfix()

--- a/source/GameMap.cpp
+++ b/source/GameMap.cpp
@@ -149,6 +149,7 @@ GameMap::GameMap(bool isServerGameMap) :
 GameMap::~GameMap()
 {
     clearAll();
+    processDeletionQueues();
     delete tileCoordinateMap;
     delete mLocalPlayer;
 }
@@ -303,6 +304,8 @@ void GameMap::addClassDescription(CreatureDefinition *c)
 
 void GameMap::addCreature(Creature *cc)
 {
+    LogManager::getSingleton().logMessage(serverStr() + "Adding Creature " + cc->getName());
+
     creatures.push_back(cc);
 
     cc->getPositionTile()->addCreature(cc);
@@ -422,11 +425,10 @@ MovableGameEntity* GameMap::getAnimatedObject(const std::string& name)
 
 void GameMap::addRenderedMovableEntity(RenderedMovableEntity *obj)
 {
+    LogManager::getSingleton().logMessage(serverStr() + "Adding rendered object " + obj->getName()
+        + ",MeshName=" + obj->getMeshName());
     if(isServerGameMap())
     {
-        LogManager::getSingleton().logMessage("Adding rendered object " + obj->getName()
-            + ",MeshName=" + obj->getMeshName());
-
         try
         {
             ServerNotification *serverNotification = new ServerNotification(
@@ -1491,12 +1493,11 @@ void GameMap::clearRooms()
 
 void GameMap::addRoom(Room *r)
 {
+    int nbTiles = r->getCoveredTiles().size();
+    LogManager::getSingleton().logMessage(serverStr() + "Adding room " + r->getName() + ", nbTiles="
+        + Ogre::StringConverter::toString(nbTiles) + ", seatId=" + Ogre::StringConverter::toString(r->getSeat()->getId()));
     if(isServerGameMap())
     {
-        int nbTiles = r->getCoveredTiles().size();
-        LogManager::getSingleton().logMessage("Adding room " + r->getName() + ", nbTiles="
-            + Ogre::StringConverter::toString(nbTiles) + ", seatId=" + Ogre::StringConverter::toString(r->getSeat()->getId()));
-
         ServerNotification notif(ServerNotification::buildRoom, getPlayerBySeat(r->getSeat()));
         r->exportHeadersToPacket(notif.mPacket);
         r->exportToPacket(notif.mPacket);
@@ -1642,12 +1643,12 @@ void GameMap::clearTraps()
 
 void GameMap::addTrap(Trap *trap)
 {
+    int nbTiles = trap->getCoveredTiles().size();
+    LogManager::getSingleton().logMessage(serverStr() + "Adding trap " + trap->getName() + ", nbTiles="
+        + Ogre::StringConverter::toString(nbTiles) + ", seatId=" + Ogre::StringConverter::toString(trap->getSeat()->getId()));
+
     if(isServerGameMap())
     {
-        int nbTiles = trap->getCoveredTiles().size();
-        LogManager::getSingleton().logMessage("Adding trap " + trap->getName() + ", nbTiles="
-            + Ogre::StringConverter::toString(nbTiles) + ", seatId=" + Ogre::StringConverter::toString(trap->getSeat()->getId()));
-
         ServerNotification notif(ServerNotification::buildTrap, getPlayerBySeat(trap->getSeat()));
         trap->exportHeadersToPacket(notif.mPacket);
         trap->exportToPacket(notif.mPacket);
@@ -1722,6 +1723,7 @@ void GameMap::clearMapLights()
 
 void GameMap::addMapLight(MapLight *m)
 {
+    LogManager::getSingleton().logMessage(serverStr() + "Adding MapLight " + m->getName());
     mapLights.push_back(m);
 
     /*

--- a/source/GameMap.h
+++ b/source/GameMap.h
@@ -67,6 +67,9 @@ public:
     GameMap(bool isServerGameMap);
     ~GameMap();
 
+    const std::string serverStr()
+    { return std::string( mIsServerGameMap ? "SERVER - " : "CLIENT - "); }
+
     //! \brief Load a level file (Part of the resource paths)
     //! \returns whether the file loaded correctly
     bool loadLevel(const std::string& levelFilepath);

--- a/source/GameMode.cpp
+++ b/source/GameMode.cpp
@@ -983,4 +983,5 @@ void GameMode::exitMode()
     ODFrameListener::getSingleton().getClientGameMap()->clearAll();
     // We process again RenderRequests to destroy/delete what clearAll has put in the queue
     RenderManager::getSingleton().processRenderRequests();
+    ODFrameListener::getSingleton().getClientGameMap()->processDeletionQueues();
 }

--- a/source/ODFrameListener.cpp
+++ b/source/ODFrameListener.cpp
@@ -151,6 +151,9 @@ ODFrameListener::~ODFrameListener()
     if (mModeManager)
         delete mModeManager;
     delete mCameraManager;
+    mGameMap->clearAll();
+    RenderManager::getSingletonPtr()->processRenderRequests();
+    mGameMap->processDeletionQueues();
     delete mGameMap;
     delete mMiniMap;
     // We deinit it here since it was also created in this class.
@@ -177,8 +180,8 @@ void ODFrameListener::exitApplication()
     ODClient::getSingleton().notifyExit();
     ODServer::getSingleton().notifyExit();
     RenderManager::getSingletonPtr()->processRenderRequests();
-    mGameMap->processDeletionQueues();
     mGameMap->clearAll();
+    mGameMap->processDeletionQueues();
     RenderManager::getSingletonPtr()->getSceneManager()->destroyQuery(mRaySceneQuery);
 
     Ogre::LogManager::getSingleton().logMessage("Remove listener registration", Ogre::LML_NORMAL);
@@ -195,6 +198,7 @@ void ODFrameListener::updateAnimations(Ogre::Real timeSinceLastFrame)
 {
     MusicPlayer::getSingleton().update(static_cast<float>(timeSinceLastFrame));
     RenderManager::getSingletonPtr()->processRenderRequests();
+    mGameMap->processDeletionQueues();
 
     mGameMap->updateAnimations(timeSinceLastFrame);
 }

--- a/source/RenderManager.cpp
+++ b/source/RenderManager.cpp
@@ -151,7 +151,6 @@ void RenderManager::createScene(Ogre::Viewport* nViewport)
 
 bool RenderManager::handleRenderRequest(const RenderRequest& renderRequest)
 {
-    //TODO - could we improve this somehow? Maybe an array of function pointers?
     switch (renderRequest.type)
     {
     case RenderRequest::refreshTile:
@@ -218,34 +217,6 @@ bool RenderManager::handleRenderRequest(const RenderRequest& renderRequest)
         rrDestroyTrap(renderRequest);
         break;
 
-    case RenderRequest::deleteRoom:
-    {
-        Room* curRoom = static_cast<Room*> (renderRequest.p);
-        delete curRoom;
-        break;
-    }
-
-    case RenderRequest::deleteTrap:
-    {
-        Trap* curTrap = static_cast<Trap*> (renderRequest.p);
-        delete curTrap;
-        break;
-    }
-
-    case RenderRequest::deleteTile:
-    {
-        Tile* curTile = static_cast<Tile*> (renderRequest.p);
-        delete curTile;
-        break;
-    }
-
-    case RenderRequest::deleteRenderedMovableEntity:
-    {
-        RenderedMovableEntity* curRenderedMovableEntity = static_cast<RenderedMovableEntity*>(renderRequest.p);
-        delete curRenderedMovableEntity;
-        break;
-    }
-
     case RenderRequest::createCreature:
         rrCreateCreature(renderRequest);
         break;
@@ -309,20 +280,6 @@ bool RenderManager::handleRenderRequest(const RenderRequest& renderRequest)
     case RenderRequest::setObjectAnimationState:
         rrSetObjectAnimationState(renderRequest);
         break;
-
-    case RenderRequest::deleteCreature:
-    {
-        Creature* curCreature = static_cast<Creature*>(renderRequest.p);
-        delete curCreature;
-        break;
-    }
-
-    case RenderRequest::deleteWeapon:
-    {
-        Weapon* curWeapon = static_cast<Weapon*>(renderRequest.p);
-        delete curWeapon;
-        break;
-    }
 
     case RenderRequest::moveSceneNode:
         rrMoveSceneNode(renderRequest);

--- a/source/RenderManager.h
+++ b/source/RenderManager.h
@@ -45,6 +45,7 @@ class OverlaySystem;
 
 class RenderManager: public Ogre::Singleton<RenderManager>
 {
+    friend class RenderRequest;
 public:
     RenderManager(Ogre::OverlaySystem* overlaySystem);
     ~RenderManager();
@@ -88,13 +89,12 @@ public:
     //! Debug function to be used for dev only. Beware, it should not be called from the server thread
     static std::string consoleListAnimationsForMesh(const std::string& meshName);
 
-protected:
+private:
     //! \brief Put a render request in the queue (implementation)
     void queueRenderRequest_priv(RenderRequest* renderRequest);
 
     //Render request functions
 
-    //TODO - could some of these be merged?
     void rrRefreshTile(const RenderRequest& renderRequest);
     void rrCreateTile(const RenderRequest& renderRequest);
     void rrDestroyTile(const RenderRequest& renderRequest);
@@ -143,7 +143,7 @@ protected:
     //! \note If the material (wall tiles only) is marked for digging, a yellow color is added
     //! to the given color.
     std::string colourizeMaterial(const std::string& materialName, Seat* seat, bool markedForDigging = false);
-private:
+
     bool mVisibleCreatures;
 
     std::deque<RenderRequest*> mRenderQueue;

--- a/source/RenderRequest.h
+++ b/source/RenderRequest.h
@@ -36,7 +36,6 @@ public:
         createTile = 0,
         refreshTile,
         destroyTile,
-        deleteTile,
         temporalMarkTile,
         attachTile,
         detachTile,
@@ -46,25 +45,20 @@ public:
         showSquareSelector,
         createCreature,
         destroyCreature,
-        deleteCreature,
         setObjectAnimationState,
         createCreatureVisualDebug,
         destroyCreatureVisualDebug,
         createWeapon,
         destroyWeapon,
-        deleteWeapon,
         pickUpEntity,
         dropHand,
         rotateHand,
         createRoom,
         destroyRoom,
-        deleteRoom,
         createRenderedMovableEntity,
         destroyRenderedMovableEntity,
-        deleteRenderedMovableEntity,
         createTrap,
         destroyTrap,
-        deleteTrap,
         createMapLight,
         updateMapLight,
         destroyMapLight,
@@ -89,7 +83,6 @@ public:
     Ogre::Vector3 vec;
     Ogre::Quaternion quaternion;
     bool b;
-    //TODO:  Add a pointer called destroyMe which is used to pass a void pointer which should be deleted after it is used, this can replace the need for str and vec.
 };
 
 #endif // RENDERREQUEST_H

--- a/source/RenderedMovableEntity.cpp
+++ b/source/RenderedMovableEntity.cpp
@@ -78,18 +78,6 @@ void RenderedMovableEntity::destroyMeshLocal()
     RenderManager::queueRenderRequest(request);
 }
 
-void RenderedMovableEntity::deleteYourselfLocal()
-{
-    MovableGameEntity::deleteYourselfLocal();
-    if(getGameMap()->isServerGameMap())
-        return;
-
-    RenderRequest* request = new RenderRequest;
-    request->type   = RenderRequest::deleteRenderedMovableEntity;
-    request->p      = static_cast<void*>(this);
-    RenderManager::queueRenderRequest(request);
-}
-
 void RenderedMovableEntity::pickup()
 {
     mIsOnMap = false;

--- a/source/RenderedMovableEntity.h
+++ b/source/RenderedMovableEntity.h
@@ -110,7 +110,6 @@ protected:
 
     virtual void createMeshLocal();
     virtual void destroyMeshLocal();
-    virtual void deleteYourselfLocal();
 private:
     Ogre::Real mRotationAngle;
     bool mIsOnMap;

--- a/source/Room.cpp
+++ b/source/Room.cpp
@@ -83,18 +83,6 @@ void Room::destroyMeshLocal()
     }
 }
 
-void Room::deleteYourselfLocal()
-{
-    Building::deleteYourselfLocal();
-    if(getGameMap()->isServerGameMap())
-        return;
-
-    RenderRequest* request = new RenderRequest;
-    request->type = RenderRequest::deleteRoom;
-    request->p = static_cast<void*>(this);
-    RenderManager::queueRenderRequest(request);
-}
-
 bool Room::compareTile(Tile* tile1, Tile* tile2)
 {
     if(tile1->getX() < tile2->getX())

--- a/source/Room.h
+++ b/source/Room.h
@@ -139,7 +139,6 @@ protected:
 
     virtual void createMeshLocal();
     virtual void destroyMeshLocal();
-    virtual void deleteYourselfLocal();
     virtual RenderedMovableEntity* notifyActiveSpotCreated(ActiveSpotPlace place, Tile* tile);
     virtual void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile);
 private :

--- a/source/RoomDungeonTemple.cpp
+++ b/source/RoomDungeonTemple.cpp
@@ -118,12 +118,10 @@ void RoomDungeonTemple::produceKobold()
     {
         try
         {
-           ServerNotification *serverNotification = new ServerNotification(
+            ServerNotification *serverNotification = new ServerNotification(
                ServerNotification::addCreature, newCreature->getGameMap()->getPlayerBySeat(newCreature->getSeat()));
-           const std::string& className = newCreature->getDefinition()->getClassName();
-           const std::string& name = newCreature->getName();
-           serverNotification->mPacket << className << name << newCreature;
-           ODServer::getSingleton().queueServerNotification(serverNotification);
+            newCreature->exportToPacket(serverNotification->mPacket);
+            ODServer::getSingleton().queueServerNotification(serverNotification);
         }
         catch (std::bad_alloc&)
         {

--- a/source/RoomPortal.cpp
+++ b/source/RoomPortal.cpp
@@ -191,9 +191,7 @@ void RoomPortal::spawnCreature()
         {
            ServerNotification *serverNotification = new ServerNotification(
                ServerNotification::addCreature, newCreature->getGameMap()->getPlayerBySeat(newCreature->getSeat()));
-           const std::string& className = newCreature->getDefinition()->getClassName();
-           const std::string& name = newCreature->getName();
-           serverNotification->mPacket << className << name << newCreature;
+           newCreature->exportToPacket(serverNotification->mPacket);
            ODServer::getSingleton().queueServerNotification(serverNotification);
         }
         catch (std::bad_alloc&)

--- a/source/Tile.cpp
+++ b/source/Tile.cpp
@@ -67,18 +67,6 @@ void Tile::destroyMeshLocal()
     RenderManager::queueRenderRequest(request);
 }
 
-void Tile::deleteYourselfLocal()
-{
-    GameEntity::deleteYourselfLocal();
-    if(getGameMap()->isServerGameMap())
-        return;
-
-    RenderRequest* request = new RenderRequest;
-    request->type = RenderRequest::deleteTile;
-    request->p = static_cast<void*>(this);
-    RenderManager::queueRenderRequest(request);
-}
-
 void Tile::setType(TileType t)
 {
     // If the type has changed from its previous value we need to see if

--- a/source/Tile.h
+++ b/source/Tile.h
@@ -304,7 +304,6 @@ public:
 protected:
     virtual void createMeshLocal();
     virtual void destroyMeshLocal();
-    virtual void deleteYourselfLocal();
 private:
     bool isFloodFillFilled();
 

--- a/source/Trap.cpp
+++ b/source/Trap.cpp
@@ -77,18 +77,6 @@ void Trap::destroyMeshLocal()
     }
 }
 
-void Trap::deleteYourselfLocal()
-{
-    Building::deleteYourselfLocal();
-    if(getGameMap()->isServerGameMap())
-        return;
-
-    RenderRequest* request = new RenderRequest;
-    request->type = RenderRequest::deleteTrap;
-    request->p = static_cast<void*>(this);
-    RenderManager::queueRenderRequest(request);
-}
-
 Trap* Trap::getTrapFromStream(GameMap* gameMap, std::istream &is)
 {
     Trap* tempTrap = nullptr;

--- a/source/Trap.h
+++ b/source/Trap.h
@@ -97,7 +97,6 @@ public:
 protected:
     virtual void createMeshLocal();
     virtual void destroyMeshLocal();
-    virtual void deleteYourselfLocal();
     virtual RenderedMovableEntity* notifyActiveSpotCreated(Tile* tile);
     virtual void notifyActiveSpotRemoved(Tile* tile);
     int mReloadTime;

--- a/source/Weapon.cpp
+++ b/source/Weapon.cpp
@@ -72,18 +72,6 @@ void Weapon::destroyMeshLocal()
     RenderManager::queueRenderRequest(request);
 }
 
-void Weapon::deleteYourselfLocal()
-{
-    GameEntity::deleteYourselfLocal();
-    if(getGameMap()->isServerGameMap())
-        return;
-
-    RenderRequest* request = new RenderRequest;
-    request->type = RenderRequest::deleteWeapon;
-    request->p = static_cast<void*>(this);
-    RenderManager::queueRenderRequest(request);
-}
-
 std::string Weapon::getFormat()
 {
     //NOTE:  When this format changes changes to RoomPortal::spawnCreature() may be necessary.

--- a/source/Weapon.h
+++ b/source/Weapon.h
@@ -99,7 +99,6 @@ public:
 protected:
     virtual void createMeshLocal();
     virtual void destroyMeshLocal();
-    virtual void deleteYourselfLocal();
 private:
     std::string mHandString;
     double      mDamage;


### PR DESCRIPTION
- Entities should be deleted by the gamemap on client side instead of the render manager
- Creature reading/writing is the same as rooms/traps
- Small fix for creature sound
- Fixed a memory leak on Creature weapons
- Added a log for entity creation on client side as well as on server side
- Added [Creature][/Creature] in creature list in levels
  fixes #247
