### PR TITLE
Add a button to grab easily workers/fighters in the in game menu

### DIFF
--- a/gui/OpenDungeonsEditorModeMenu.layout
+++ b/gui/OpenDungeonsEditorModeMenu.layout
@@ -60,6 +60,15 @@
                 <Property name="ClippedByParent" value="False" />
                 <Property name="VerticalAlignment" value="Centre" />
             </Window>
+            <Window type="OD/StaticText" name="CreatureSpawnDisplay" >
+                <Property name="Area" value="{{0,550},{0,0},{0,750},{0,25}}" />
+                <Property name="Text" value="Creature (C): ?" />
+                <Property name="MaxSize" value="{{1,0},{1,0}}" />
+                <Property name="TooltipText" value="Selected Creature to spawn" />
+                <Property name="HorzFormatting" value="RightAligned" />
+                <Property name="ClippedByParent" value="False" />
+                <Property name="VerticalAlignment" value="Centre" />
+            </Window>
         </Window>
         <Window type="OD/Button" name="OptionsButton" >
             <Property name="Area" value="{{1,-277},{0,2},{1,-205},{0,35}}" />
@@ -122,13 +131,7 @@
             </Window>
             <LayoutImport type="DefaultWindow" filename="OpenDungeonsMenuRooms.layout" name="RoomsImport" />
             <LayoutImport type="DefaultWindow" filename="OpenDungeonsMenuTraps.layout" name="TrapImport" />
-            <Window type="DefaultWindow" name="Creatures" >
-                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
-                <Property name="Text" value="Creatures" />
-                <Property name="MaxSize" value="{{1,0},{1,0}}" />
-                <Property name="Visible" value="False" />
-                <Property name="RiseOnClickEnabled" value="False" />
-            </Window>
+            <LayoutImport type="DefaultWindow" filename="OpenDungeonsMenuCreatures.layout" name="CreaturesImport" />
             <Window type="DefaultWindow" name="Lights" >
                 <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="Text" value="Lights" />

--- a/gui/OpenDungeonsGameModeMenu.layout
+++ b/gui/OpenDungeonsGameModeMenu.layout
@@ -97,13 +97,7 @@
             <Property name="RiseOnClickEnabled" value="False" />
             <LayoutImport type="DefaultWindow" filename="OpenDungeonsMenuRooms.layout" name="RoomsImport" />
             <LayoutImport type="DefaultWindow" filename="OpenDungeonsMenuTraps.layout" name="RoomsImport" />
-            <Window type="DefaultWindow" name="Creatures" >
-                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
-                <Property name="Text" value="Creatures" />
-                <Property name="MaxSize" value="{{1,0},{1,0}}" />
-                <Property name="Visible" value="False" />
-                <Property name="RiseOnClickEnabled" value="False" />
-            </Window>
+            <LayoutImport type="DefaultWindow" filename="OpenDungeonsMenuCreatures.layout" name="CreaturesImport" />
             <Window type="DefaultWindow" name="Spells" >
                 <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="Text" value="Spells" />

--- a/gui/OpenDungeonsIcons.imageset
+++ b/gui/OpenDungeonsIcons.imageset
@@ -21,4 +21,7 @@
     <Image height="60" name="SpikeTrapButton" width="60" xPos="194" yPos="159" />
     <Image height="60" name="BoulderTrapButton" width="60" xPos="256" yPos="159" />
     <Image height="60" name="DestroyTrapButton" width="60" xPos="450" yPos="97" />
+
+    <Image height="60" name="WorkerButton" width="60" xPos="1" yPos="385" />
+    <Image height="60" name="FighterButton" width="60" xPos="63" yPos="385" />
 </Imageset>

--- a/gui/OpenDungeonsMenuCreatures.layout
+++ b/gui/OpenDungeonsMenuCreatures.layout
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<GUILayout version="4" >
+    <Window type="DefaultWindow" name="Creatures" >
+        <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
+        <Property name="Text" value="Creatures" />
+        <Property name="MaxSize" value="{{1,0},{1,0}}" />
+        <Property name="Visible" value="False" />
+        <Property name="RiseOnClickEnabled" value="False" />
+        <Window type="OD/ImageButton" name="WorkerButton" >
+            <Property name="Area" value="{{0,20},{0,20},{0,80},{0,80}}" />
+            <Property name="NormalImage" value="OpenDungeonsIcons/WorkerButton" />
+            <Property name="TooltipText" value="Add a worker in hand if available" />
+            <Property name="InheritsAlpha" value="False" />
+        </Window>
+        <Window type="OD/ImageButton" name="FighterButton" >
+            <Property name="Area" value="{{0,80},{0,20},{0,140},{0,80}}" />
+            <Property name="NormalImage" value="OpenDungeonsIcons/FighterButton" />
+            <Property name="TooltipText" value="Add a fighter in hand if available" />
+            <Property name="InheritsAlpha" value="False" />
+        </Window>
+    </Window>
+</GUILayout>

--- a/levels/skirmish/TestSingleplayerSmall.level
+++ b/levels/skirmish/TestSingleplayerSmall.level
@@ -858,12 +858,12 @@ Wizard
 [Creatures]
 # SeatId	ClassName	Name	Level	CurrentXP	CurrenHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	PosX	PosY	PosZ	LeftWeapon name	damage	range	defense	RightWeapon name	damage	range	defense
 [Creature]
-1	BigKnight	BigKnight1	1	0	125	100	0	0	7	7	0	none	1	1	3	none	8	1	0	
+1	BigKnight	BigKnight1	1	0	125	100	0	0	7	7	0	none	1	1	3	none	8	1	0
 [/Creature]
 [Creature]
-1	Adventurer	Adventurer2	1	0	125	100	0	0	7	8	0	none	1	3	3	none	8	3	0	
+1	Adventurer	Adventurer2	1	0	125	100	0	0	7	8	0	none	1	3	3	none	8	3	0
 [/Creature]
 [Creature]
-Dragon	Dragon1	12	9	0	3	none	0	1	0	none	0	1	0	5	1
+3 Dragon	Dragon1	1	0	125	100	0	0	7	7	0	none	1	1	3	none	8	1	0
 [/Creature]
 [/Creatures]

--- a/levels/skirmish/TestSingleplayerSmall.level
+++ b/levels/skirmish/TestSingleplayerSmall.level
@@ -228,6 +228,11 @@ ProtectDungeonTemple	NULL
 15	45	1	0
 16	24	2	100
 16	25	2	100
+17	7	6	0	3
+17	9	6	0	3
+17	10	6	0	3
+17	12	6	0	3
+17	13	6	0	3
 17	24	2	100
 17	25	2	100
 18	24	2	100
@@ -744,8 +749,17 @@ ProtectDungeonTemple	NULL
 # typeTrap	seatId	numTiles		Subsequent Lines: tileX	tileY		Subsequent Lines: optional specific data
 [Trap]
 2	3	2
-14	9
-14	10
+17	9
+17	10
+[/Trap]
+[Trap]
+1	3	2
+17	12
+17	13
+[/Trap]
+[Trap]
+3	3	1
+17	7
 [/Trap]
 [/Traps]
 
@@ -848,5 +862,8 @@ Wizard
 [/Creature]
 [Creature]
 1	Adventurer	Adventurer2	1	0	125	100	0	0	7	8	0	none	1	3	3	none	8	3	0	
+[/Creature]
+[Creature]
+Dragon	Dragon1	12	9	0	3	none	0	1	0	none	0	1	0	5	1
 [/Creature]
 [/Creatures]

--- a/source/camera/CameraManager.cpp
+++ b/source/camera/CameraManager.cpp
@@ -151,10 +151,13 @@ void CameraManager::createViewport(Ogre::RenderWindow* renderWindow)
 
 void CameraManager::setFPPCamera(Creature* cc)
 {
+    // That should be done in the RenderManager
+#if 0
     Ogre::SceneNode* tmpNode = mSceneManager->getSceneNode("FPP_node");
     tmpNode->getParentSceneNode()->removeChild(tmpNode);
     tmpNode->setInheritOrientation(true);
     cc->mSceneNode->addChild(tmpNode);
+#endif // 0
 }
 
 Ogre::SceneNode* CameraManager::getActiveCameraNode()

--- a/source/entities/Creature.h
+++ b/source/entities/Creature.h
@@ -248,6 +248,9 @@ public:
     //! \brief Returns true if the given action is queued in the action list. False otherwise
     bool isActionInList(CreatureAction::ActionType action);
 
+    const std::deque<CreatureAction>& getActionQueue()
+    { return mActionQueue; }
+
     //! \brief Clears the action queue, except for the Idle action at the end.
     void clearActionQueue();
 

--- a/source/gamemap/GameMap.h
+++ b/source/gamemap/GameMap.h
@@ -120,6 +120,9 @@ public:
     //! \brief Returns a vector containing all the creatures controlled by the given seat.
     std::vector<Creature*> getCreaturesBySeat(Seat* seat);
 
+    Creature* getWorkerToPickupBySeat(Seat* seat);
+    Creature* getFighterToPickupBySeat(Seat* seat);
+
     //! \brief Animated objects related functions.
     void clearAnimatedObjects();
     void addAnimatedObject(MovableGameEntity *a);

--- a/source/modes/AbstractApplicationMode.h
+++ b/source/modes/AbstractApplicationMode.h
@@ -53,6 +53,15 @@ public:
         nullDragType
     };
 
+    enum GuiAction
+    {
+        ButtonPressedCreatureWorker,
+        ButtonPressedCreatureFighter
+    };
+
+    virtual void notifyGuiAction(GuiAction guiAction)
+    { }
+
     virtual bool mouseMoved     (const OIS::MouseEvent &arg) = 0;
     virtual bool mousePressed   (const OIS::MouseEvent &arg, OIS::MouseButtonID id) = 0;
     virtual bool mouseReleased  (const OIS::MouseEvent &arg, OIS::MouseButtonID id) = 0;

--- a/source/modes/EditorMode.h
+++ b/source/modes/EditorMode.h
@@ -54,6 +54,8 @@ public:
 
     virtual void exitMode();
 
+    virtual void notifyGuiAction(GuiAction guiAction);
+
 private:
     //! \brief Tile type (Dirt, Lava, ...)
     Tile::TileType mCurrentTileType;
@@ -64,6 +66,9 @@ private:
 
     //! \brief Current selected seat id
     int mCurrentSeatId;
+
+    //! \brief Current selected creature to spawn
+    uint32_t mCurrentCreatureIndex;
 
     //! \brief The creature node name being dragged by the mouse
     std::string mDraggedCreature;

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -983,3 +983,32 @@ void GameMode::exitMode()
     RenderManager::getSingleton().processRenderRequests();
     ODFrameListener::getSingleton().getClientGameMap()->processDeletionQueues();
 }
+
+void GameMode::notifyGuiAction(GuiAction guiAction)
+{
+    switch(guiAction)
+    {
+            case GuiAction::ButtonPressedCreatureWorker:
+            {
+                if(ODClient::getSingleton().isConnected())
+                {
+                    ClientNotification *clientNotification = new ClientNotification(
+                        ClientNotification::askPickupWorker);
+                    ODClient::getSingleton().queueClientNotification(clientNotification);
+                }
+                break;
+            }
+            case GuiAction::ButtonPressedCreatureFighter:
+            {
+                if(ODClient::getSingleton().isConnected())
+                {
+                    ClientNotification *clientNotification = new ClientNotification(
+                        ClientNotification::askPickupFighter);
+                    ODClient::getSingleton().queueClientNotification(clientNotification);
+                }
+                break;
+            }
+            default:
+                break;
+    }
+}

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -81,6 +81,8 @@ class  GameMode: public AbstractApplicationMode
 
     virtual void exitMode();
 
+    virtual void notifyGuiAction(GuiAction guiAction);
+
  protected:
     //! \brief Handle the keyboard input in normal mode
     virtual bool keyPressedNormal   (const OIS::KeyEvent &arg);

--- a/source/network/ClientNotification.cpp
+++ b/source/network/ClientNotification.cpp
@@ -58,6 +58,10 @@ std::string ClientNotification::typeString(ClientNotificationType type)
             return "ackNewTurn";
         case ClientNotificationType::askCreatureInfos:
             return "askCreatureInfos";
+        case ClientNotificationType::askPickupWorker:
+            return "askPickupWorker";
+        case ClientNotificationType::askPickupFighter:
+            return "askPickupFighter";
         case ClientNotificationType::editorAskSaveMap:
             return "editorAskSaveMap";
         case ClientNotificationType::editorAskChangeTiles:
@@ -66,6 +70,10 @@ std::string ClientNotification::typeString(ClientNotificationType type)
             return "editorAskBuildRoom";
         case ClientNotificationType::editorAskBuildTrap:
             return "editorAskBuildTrap";
+        case ClientNotificationType::editorCreateWorker:
+            return "editorCreateWorker";
+        case ClientNotificationType::editorCreateFighter:
+            return "editorCreateFighter";
         default:
             LogManager::getSingleton().logMessage("ERROR: Unknown enum for ClientNotificationType="
                 + Ogre::StringConverter::toString(static_cast<int>(type)));

--- a/source/network/ClientNotification.h
+++ b/source/network/ClientNotification.h
@@ -49,6 +49,8 @@ public:
         askSellTrapTiles,
         ackNewTurn,
         askCreatureInfos,
+        askPickupWorker,
+        askPickupFighter,
 
         //  Editor
         editorAskSaveMap,
@@ -56,7 +58,9 @@ public:
         editorAskBuildRoom,
         editorAskBuildTrap,
         editorAskDestroyRoomTiles,
-        editorAskDestroyTrapTiles
+        editorAskDestroyTrapTiles,
+        editorCreateWorker,
+        editorCreateFighter
     };
 
     ClientNotification(ClientNotificationType type);

--- a/source/render/Gui.cpp
+++ b/source/render/Gui.cpp
@@ -196,6 +196,14 @@ void Gui::assignEventHandlers()
             CEGUI::PushButton::EventClicked,
             CEGUI::Event::Subscriber(&destroyTrapButtonPressed));
 
+    sheets[inGameMenu]->getChild(BUTTON_CREATURE_WORKER)->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&workerCreatureButtonPressed));
+
+    sheets[inGameMenu]->getChild(BUTTON_CREATURE_FIGHTER)->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&fighterCreatureButtonPressed));
+
     sheets[inGameMenu]->getChild(MINIMAP)->subscribeEvent(
             CEGUI:: Window::EventMouseClick,
             CEGUI::Event::Subscriber(&miniMapclicked));
@@ -276,6 +284,14 @@ void Gui::assignEventHandlers()
     sheets[editorModeGui]->getChild(BUTTON_DESTROY_TRAP)->subscribeEvent(
             CEGUI::PushButton::EventClicked,
             CEGUI::Event::Subscriber(&destroyTrapButtonPressed));
+
+    sheets[editorModeGui]->getChild(BUTTON_CREATURE_WORKER)->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&workerCreatureButtonPressed));
+
+    sheets[editorModeGui]->getChild(BUTTON_CREATURE_FIGHTER)->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&fighterCreatureButtonPressed));
 
     sheets[editorModeGui]->getChild(MINIMAP)->subscribeEvent(
             CEGUI:: Window::EventMouseClick,
@@ -501,6 +517,28 @@ bool Gui::destroyTrapButtonPressed(const CEGUI::EventArgs& e)
     gameMap->getLocalPlayer()->setNewTrapType(Trap::nullTrapType);
     gameMap->getLocalPlayer()->setCurrentAction(Player::SelectedAction::destroyTrap);
     SoundEffectsManager::getSingleton().playInterfaceSound(SoundEffectsManager::BUTTONCLICK);
+    return true;
+}
+
+bool Gui::workerCreatureButtonPressed(const CEGUI::EventArgs& e)
+{
+    ModeManager* mm = ODFrameListener::getSingleton().getModeManager();
+    if ((mm == nullptr) || (mm->getCurrentMode() == nullptr))
+        return true;
+
+    SoundEffectsManager::getSingleton().playInterfaceSound(SoundEffectsManager::BUTTONCLICK);
+    mm->getCurrentMode()->notifyGuiAction(AbstractApplicationMode::GuiAction::ButtonPressedCreatureWorker);
+    return true;
+}
+
+bool Gui::fighterCreatureButtonPressed(const CEGUI::EventArgs& e)
+{
+    ModeManager* mm = ODFrameListener::getSingleton().getModeManager();
+    if ((mm == nullptr) || (mm->getCurrentMode() == nullptr))
+        return true;
+
+    SoundEffectsManager::getSingleton().playInterfaceSound(SoundEffectsManager::BUTTONCLICK);
+    mm->getCurrentMode()->notifyGuiAction(AbstractApplicationMode::GuiAction::ButtonPressedCreatureFighter);
     return true;
 }
 
@@ -811,6 +849,8 @@ const std::string Gui::BUTTON_TRAP_BOULDER = "MainTabControl/Traps/BoulderTrapBu
 const std::string Gui::BUTTON_DESTROY_TRAP = "MainTabControl/Traps/DestroyTrapButton";
 const std::string Gui::TAB_SPELLS = "MainTabControl/Spells";
 const std::string Gui::TAB_CREATURES = "MainTabControl/Creatures";
+const std::string Gui::BUTTON_CREATURE_WORKER = "MainTabControl/Creatures/WorkerButton";
+const std::string Gui::BUTTON_CREATURE_FIGHTER = "MainTabControl/Creatures/FighterButton";
 const std::string Gui::TAB_COMBAT = "MainTabControl/Combat";
 
 const std::string Gui::MM_BACKGROUND = "Background";
@@ -852,3 +892,4 @@ const std::string Gui::EDITOR_CLAIMED_BUTTON = "MainTabControl/Tiles/ClaimedButt
 const std::string Gui::EDITOR_FULLNESS = "HorizontalPipe/FullnessDisplay";
 const std::string Gui::EDITOR_CURSOR_POS = "HorizontalPipe/PositionDisplay";
 const std::string Gui::EDITOR_SEAT_ID = "HorizontalPipe/SeatIdDisplay";
+const std::string Gui::EDITOR_CREATURE_SPAWN = "HorizontalPipe/CreatureSpawnDisplay";

--- a/source/render/Gui.h
+++ b/source/render/Gui.h
@@ -95,6 +95,8 @@ public:
     static const std::string BUTTON_DESTROY_TRAP;
     static const std::string TAB_SPELLS;
     static const std::string TAB_CREATURES;
+    static const std::string BUTTON_CREATURE_WORKER;
+    static const std::string BUTTON_CREATURE_FIGHTER;
     static const std::string TAB_COMBAT;
     static const std::string MM_BACKGROUND;
     static const std::string MM_WELCOME_MESSAGE;
@@ -113,6 +115,7 @@ public:
     static const std::string EDITOR_FULLNESS;
     static const std::string EDITOR_CURSOR_POS;
     static const std::string EDITOR_SEAT_ID;
+    static const std::string EDITOR_CREATURE_SPAWN;
     static const std::string EXIT_CONFIRMATION_POPUP;
     static const std::string EXIT_CONFIRMATION_POPUP_YES_BUTTON;
     static const std::string EXIT_CONFIRMATION_POPUP_NO_BUTTON;
@@ -209,6 +212,8 @@ private:
     static bool spikeTrapButtonPressed  (const CEGUI::EventArgs& e);
     static bool boulderTrapButtonPressed(const CEGUI::EventArgs& e);
     static bool destroyTrapButtonPressed(const CEGUI::EventArgs& e);
+    static bool workerCreatureButtonPressed     (const CEGUI::EventArgs& e);
+    static bool fighterCreatureButtonPressed    (const CEGUI::EventArgs& e);
     static bool confirmExitYesButtonPressed     (const CEGUI::EventArgs& e);
     static bool confirmExitNoButtonPressed      (const CEGUI::EventArgs& e);
 


### PR DESCRIPTION
fixes #84
fixes #85

Concerning the worker pickup, the logic is :
1 - Take idle worker
2 - Take fighting/fleeing
3 - Take claimers
4 - Take diggers
5 - Take gold digger/depositers or all the rest
For each, we pickup the highest leveled available

Concerning the fighter pickup, the logic is :
1 - Take fleeing fighters
2 - Take idle fighters
3 - Take busy (working/eating) fighters
4 - Then take fighting fighters or all the rest
For each, we pickup the highest leveled available

As a bonus, I've added support to add creatures in the editor. To use it :
- Press C to change creature type (class will be displayed in the top of the screen)
- Press Y to change the creature's Seat
- Press fighter button to add the creature. It will be in the keeper hand
- Drop the creature where you want
