### PR TITLE
Allow to choose faction before launching a game + configurable spawn pool per faction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,7 @@ set(OD_SOURCEFILES
     ${SRC}/modes/GameMode.cpp
     ${SRC}/modes/InputManager.cpp
     ${SRC}/modes/MenuMode.cpp
+    ${SRC}/modes/MenuModeConfigureSeats.cpp
     ${SRC}/modes/MenuModeEditor.cpp
     ${SRC}/modes/MenuModeMultiplayerClient.cpp
     ${SRC}/modes/MenuModeMultiplayerServer.cpp

--- a/config/factions.cfg
+++ b/config/factions.cfg
@@ -1,0 +1,40 @@
+# Factions definition file.
+# It defines which creatures can spawn through the portal per faction.
+# Each Faction is defined with [Factions] [/Factions]
+# within a [Faction] [/Faction] tag couple.
+
+[Factions]
+[Faction]
+    Name	Keeper
+    [SpawnPool]
+    ConstructWorker
+    CaveHornet
+    Wyvern
+    Dragon
+    Orc
+    Kreatur
+    Goblin
+    PitDemon
+    Spider
+    Tentacle1
+    Tentacle2
+    Troll
+    LizardMan
+    Scarab
+    Slime
+    [/SpawnPool]
+[/Faction]
+[Faction]
+    Name	Hero
+    [SpawnPool]
+    Gnome
+    Knight
+    BigKnight
+    Adventurer
+    Dwarf1
+    Dwarf2
+    Dwarf3
+    Wizard
+    [/SpawnPool]
+[/Faction]
+[/Factions]

--- a/config/global.cfg
+++ b/config/global.cfg
@@ -64,6 +64,10 @@
     Type	SpawnConditions
     Filename	spawnconditions.cfg
 [/ConfigFile]
+[ConfigFile]
+    Type	Factions
+    Filename	factions.cfg
+[/ConfigFile]
 [/ConfigFiles]
 [GameConfig]
     NetworkPort	31222

--- a/gui/OpenDungeonsMenuConfigureSeats.layout
+++ b/gui/OpenDungeonsMenuConfigureSeats.layout
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<GUILayout version="4" >
+    <Window type="OD/StaticImage" name="Background" >
+        <Property name="Area" value="{{0,0},{0,0},{1,2},{1,0}}" />
+        <Property name="Image" value="ODMainMenuBackground/MainMenuBackground" />
+        <Property name="MaxSize" value="{{1,0},{1,0}}" />
+        <Property name="FrameEnabled" value="False" />
+        <Property name="BackgroundEnabled" value="False" />
+        <Window type="OD/StaticText" name="LoadingText" >
+            <Property name="Area" value="{{0.5,-301},{0.5,240},{0.5,299},{0.5,260}}" />
+            <Property name="Text" value="Loading..." />
+            <Property name="MaxSize" value="{{1,0},{1,0}}" />
+            <Property name="FrameEnabled" value="False" />
+            <Property name="HorzFormatting" value="CentreAligned" />
+            <Property name="BackgroundEnabled" value="False" />
+        </Window>
+        <Window type="OD/StaticImage" name="WelcomeBanner" >
+            <Property name="Area" value="{{0.5,-320},{0,52},{0.5,320},{0,191}}" />
+            <Property name="Image" value="ODLogo/Logo" />
+            <Property name="MaxSize" value="{{1,0},{1,0}}" />
+            <Property name="FrameEnabled" value="False" />
+            <Property name="BackgroundEnabled" value="False" />
+        </Window>
+        <Window type="OD/FrameWindow" name="ListPlayers" >
+            <Property name="Area" value="{{0.5,-315},{0.5,-180},{0.5,315},{0.5,240}}" />
+            <Property name="Text" value="Please configure players..." />
+            <Property name="MinSize" value="{{0,630},{0,420}}" />
+            <Property name="AlwaysOnTop" value="True" />
+            <Window type="OD/StaticText" name="TextSeatTitle" >
+               <Property name="Area" value="{{0,20},{0,40},{0,100},{0,70}}" />
+               <Property name="Text" value="Seat" />
+               <Property name="FrameEnabled" value="False" />
+               <Property name="BackgroundEnabled" value="False" />
+            </Window>
+            <Window type="OD/StaticText" name="ComboPlayerTypeSeatTitle" >
+                <Property name="Area" value="{{0,100},{0,40},{0.5,-10},{0,70}}" />
+               <Property name="Text" value="Player faction" />
+               <Property name="FrameEnabled" value="False" />
+               <Property name="BackgroundEnabled" value="False" />
+            </Window>
+            <Window type="OD/StaticText" name="ComboPlayerSeatTitle" >
+                <Property name="Area" value="{{0.5,10},{0,40},{1,-20},{0,70}}" />
+               <Property name="Text" value="Player" />
+               <Property name="FrameEnabled" value="False" />
+               <Property name="BackgroundEnabled" value="False" />
+            </Window>
+            <Window type="OD/MainMenuButton" name="BackButton" >
+                <Property name="Area" value="{{0.5,-228},{1,-100},{0.5,-64},{1,-20}}" />
+                <Property name="Text" value="Back" />
+            </Window>
+            <Window type="OD/MainMenuButton" name="LaunchGameButton" >
+                <Property name="Area" value="{{0.5,-2},{1,-100},{0.5,162},{1,-20}}" />
+                <Property name="Text" value="Start Game" />
+            </Window>
+        </Window>
+    </Window>
+</GUILayout>

--- a/levels/multiplayer/TestMultiplayer.level
+++ b/levels/multiplayer/TestMultiplayer.level
@@ -8,11 +8,11 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	faction	startingX	startingY	color	startingGold
-1	1	Player	195	207	1	1000
-2	2	Player	252	211	2	1000
-3	3	KeeperAI	167	104	3	1000
-4	4	KeeperAI	266	92	4	1000
+# seatId	teamId	player	faction	startingX	startingY	color	startingGold
+1	1	Human	Keeper	195	207	1	1000
+2	2	Choice	Choice	252	211	2	1000
+3	3	Choice	Choice	167	104	3	1000
+4	4	Choice	Choice	266	92	4	1000
 5	5	none	200	200	5	1000
 [/Seats]
 
@@ -5872,89 +5872,6 @@ ProtectDungeonTemple	NULL
 # posX	posY	posZ	diffuseR	diffuseG	diffuseB	specularR	specularG	specularB	attenRange	attenConst	attenLin	attenQuad
 193	205	3.75	0.9	0.8	0.6	0.2	0.2	0.2	50	0.012	0.32	0.0018
 [/Lights]
-
-[Spawn_Pools]
-# Each team's spawn pool.
-# Describes what each team can spawn.
-
-[Spawn_Pool]
-# seat id
-1
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-2
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-3
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-4
-# Creature list
-Gnome
-Knight
-BigKnight
-Adventurer
-Dwarf1
-Dwarf2
-Dwarf3
-Wizard
-[/Spawn_Pool]
-
-[/Spawn_Pools]
 
 [Creatures]
 # SeatId	ClassName	Name	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	PosX	PosY	PosZ	LeftWeapon RightWeapon

--- a/levels/multiplayer/TestMultiplayerSmall1v1.level
+++ b/levels/multiplayer/TestMultiplayerSmall1v1.level
@@ -8,9 +8,9 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	faction	startingX	startingY	color	startingGold
-1	1	Player	10	10	1	1000
-2	2	Player	10	40	2	1000
+# seatId	teamId	player	faction	startingX	startingY	color	startingGold
+1	1	Human	Choice	10	10	1	1000
+2	2	Choice	Choice	10	40	2	1000
 [/Seats]
 
 [Goals]
@@ -498,54 +498,6 @@ ProtectDungeonTemple	NULL
 
 [EquipmentDefinitions]
 [/EquipmentDefinitions]
-
-[Spawn_Pools]
-# Each team's spawn pool.
-# Describes what each team can spawn.
-
-[Spawn_Pool]
-# seat id
-1
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-2
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[/Spawn_Pools]
 
 [Creatures]
 # SeatId	ClassName	Name	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	PosX	PosY	PosZ	LeftWeapon	RightWeapon

--- a/levels/multiplayer/TestMultiplayerSmallAlliance.level
+++ b/levels/multiplayer/TestMultiplayerSmallAlliance.level
@@ -8,11 +8,11 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	faction	startingX	startingY	color	startingGold
-1	1	Player	10	10	1	1000
-2	1	Player	10	40	2	1000
-3	2	KeeperAI	40	10	3	1000
-4	2	KeeperAI	40	40	4	1000
+# seatId	teamId	player	faction	startingX	startingY	color	startingGold
+1	1	Human	Keeper	10	10	1	1000
+2	1	Choice	Choice	10	40	2	1000
+3	2	Choice	Keeper	40	10	3	1000
+4	2	Choice	Choice	40	40	4	1000
 [/Seats]
 
 [Goals]
@@ -748,89 +748,6 @@ ProtectDungeonTemple	NULL
 # posX	posY	posZ	diffuseR	diffuseG	diffuseB	specularR	specularG	specularB	attenRange	attenConst	attenLin	attenQuad
 12	7	3.75	0.9	0.8	0.6	0.2	0.2	0.2	50	0.012	0.32	0.0018
 [/Lights]
-
-[Spawn_Pools]
-# Each team's spawn pool.
-# Describes what each team can spawn.
-
-[Spawn_Pool]
-# seat id
-1
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-2
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-3
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-4
-# Creature list
-Gnome
-Knight
-BigKnight
-Adventurer
-Dwarf1
-Dwarf2
-Dwarf3
-Wizard
-[/Spawn_Pool]
-
-[/Spawn_Pools]
 
 [Creatures]
 # SeatId	ClassName	Name	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	PosX	PosY	PosZ	LeftWeapon RightWeapon

--- a/levels/multiplayer/TestMultiplayerSmallFreeForAll.level
+++ b/levels/multiplayer/TestMultiplayerSmallFreeForAll.level
@@ -8,11 +8,11 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	faction	startingX	startingY	color	startingGold
-1	1	Player	10	10	1	1000
-2	2	Player	10	40	2	1000
-3	3	KeeperAI	40	10	3	1000
-4	4	KeeperAI	40	40	4	1000
+# seatId	teamId	player	faction	startingX	startingY	color	startingGold
+1	1	Choice	Choice	10	10	1	1000
+2	2	Choice	Choice	10	40	2	1000
+3	3	Choice	Choice	40	10	3	1000
+4	4	Choice	Choice	40	40	4	1000
 [/Seats]
 
 [Goals]
@@ -748,89 +748,6 @@ ProtectDungeonTemple	NULL
 # posX	posY	posZ	diffuseR	diffuseG	diffuseB	specularR	specularG	specularB	attenRange	attenConst	attenLin	attenQuad
 12	7	3.75	0.9	0.8	0.6	0.2	0.2	0.2	50	0.012	0.32	0.0018
 [/Lights]
-
-[Spawn_Pools]
-# Each team's spawn pool.
-# Describes what each team can spawn.
-
-[Spawn_Pool]
-# seat id
-1
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-2
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-3
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-4
-# Creature list
-Gnome
-Knight
-BigKnight
-Adventurer
-Dwarf1
-Dwarf2
-Dwarf3
-Wizard
-[/Spawn_Pool]
-
-[/Spawn_Pools]
 
 [Creatures]
 # SeatId	ClassName	Name	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	PosX	PosY	PosZ	LeftWeapon RightWeapon

--- a/levels/skirmish/Scream in the Dark.level
+++ b/levels/skirmish/Scream in the Dark.level
@@ -8,12 +8,12 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	faction	startingX	startingY	color	startingGold
-1	1	Player	5	6	1	1000
-2	1	KeeperAI	89	15	2	1000
-3	2	KeeperAI	91	55	3	1000
-4	2	KeeperAI	47	94	4	1000
-5	3	KeeperAI	47	94	5	1000
+# seatId	teamId	player	faction	startingX	startingY	color	startingGold
+1	1	Human	Keeper	5	6	1	1000
+2	1	AI	Keeper	89	15	2	1000
+3	2	AI	Keeper	91	55	3	1000
+4	2	AI	Keeper	47	94	4	1000
+5	3	AI	Keeper	47	94	5	1000
 [/Seats]
 
 [Goals]
@@ -5245,100 +5245,6 @@ ProtectDungeonTemple	NULL
 [Lights]
 # posX	posY	posZ	diffuseR	diffuseG	diffuseB	specularR	specularG	specularB	attenRange	attenConst	attenLin	attenQuad
 [/Lights]
-
-[Spawn_Pools]
-# Each team's spawn pool.
-# Describes what each team can spawn.
-
-[Spawn_Pool]
-# seat id
-1
-# Creature list
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-2
-# Creature list
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-3
-# Creature list
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-4
-# Creature list
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-5
-# Creature list
-Gnome
-Knight
-BigKnight
-Adventurer
-Dwarf3
-Wizard
-[/Spawn_Pool]
-
-[/Spawn_Pools]
 
 [Creatures]
 # SeatId	ClassName	Name	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	PosX	PosY	PosZ	LeftWeapon RightWeapon

--- a/levels/skirmish/Stonekeep siege.level
+++ b/levels/skirmish/Stonekeep siege.level
@@ -8,12 +8,12 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	faction	startingX	startingY	color	startingGold
-1	1	Player	51	16	1	1000
-2	2	KeeperAI	7	55	2	1000
-3	3	KeeperAI	91	55	3	1000
-4	4	KeeperAI	47	94	4	1000
-5	5	none	47	94	5	1000
+# seatId	teamId	player	faction	startingX	startingY	color	startingGold
+1	1	Human	Keeper	51	16	1	1000
+2	2	AI	Keeper	7	55	2	1000
+3	3	AI	Keeper	91	55	3	1000
+4	4	AI	Keeper	47	94	4	1000
+5	5	Inactive	Keeper	47	94	5	1000
 [/Seats]
 
 [Goals]
@@ -4011,83 +4011,6 @@ ProtectDungeonTemple	NULL
 51	16	3.75	0.9	0.8	0.6	0.2	0.2	0.2	50	0.012	0.32	0.0018
 47	94	3.75	0.9	0.8	0.6	0.2	0.2	0.2	50	0.012	0.32	0.0018
 [/Lights]
-
-[Spawn_Pools]
-# Each team's spawn pool.
-# Describes what each team can spawn.
-
-[Spawn_Pool]
-# seat id
-1
-# Creature list
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-2
-# Creature list
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-3
-# Creature list
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-4
-# Creature list
-Gnome
-Knight
-BigKnight
-Adventurer
-Dwarf1
-Dwarf2
-Dwarf3
-Wizard
-[/Spawn_Pool]
-
-[/Spawn_Pools]
 
 [Creatures]
 # SeatId	ClassName	Name	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	PosX	PosY	PosZ	LeftWeapon RightWeapon

--- a/levels/skirmish/TestSingleplayer.level
+++ b/levels/skirmish/TestSingleplayer.level
@@ -8,12 +8,12 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	faction	startingX	startingY	color	startingGold
-1	1	Player	195	207	1	1000
-2	2	KeeperAI	200	200	2	1000
-3	3	KeeperAI	200	200	3	1000
-4	4	KeeperAI	266	95	4	1000
-5	5	none	200	200	5	1000
+# seatId	teamId	player	faction	startingX	startingY	color	startingGold
+1	1	Human	Keeper	195	207	1	1000
+2	2	AI	Keeper	200	200	2	1000
+3	3	AI	Keeper	200	200	3	1000
+4	4	AI	Keeper	266	95	4	1000
+5	5	Inactive	Keeper	200	200	5	1000
 [/Seats]
 
 [Goals]
@@ -5872,89 +5872,6 @@ ProtectDungeonTemple	NULL
 # posX	posY	posZ	diffuseR	diffuseG	diffuseB	specularR	specularG	specularB	attenRange	attenConst	attenLin	attenQuad
 193	205	3.75	0.9	0.8	0.6	0.2	0.2	0.2	50	0.012	0.32	0.0018
 [/Lights]
-
-[Spawn_Pools]
-# Each team's spawn pool.
-# Describes what each team can spawn.
-
-[Spawn_Pool]
-# seat id
-1
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-2
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-3
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-4
-# Creature list
-Gnome
-Knight
-BigKnight
-Adventurer
-Dwarf1
-Dwarf2
-Dwarf3
-Wizard
-[/Spawn_Pool]
-
-[/Spawn_Pools]
 
 [Creatures]
 # SeatId	ClassName	Name	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	PosX	PosY	PosZ	LeftWeapon RightWeapon

--- a/levels/skirmish/TestSingleplayerSmall.level
+++ b/levels/skirmish/TestSingleplayerSmall.level
@@ -8,11 +8,11 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	faction	startingX	startingY	color	startingGold
-1	1	Player	10	10	1	1000
-2	1	KeeperAI	10	40	2	1000
-3	2	KeeperAI	40	10	3	1000
-4	2	KeeperAI	40	40	4	1000
+# seatId	teamId	player	faction	startingX	startingY	color	startingGold
+1	1	Human	Keeper	10	10	1	1000
+2	1	AI	Hero	10	40	2	1000
+3	2	Choice	Choice	40	10	3	1000
+4	2	Choice	Choice	40	40	4	1000
 [/Seats]
 
 [Goals]
@@ -845,89 +845,6 @@ ProtectDungeonTemple	NULL
     [/Stats]
 [/Equipment]
 [/EquipmentDefinitions]
-
-[Spawn_Pools]
-# Each team's spawn pool.
-# Describes what each team can spawn.
-
-[Spawn_Pool]
-# seat id
-1
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-2
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-3
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-4
-# Creature list
-Gnome
-Knight
-BigKnight
-Adventurer
-Dwarf1
-Dwarf2
-Dwarf3
-Wizard
-[/Spawn_Pool]
-
-[/Spawn_Pools]
 
 [Creatures]
 # SeatId	ClassName	Name	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	PosX	PosY	PosZ	LeftWeapon	RightWeapon

--- a/levels/skirmish/TestSingleplayerSmallEmpty.level
+++ b/levels/skirmish/TestSingleplayerSmallEmpty.level
@@ -8,9 +8,9 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	faction	startingX	startingY	color	startingGold
-1	1	Player	10	10	1	1000
-2	2	None	10	10	2	1000
+# seatId	teamId	player	faction	startingX	startingY	color	startingGold
+1	1	Choice	Keeper	10	10	1	1000
+2	2	Inactive	Keeper	10	10	2	1000
 [/Seats]
 
 [Goals]
@@ -2588,35 +2588,6 @@ ProtectDungeonTemple	NULL
 # posX	posY	posZ	diffuseR	diffuseG	diffuseB	specularR	specularG	specularB	attenRange	attenConst	attenLin	attenQuad
 12	7	3.75	0.9	0.8	0.6	0.2	0.2	0.2	50	0.012	0.32	0.0018
 [/Lights]
-
-[Spawn_Pools]
-# Each team's spawn pool.
-# Describes what each team can spawn.
-
-[Spawn_Pool]
-# seat id
-1
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Gnome
-Goblin
-PitDemon
-Spider
-Wizard
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[/Spawn_Pools]
 
 [Creatures]
 # SeatId	ClassName	Name	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	PosX	PosY	PosZ	LeftWeapon RightWeapon

--- a/levels/skirmish/TestSingleplayerSmallPassability.level
+++ b/levels/skirmish/TestSingleplayerSmallPassability.level
@@ -8,8 +8,8 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	faction	startingX	startingY	color	startingGold
-1	1	Player	1	1	1	1000
+# seatId	teamId	player	faction	startingX	startingY	color	startingGold
+1	1	Human	Keeper	1	1	1	1000
 [/Seats]
 
 [Goals]
@@ -171,12 +171,6 @@ ProtectDungeonTemple	NULL
 # posX	posY	posZ	diffuseR	diffuseG	diffuseB	specularR	specularG	specularB	attenRange	attenConst	attenLin	attenQuad
 12	7	3.75	0.9	0.8	0.6	0.2	0.2	0.2	50	0.012	0.32	0.0018
 [/Lights]
-
-[Spawn_Pools]
-# Each team's spawn pool.
-# Describes what each team can spawn.
-
-[/Spawn_Pools]
 
 [Creatures]
 # SeatId	ClassName	Name	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	PosX	PosY	PosZ	LeftWeapon RightWeapon

--- a/levels/skirmish/oldTest.level
+++ b/levels/skirmish/oldTest.level
@@ -8,12 +8,12 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	faction	startingX	startingY	color	startingGold
-1	1	Player	200	200	1	1000
-2	2	KeeperAI	200	200	2	1000
-3	3	KeeperAI	200	200	3	1000
-4	4	none	200	200	4	1000
-5	5	none	200	200	5	1000
+# seatId	teamId	player	faction	startingX	startingY	color	startingGold
+1	1	Human	Keeper	200	200	1	1000
+2	2	AI	Choice	200	200	2	1000
+3	3	AI	Choice	200	200	3	1000
+4	4	Inactive	Keeper	200	200	4	1000
+5	5	Inactive	Keeper	200	200	5	1000
 [/Seats]
 
 [Goals]
@@ -6634,68 +6634,6 @@ ProtectDungeonTemple	NULL
 # posX	posY	posZ	diffuseR	diffuseG	diffuseB	specularR	specularG	specularB	attenRange	attenConst	attenLin	attenQuad
 193	205	3.75	0.9	0.8	0.6	0.2	0.2	0.2	50	0.012	0.32	0.0018
 [/Lights]
-
-[Spawn_Pools]
-# Each team's spawn pool.
-# Describes what each team can spawn.
-
-[Spawn_Pool]
-# seat id
-1
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-2
-# Creature list
-ConstructWorker
-CaveHornet
-Wyvern
-Dragon
-Orc
-Kreatur
-Goblin
-PitDemon
-Spider
-Tentacle1
-Tentacle2
-Troll
-LizardMan
-Scarab
-Slime
-[/Spawn_Pool]
-
-[Spawn_Pool]
-# seat id
-3
-# Creature list
-Gnome
-Knight
-BigKnight
-Adventurer
-Dwarf1
-Dwarf2
-Dwarf3
-Wizard
-[/Spawn_Pool]
-
-[/Spawn_Pools]
 
 [Creatures]
 # SeatId	ClassName	Name	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	PosX	PosY	PosZ	LeftWeapon RightWeapon

--- a/source/ODApplication.cpp
+++ b/source/ODApplication.cpp
@@ -230,7 +230,6 @@ For information on how to use a particular command, type help followed by the co
 \n\tmousespeed - sets the mouse speed\
 \n\tambientlight - set the ambient light color\
 \n\tconnect - connect to a server\
-\n\thost - host a server\
 \n\tchat - send a message to other people in the game\
 \n\tnearclip - sets the near clipping distance\
 \n\tfarclip - sets the far clipping distance\

--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -1581,12 +1581,9 @@ bool Creature::handleDigTileAction()
         // If the tile is a gold tile accumulate gold for this creature.
         if (tempTile->getType() == Tile::gold)
         {
-            //FIXME: Make sure we can't dig gold if the creature has max gold.
-            // Or let gold on the ground, until there is space so that the player
-            // isn't stuck when making a way through gold.
             double tempDouble = 5 * std::min(mDefinition->getDigRate(), tempTile->getFullness());
             mGold += (int)tempDouble;
-            getSeat()->mGoldMined += static_cast<int>(tempDouble);
+            getSeat()->addGoldMined(static_cast<int>(tempDouble));
             receiveExp(5.0 * mDefinition->getDigRate() / 20.0);
         }
 

--- a/source/entities/Tile.cpp
+++ b/source/entities/Tile.cpp
@@ -880,10 +880,6 @@ void Tile::setSelected(bool ss, Player* pp)
 
 void Tile::setMarkedForDiggingForAllPlayersExcept(bool s, Seat* exceptSeat)
 {
-    Player* player = getGameMap()->getLocalPlayer();
-    if(exceptSeat == NULL || (player->getSeat() != NULL && !exceptSeat->isAlliedSeat(player->getSeat())))
-        setMarkedForDigging(s, player);
-
     for (unsigned int i = 0, num = getGameMap()->numPlayers(); i < num; ++i)
     {
         Player* player = getGameMap()->getPlayer(i);

--- a/source/game/Player.cpp
+++ b/source/game/Player.cpp
@@ -33,12 +33,13 @@
 
 #include "utils/LogManager.h"
 
-Player::Player() :
+Player::Player(GameMap* gameMap, int32_t id) :
+    mId(id),
     mNewRoomType(Room::nullRoomType),
     mNewTrapType(Trap::nullTrapType),
     mCurrentAction(SelectedAction::none),
-    mGameMap(NULL),
-    mSeat(NULL),
+    mGameMap(gameMap),
+    mSeat(nullptr),
     mHasAI(false),
     mFightingTime(0.0f),
     mIsPlayerLostSent(false)

--- a/source/game/Player.h
+++ b/source/game/Player.h
@@ -134,7 +134,7 @@ public:
 private:
     //! \brief Player ID is only used during seat configuration phase
     //! During the game, one should use the seat ID to identify a player because
-    //! every AI player has an AI = 0.
+    //! every AI player has an id = 0.
     //! ID is unique only for human players
     int32_t mId;
     //! \brief Room or trap tile type the player is currently willing to place on map.

--- a/source/game/Player.h
+++ b/source/game/Player.h
@@ -38,6 +38,7 @@ class Creature;
  */
 class Player
 {
+    friend class Seat;
 public:
     enum SelectedAction
     {
@@ -49,7 +50,10 @@ public:
         destroyRoom,
         destroyTrap
     };
-    Player();
+    Player(GameMap* gameMap, int32_t id);
+
+    inline int32_t getId() const
+    { return mId; }
 
     const std::string& getNick() const
     { return mNickname; }
@@ -62,9 +66,6 @@ public:
 
     void setNick (const std::string& nick)
     { mNickname = nick; }
-
-    void setSeat(Seat* seat)
-    { mSeat = seat; }
 
     //! \brief A simple accessor function to return the number of creatures
     //! this player is holding in his/her hand that belongs to seat seat.
@@ -96,9 +97,6 @@ public:
 
     //! \brief Clears all creatures that a player might have in his hand
     void notifyNoMoreDungeonTemple();
-
-    inline void setGameMap(GameMap* gameMap)
-    { mGameMap = gameMap; }
 
     inline bool getHasAI() const
     { return mHasAI; }
@@ -134,6 +132,11 @@ public:
     { mCurrentAction = action; }
 
 private:
+    //! \brief Player ID is only used during seat configuration phase
+    //! During the game, one should use the seat ID to identify a player because
+    //! every AI player has an AI = 0.
+    //! ID is unique only for human players
+    int32_t mId;
     //! \brief Room or trap tile type the player is currently willing to place on map.
     Room::RoomType mNewRoomType;
     Trap::TrapType mNewTrapType;

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -324,7 +324,7 @@ const CreatureDefinition* Seat::getNextCreatureClassToSpawn()
     if(defSpawnable.empty())
         return nullptr;
 
-    // We choose randomly a creature to spawn according to there points
+    // We choose randomly a creature to spawn according to their points
     int32_t cpt = Random::Int(0, nbPointsTotal);
     for(std::pair<const CreatureDefinition*, int32_t>& def : defSpawnable)
     {

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -30,16 +30,22 @@
 #include "utils/LogManager.h"
 #include "utils/Random.h"
 
+const std::string Seat::PLAYER_TYPE_HUMAN = "Human";
+const std::string Seat::PLAYER_TYPE_AI = "AI";
+const std::string Seat::PLAYER_TYPE_INACTIVE = "Inactive";
+const std::string Seat::PLAYER_TYPE_CHOICE = "Choice";
+const std::string Seat::PLAYER_FACTION_CHOICE = "Choice";
+
 Seat::Seat(GameMap* gameMap) :
+    mGameMap(gameMap),
+    mPlayer(nullptr),
     mTeamId(0),
-    mStartingX(0),
-    mStartingY(0),
     mMana(1000),
     mManaDelta(0),
-    mHp(1000),
+    mStartingX(0),
+    mStartingY(0),
     mGoldMined(0),
     mNumCreaturesControlled(0),
-    mGameMap(gameMap),
     mNumClaimedTiles(0),
     mHasGoalsChanged(true),
     mGold(0),
@@ -268,21 +274,22 @@ bool Seat::canTrapBeDestroyedBy(Seat* seat)
     return false;
 }
 
-void Seat::addSpawnableCreature(const std::string& creature_name)
+void Seat::setPlayer(Player* player)
 {
-    const CreatureDefinition* def = ConfigManager::getSingleton().getCreatureDefinition(creature_name);
-    OD_ASSERT_TRUE_MSG(def != nullptr, "creature_name=" + creature_name);
-    if(def == nullptr)
-        return;
-    mSpawnPool.push_back(std::pair<const CreatureDefinition*, bool>(def, false));
+    OD_ASSERT_TRUE_MSG(mPlayer == nullptr, "A player=" + mPlayer->getNick() + " already on seat id="
+        + Ogre::StringConverter::toString(getId()));
+
+    mPlayer = player;
+    mPlayer->mSeat = this;
 }
 
-
-void Seat::writeSpawnPool(std::ofstream& file) const
+void Seat::initSpawnPool()
 {
-    for(std::pair<const CreatureDefinition*, bool> def : mSpawnPool)
+    const std::vector<const CreatureDefinition*>& pool = ConfigManager::getSingleton().getFactionSpawnPool(mFaction);
+    OD_ASSERT_TRUE_MSG(!pool.empty(), "Empty spwn pool for faction=" + mFaction);
+    for(const CreatureDefinition* def : pool)
     {
-        file << def.first->getClassName() << std::endl;
+        mSpawnPool.push_back(std::pair<const CreatureDefinition*, bool>(def, false));
     }
 }
 
@@ -341,12 +348,12 @@ const CreatureDefinition* Seat::getNextCreatureClassToSpawn()
 
 std::string Seat::getFormat()
 {
-    return "seatId\tteamId\tfaction\tstartingX\tstartingY\tcolor\tstartingGold";
+    return "seatId\tteamId\tplayer\tfaction\tstartingX\tstartingY\tcolor\tstartingGold";
 }
 
 ODPacket& operator<<(ODPacket& os, Seat *s)
 {
-    os << s->mId << s->mTeamId << s->mFaction << s->mStartingX
+    os << s->mId << s->mTeamId << s->mPlayerTypeOriginal << s->mPlayerType << s->mFactionOriginal << s->mFaction << s->mStartingX
        << s->mStartingY;
     os << s->mColorId;
     os << s->mGold << s->mMana << s->mManaDelta << s->mNumClaimedTiles;
@@ -357,7 +364,8 @@ ODPacket& operator<<(ODPacket& os, Seat *s)
 
 ODPacket& operator>>(ODPacket& is, Seat *s)
 {
-    is >> s->mId >> s->mTeamId >> s->mFaction >> s->mStartingX >> s->mStartingY;
+    is >> s->mId >> s->mTeamId >> s->mPlayerTypeOriginal >> s->mPlayerType;
+    is >> s->mFactionOriginal >> s->mFaction >> s->mStartingX >> s->mStartingY;
     is >> s->mColorId;
     is >> s->mGold >> s->mMana >> s->mManaDelta >> s->mNumClaimedTiles;
     is >> s->mHasGoalsChanged;
@@ -368,10 +376,11 @@ ODPacket& operator>>(ODPacket& is, Seat *s)
 
 const std::string Seat::getFactionFromLine(const std::string& line)
 {
+    const uint32_t indexFactionInLine = 3;
     std::vector<std::string> elems = Helper::split(line, '\t');
-    OD_ASSERT_TRUE_MSG(elems.size() > 2, "line=" + line);
-    if(elems.size() > 2)
-        return elems[2];
+    OD_ASSERT_TRUE_MSG(elems.size() > indexFactionInLine, "line=" + line);
+    if(elems.size() > indexFactionInLine)
+        return elems[indexFactionInLine];
 
     return std::string();
 }
@@ -380,13 +389,15 @@ void Seat::loadFromLine(const std::string& line, Seat *s)
 {
     std::vector<std::string> elems = Helper::split(line, '\t');
 
-    s->mId = Helper::toInt(elems[0]);
-    s->mTeamId = Helper::toInt(elems[1]);
-    s->mFaction = elems[2];
-    s->mStartingX = Helper::toInt(elems[3]);
-    s->mStartingY = Helper::toInt(elems[4]);
-    s->mColorId = elems[5];
-    s->mStartingGold = Helper::toInt(elems[6]);
+    int32_t i = 0;
+    s->mId = Helper::toInt(elems[i++]);
+    s->mTeamId = Helper::toInt(elems[i++]);
+    s->mPlayerTypeOriginal = elems[i++];
+    s->mFactionOriginal = elems[i++];
+    s->mStartingX = Helper::toInt(elems[i++]);
+    s->mStartingY = Helper::toInt(elems[i++]);
+    s->mColorId = elems[i++];
+    s->mStartingGold = Helper::toInt(elems[i++]);
     s->mColorValue = ConfigManager::getSingleton().getColorFromId(s->mColorId);
 }
 
@@ -407,7 +418,7 @@ bool Seat::sortForMapSave(Seat* s1, Seat* s2)
 
 std::ostream& operator<<(std::ostream& os, Seat *s)
 {
-    os << s->mId << "\t" << s->mTeamId << "\t" << s->mFaction << "\t" << s->mStartingX
+    os << s->mId << "\t" << s->mTeamId << "\t" << s->mPlayerTypeOriginal << "\t" << s->mFactionOriginal << "\t" << s->mStartingX
        << "\t"<< s->mStartingY;
     os << "\t" << s->mColorId;
     os << "\t" << s->mStartingGold;
@@ -416,7 +427,7 @@ std::ostream& operator<<(std::ostream& os, Seat *s)
 
 std::istream& operator>>(std::istream& is, Seat *s)
 {
-    is >> s->mId >> s->mTeamId >> s->mFaction >> s->mStartingX >> s->mStartingY;
+    is >> s->mId >> s->mTeamId >> s->mPlayerTypeOriginal >> s->mFactionOriginal >> s->mStartingX >> s->mStartingY;
     is >> s->mColorId;
     is >> s->mStartingGold;
     s->mColorValue = ConfigManager::getSingleton().getColorFromId(s->mColorId);

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -286,7 +286,7 @@ void Seat::setPlayer(Player* player)
 void Seat::initSpawnPool()
 {
     const std::vector<const CreatureDefinition*>& pool = ConfigManager::getSingleton().getFactionSpawnPool(mFaction);
-    OD_ASSERT_TRUE_MSG(!pool.empty(), "Empty spwn pool for faction=" + mFaction);
+    OD_ASSERT_TRUE_MSG(!pool.empty(), "Empty spawn pool for faction=" + mFaction);
     for(const CreatureDefinition* def : pool)
     {
         mSpawnPool.push_back(std::pair<const CreatureDefinition*, bool>(def, false));
@@ -353,7 +353,7 @@ std::string Seat::getFormat()
 
 ODPacket& operator<<(ODPacket& os, Seat *s)
 {
-    os << s->mId << s->mTeamId << s->mPlayerTypeOriginal << s->mPlayerType << s->mFactionOriginal << s->mFaction << s->mStartingX
+    os << s->mId << s->mTeamId << s->mPlayerType << s->mFaction << s->mStartingX
        << s->mStartingY;
     os << s->mColorId;
     os << s->mGold << s->mMana << s->mManaDelta << s->mNumClaimedTiles;
@@ -364,8 +364,8 @@ ODPacket& operator<<(ODPacket& os, Seat *s)
 
 ODPacket& operator>>(ODPacket& is, Seat *s)
 {
-    is >> s->mId >> s->mTeamId >> s->mPlayerTypeOriginal >> s->mPlayerType;
-    is >> s->mFactionOriginal >> s->mFaction >> s->mStartingX >> s->mStartingY;
+    is >> s->mId >> s->mTeamId >> s->mPlayerType;
+    is >> s->mFaction >> s->mStartingX >> s->mStartingY;
     is >> s->mColorId;
     is >> s->mGold >> s->mMana >> s->mManaDelta >> s->mNumClaimedTiles;
     is >> s->mHasGoalsChanged;
@@ -392,8 +392,8 @@ void Seat::loadFromLine(const std::string& line, Seat *s)
     int32_t i = 0;
     s->mId = Helper::toInt(elems[i++]);
     s->mTeamId = Helper::toInt(elems[i++]);
-    s->mPlayerTypeOriginal = elems[i++];
-    s->mFactionOriginal = elems[i++];
+    s->mPlayerType = elems[i++];
+    s->mFaction = elems[i++];
     s->mStartingX = Helper::toInt(elems[i++]);
     s->mStartingY = Helper::toInt(elems[i++]);
     s->mColorId = elems[i++];
@@ -418,7 +418,7 @@ bool Seat::sortForMapSave(Seat* s1, Seat* s2)
 
 std::ostream& operator<<(std::ostream& os, Seat *s)
 {
-    os << s->mId << "\t" << s->mTeamId << "\t" << s->mPlayerTypeOriginal << "\t" << s->mFactionOriginal << "\t" << s->mStartingX
+    os << s->mId << "\t" << s->mTeamId << "\t" << s->mPlayerType << "\t" << s->mFaction << "\t" << s->mStartingX
        << "\t"<< s->mStartingY;
     os << "\t" << s->mColorId;
     os << "\t" << s->mStartingGold;
@@ -427,7 +427,7 @@ std::ostream& operator<<(std::ostream& os, Seat *s)
 
 std::istream& operator>>(std::istream& is, Seat *s)
 {
-    is >> s->mId >> s->mTeamId >> s->mPlayerTypeOriginal >> s->mFactionOriginal >> s->mStartingX >> s->mStartingY;
+    is >> s->mId >> s->mTeamId >> s->mPlayerType >> s->mFaction >> s->mStartingX >> s->mStartingY;
     is >> s->mColorId;
     is >> s->mStartingGold;
     s->mColorValue = ConfigManager::getSingleton().getColorFromId(s->mColorId);

--- a/source/game/Seat.h
+++ b/source/game/Seat.h
@@ -19,6 +19,7 @@
 #define SEAT_H
 
 
+#include <OgreVector3.h>
 #include <OgreColourValue.h>
 #include <string>
 #include <vector>
@@ -29,6 +30,7 @@ class Goal;
 class ODPacket;
 class GameMap;
 class CreatureDefinition;
+class Player;
 
 class Seat
 {
@@ -37,6 +39,9 @@ public:
     friend class ODClient;
     // Constructors
     Seat(GameMap* gameMap);
+
+    inline Player* getPlayer()
+    { return mPlayer; }
 
     //! \brief Adds a goal to the vector of goals which must be completed by this seat before it can be declared a winner.
     void addGoal(Goal* g);
@@ -100,8 +105,14 @@ public:
     int getId() const
     { return mId; }
 
+    const std::string& getFactionOriginal() const
+    { return mFactionOriginal; }
+
     const std::string& getFaction() const
     { return mFaction; }
+
+    void setFaction(const std::string& faction)
+    { mFaction = faction; }
 
     const std::string& getColorId() const
     { return mColorId; }
@@ -121,12 +132,27 @@ public:
     inline double getManaDelta() const
     { return mManaDelta; }
 
-    void resetSpawnPool()
-    { mSpawnPool.clear(); }
+    inline int getStartingGold() const
+    { return mStartingGold; }
 
-    void addSpawnableCreature(const std::string& creature_name);
+    inline Ogre::Vector3 getStartingPosition() const
+    { return Ogre::Vector3(static_cast<Ogre::Real>(mStartingX), static_cast<Ogre::Real>(mStartingY), 0); }
 
-    void writeSpawnPool(std::ofstream& file) const;
+    inline void addGoldMined(int quantity)
+    { mGoldMined += quantity; }
+
+    const std::string& getPlayerTypeOriginal() const
+    { return mPlayerTypeOriginal; }
+
+    const std::string& getPlayerType() const
+    { return mPlayerType; }
+
+    void setPlayerType(const std::string& playerType)
+    { mPlayerType = playerType; }
+
+    void setPlayer(Player* player);
+
+    void initSpawnPool();
 
     const CreatureDefinition* getNextCreatureClassToSpawn();
 
@@ -140,33 +166,6 @@ public:
     bool canRoomBeDestroyedBy(Seat* seat);
     bool canTrapBeDestroyedBy(Seat* seat);
 
-    // TODO : most of these should be private
-    //! \brief The team id of the player sitting in this seat.
-    int mTeamId;
-
-    //! \brief The name of the faction that this seat is playing as.
-    std::string mFaction;
-
-    //! \brief The starting camera location (in tile coordinates) of this seat.
-    int mStartingX;
-    int mStartingY;
-
-    //! \brief The amount of 'keeper mana' the player has.
-    double mMana;
-
-    //! \brief The amount of 'keeper mana' the player gains/loses per turn, updated in GameMap::doTurn().
-    double mManaDelta;
-
-    //! \brief The amount of 'keeper HP' the player has.
-    double mHp;
-
-    //! \brief The total amount of gold coins mined by workers under this seat's control.
-    int mGoldMined;
-
-    int mNumCreaturesControlled;
-
-    int mStartingGold;
-
     static bool sortForMapSave(Seat* s1, Seat* s2);
 
     static std::string getFormat();
@@ -178,11 +177,53 @@ public:
     static void loadFromLine(const std::string& line, Seat *s);
     static const std::string getFactionFromLine(const std::string& line);
 
+    static const std::string PLAYER_TYPE_HUMAN;
+    static const std::string PLAYER_TYPE_AI;
+    static const std::string PLAYER_TYPE_INACTIVE;
+    static const std::string PLAYER_TYPE_CHOICE;
+
+    static const std::string PLAYER_FACTION_CHOICE;
+
 private:
     void goalsHasChanged();
 
     //! \brief The game map this seat belongs to
     GameMap* mGameMap;
+
+    //! \brief The player sitting on this seat
+    Player* mPlayer;
+
+    //! \brief The team id of the player sitting in this seat.
+    int mTeamId;
+
+    //! \brief The type of player (can be Human or AI).
+    std::string mPlayerType;
+
+    //! \brief The type of player (can be Human or AI).
+    std::string mPlayerTypeOriginal;
+
+    //! \brief The name of the faction that this seat is playing as (can be Keeper or Hero).
+    std::string mFaction;
+
+    //! \brief The name of the faction that this seat is playing as (can be Keeper or Hero).
+    std::string mFactionOriginal;
+
+    //! \brief The amount of 'keeper mana' the player has.
+    double mMana;
+
+    //! \brief The amount of 'keeper mana' the player gains/loses per turn, updated in GameMap::doTurn().
+    double mManaDelta;
+
+    //! \brief The starting camera location (in tile coordinates) of this seat.
+    int mStartingX;
+    int mStartingY;
+
+    //! \brief The total amount of gold coins mined by workers under this seat's control.
+    int mGoldMined;
+
+    int mNumCreaturesControlled;
+
+    int mStartingGold;
 
     //! \brief The actual color that this color index translates into.
     std::string mColorId;

--- a/source/game/Seat.h
+++ b/source/game/Seat.h
@@ -105,9 +105,6 @@ public:
     int getId() const
     { return mId; }
 
-    const std::string& getFactionOriginal() const
-    { return mFactionOriginal; }
-
     const std::string& getFaction() const
     { return mFaction; }
 
@@ -140,9 +137,6 @@ public:
 
     inline void addGoldMined(int quantity)
     { mGoldMined += quantity; }
-
-    const std::string& getPlayerTypeOriginal() const
-    { return mPlayerTypeOriginal; }
 
     const std::string& getPlayerType() const
     { return mPlayerType; }
@@ -199,14 +193,8 @@ private:
     //! \brief The type of player (can be Human or AI).
     std::string mPlayerType;
 
-    //! \brief The type of player (can be Human or AI).
-    std::string mPlayerTypeOriginal;
-
     //! \brief The name of the faction that this seat is playing as (can be Keeper or Hero).
     std::string mFaction;
-
-    //! \brief The name of the faction that this seat is playing as (can be Keeper or Hero).
-    std::string mFactionOriginal;
 
     //! \brief The amount of 'keeper mana' the player has.
     double mMana;

--- a/source/gamemap/GameMap.h
+++ b/source/gamemap/GameMap.h
@@ -210,9 +210,8 @@ public:
     //! \brief Deletes the data structure for all the players in the GameMap.
     void clearPlayers();
 
-    //! \brief Adds a pointer to a player structure to the players stored by this GameMap. Assigns the
-    //! seat to the player
-    void addPlayer(Player *player, Seat* seat);
+    //! \brief Adds a pointer to a player structure to the players stored by this GameMap
+    bool addPlayer(Player *player);
 
     //! \brief Assigns an ai to the chosen player
     bool assignAI(Player& player, const std::string& aiType, const std::string& parameters = std::string());
@@ -225,6 +224,12 @@ public:
     Player* getPlayer(const std::string& cName);
     const Player* getPlayer(const std::string& cName) const;
 
+    const std::vector<Player*>& getPlayers() const
+    { return mPlayers; }
+
+    const std::vector<Seat*>& getSeats() const
+    { return mSeats; }
+
     //! \brief Returns a pointer to the player structure stored by this GameMap whose seat id matches seatId.
     Player* getPlayerBySeatId(int seatId);
     Player* getPlayerBySeat(Seat* seat);
@@ -232,38 +237,16 @@ public:
     //! \brief Returns the number of player structures stored in this GameMap.
     unsigned int numPlayers() const;
 
-    //! \brief A simple mutator method to clear the vector of empty Seats stored in the GameMap.
-    void clearEmptySeats();
+    //! \brief A simple mutator method to clear the vector of Seats stored in the GameMap.
+    void clearSeats();
 
-    //! \brief A simple mutator method to add another empty Seat to the GameMap.
-    void addEmptySeat(Seat* s);
-
-    //! \brief A simple accessor method to return the given Seat.
-    Seat* getEmptySeat(int index);
-    const Seat* getEmptySeat(int index) const;
-
-    //! \brief A simple accessor method to return the first Seat with the given faction.
-    Seat* getEmptySeat(const std::string& faction);
-
-    //! \brief Removes the Seat with given id from the GameMap and returns a pointer to it,
-    //! this is used when a Player "sits down" at the GameMap.
-    Seat* popEmptySeat(int id);
+    //! \brief A simple mutator method to add another Seat to the GameMap.
+    void addSeat(Seat* s);
 
     int nextSeatId(int SeatId);
 
-    //! \brief A simple accessor method to return the number of empty Seats on the GameMap.
-    unsigned int numEmptySeats() const;
-
     void clearFilledSeats();
     void clearAiManager();
-
-    void addFilledSeat(Seat *s);
-
-    //! \brief A simple accessor method to return the given filled Seat.
-    Seat* getFilledSeat(int index);
-    const Seat* getFilledSeat(int index) const;
-
-    unsigned int numFilledSeats() const;
 
     Seat* getSeatById(int id);
 
@@ -386,11 +369,20 @@ public:
      */
     void enableFloodFill();
 
+    inline void setLocalPlayer(Player* player)
+    { mLocalPlayer = player; }
+
     inline Player* getLocalPlayer()
     { return mLocalPlayer; }
 
     inline const Player* getLocalPlayer() const
     { return mLocalPlayer; }
+
+    inline const std::string& getLocalPlayerNick()
+    { return mLocalPlayerNick; }
+
+    inline void setLocalPlayerNick(const std::string& nick)
+    { mLocalPlayerNick = nick; }
 
     //! \brief Updates the different entities animations.
     void updateAnimations(Ogre::Real timeSinceLastFrame);
@@ -477,8 +469,11 @@ public:
 private:
     void replaceFloodFill(Tile::FloodFillType floodFillType, int colorOld, int colorNew);
     bool mIsServerGameMap;
-    //! \brief the Local player reference.
+    //! \brief the Local player reference. The local player will also be in the player list so this pointer
+    //! should not be deleted as it will be handled like every other in the list.
     Player* mLocalPlayer;
+
+    std::string mLocalPlayerNick;
 
     //! \brief The current server turn number.
     int64_t mTurnNumber;
@@ -520,9 +515,8 @@ private:
     std::vector<MapLight*> mapLights;
 
     //! \brief Players and available game player slots (Seats)
-    std::vector<Player*> players;
-    std::vector<Seat*> emptySeats;
-    std::vector<Seat*> filledSeats;
+    std::vector<Player*> mPlayers;
+    std::vector<Seat*> mSeats;
     std::vector<Seat*> winningSeats;
 
     //! \brief Common player goals

--- a/source/goals/GoalMineNGold.cpp
+++ b/source/goals/GoalMineNGold.cpp
@@ -40,7 +40,7 @@ bool GoalMineNGold::isMet(Seat *s)
 std::string GoalMineNGold::getDescription(Seat *s)
 {
     std::stringstream tempSS;
-    tempSS << "Mined " << s->mGoldMined << " of " << mGoldToMine
+    tempSS << "Mined " << s->getGoldMined() << " of " << mGoldToMine
             << " gold coins.";
     return tempSS.str();
 }

--- a/source/modes/AbstractApplicationMode.h
+++ b/source/modes/AbstractApplicationMode.h
@@ -93,8 +93,6 @@ public:
         return mModeType;
     }
 
-    virtual bool waitForGameStart() { return false; }
-
     //! \brief Makes the handling of louse and keyboard interact with this mode.
     virtual void giveFocus();
 

--- a/source/modes/Console_executePromptCommand.cpp
+++ b/source/modes/Console_executePromptCommand.cpp
@@ -510,11 +510,12 @@ bool Console::executePromptCommand(const std::string& command, std::string argum
             else if (arguments.compare("colors") == 0 || arguments.compare("colours") == 0)
             {
                 tempSS << "Number:\tRed:\tGreen:\tBlue:\n";
-                for (unsigned int i = 0; i < gameMap->numFilledSeats(); ++i)
+                const std::vector<Seat*> seats = gameMap->getSeats();
+                for (Seat* seat : seats)
                 {
-                    Ogre::ColourValue color = gameMap->getFilledSeat(i)->getColorValue();
+                    Ogre::ColourValue color = seat->getColorValue();
 
-                    tempSS << "\n" << i << "\t\t" << color.r
+                    tempSS << "\n" << seat->getId() << "\t\t" << color.r
                            << "\t\t" << color.g << "\t\t" << color.b;
                 }
             }
@@ -612,22 +613,6 @@ bool Console::executePromptCommand(const std::string& command, std::string argum
         frameListener->mCommandOutput += "\nRecreating all meshes.\n";
     }*/
 
-    // Set your nickname
-    else if (command.compare("nick") == 0)
-    {
-        if (!arguments.empty())
-        {
-            gameMap->getLocalPlayer()->setNick(arguments);
-            frameListener->mCommandOutput += "\nNickname set to:  ";
-        }
-        else
-        {
-            frameListener->mCommandOutput += "\nCurrent nickname is:  ";
-        }
-
-        frameListener->mCommandOutput += gameMap->getLocalPlayer()->getNick() + "\n";
-    }
-
     /*
     // Set chat message variables
     else if (command.compare("maxtime") == 0)
@@ -713,42 +698,6 @@ bool Console::executePromptCommand(const std::string& command, std::string argum
 
         frameListener->mCommandOutput += "\n";
 
-    }
-
-    // Host a server
-    else if (command.compare("host") == 0)
-    {
-        // Make sure we have set a nickname.
-        if ((!gameMap->getLocalPlayer()->getNick().empty()) &&
-            (!arguments.empty()))
-        {
-            // Make sure we are not already connected to a server or hosting a game.
-            if (!frameListener->isConnected())
-            {
-                if (ODServer::getSingleton().startServer(arguments, false, ODServer::ServerMode::ModeGame))
-                {
-                    frameListener->mCommandOutput += "\nServer started successfully.\n";
-
-                    // Automatically closes the terminal
-                    frameListener->mTerminalActive = false;
-                }
-                else
-                {
-                    frameListener->mCommandOutput += "\nERROR:  Could not start server!\n";
-                }
-
-            }
-            else
-            {
-                frameListener->mCommandOutput
-                        += "\nERROR:  You are already connected to a game or are already hosting a game!\n";
-            }
-        }
-        else
-        {
-            frameListener->mCommandOutput
-                    += "\nYou must set a nick with the \"nick\" command before you can host a server.\n";
-        }
     }
 
     // Send help command information to all players

--- a/source/modes/Console_getHelp.cpp
+++ b/source/modes/Console_getHelp.cpp
@@ -121,13 +121,6 @@ string Console::getHelpText(std::string arg)
                 + "ambientlight 0.4 0.6 0.5\n\nThe above command sets the ambient light color to red=0.4, green=0.6, and blue = 0.5.";
     }
 
-    else if (arg.compare("host") == 0)
-    {
-        std::stringstream s;
-        s << ConfigManager::getSingleton().getNetworkPort();
-        return "Starts a server thread running on this machine.  This utility takes a port number as an argument.  The port number is the port to listen on for a connection.  The default (if no argument is given) is to use" + s.str() + "for the port number.";
-    }
-
     else if (arg.compare("connnect") == 0)
     {
         return "Connect establishes a connection with a server.  It takes as its argument an IP address specified in dotted decimal notation (such as 192.168.1.100), and starts a client thread which monitors the connection for events.";

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -777,9 +777,7 @@ bool GameMode::keyPressedNormal(const OIS::KeyEvent &arg)
         if(isConnected()) // If we are in a game.
         {
             Seat* tempSeat = mGameMap->getLocalPlayer()->getSeat();
-            frameListener.cameraFlyTo(Ogre::Vector3((Ogre::Real)tempSeat->mStartingX,
-                                                   (Ogre::Real)tempSeat->mStartingY,
-                                                   (Ogre::Real)0.0));
+            frameListener.cameraFlyTo(tempSeat->getStartingPosition());
         }
         break;
 

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -77,8 +77,6 @@ class  GameMode: public AbstractApplicationMode
     //! \brief Called when exit button is pressed
     void popupExit(bool pause);
 
-    bool waitForGameStart() { return true; }
-
     virtual void exitMode();
 
     virtual void notifyGuiAction(GuiAction guiAction);

--- a/source/modes/MenuMode.cpp
+++ b/source/modes/MenuMode.cpp
@@ -40,6 +40,7 @@ void MenuMode::activate()
     MusicPlayer::getSingleton().play("Pal_Zoltan_Illes_OpenDungeons_maintheme.ogg");
 
     GameMap* gameMap = ODFrameListener::getSingletonPtr()->getClientGameMap();
+    gameMap->clearAll();
     gameMap->setGamePaused(true);
 }
 

--- a/source/modes/MenuModeConfigureSeats.cpp
+++ b/source/modes/MenuModeConfigureSeats.cpp
@@ -1,0 +1,509 @@
+/*
+ *  Copyright (C) 2011-2014  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "gamemap/GameMap.h"
+
+#include "modes/MenuModeConfigureSeats.h"
+#include "modes/ModeManager.h"
+
+#include "render/Gui.h"
+#include "render/ODFrameListener.h"
+
+#include "network/ODServer.h"
+#include "network/ODClient.h"
+#include "network/ServerNotification.h"
+
+#include "sound/MusicPlayer.h"
+
+#include "utils/ConfigManager.h"
+#include "utils/LogManager.h"
+
+#include <CEGUI/CEGUI.h>
+
+#include <boost/filesystem.hpp>
+
+const std::string TEXT_SEAT_ID_PREFIX = "TextSeat";
+const std::string COMBOBOX_PLAYER_FACTION_PREFIX = "ComboPlayerFactionSeat";
+const std::string COMBOBOX_PLAYER_PREFIX = "ComboPlayerSeat";
+
+MenuModeConfigureSeats::MenuModeConfigureSeats(ModeManager *modeManager):
+    AbstractApplicationMode(modeManager, ModeManager::MENU_CONFIGURE_SEATS)
+{
+}
+
+MenuModeConfigureSeats::~MenuModeConfigureSeats()
+{
+    CEGUI::Window* tmpWin = Gui::getSingleton().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("ListPlayers");
+    for(Seat* seat : mSeats)
+    {
+        std::string name;
+        name = TEXT_SEAT_ID_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        tmpWin->destroyChild(name);
+        name = COMBOBOX_PLAYER_FACTION_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        tmpWin->destroyChild(name);
+        name = COMBOBOX_PLAYER_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        tmpWin->destroyChild(name);
+    }
+}
+
+void MenuModeConfigureSeats::activate()
+{
+    // Loads the corresponding Gui sheet.
+    Gui::getSingleton().loadGuiSheet(Gui::guiSheet::configureSeats);
+
+    giveFocus();
+
+    // Play the main menu music
+    // TODO: Make this configurable.
+    MusicPlayer::getSingleton().play("Pal_Zoltan_Illes_OpenDungeons_maintheme.ogg");
+
+    // We use the client game map to allow everybody to see how the server is configuring seats
+    GameMap* gameMap = ODFrameListener::getSingleton().getClientGameMap();
+    gameMap->setGamePaused(true);
+
+    CEGUI::WindowManager& winMgr = CEGUI::WindowManager::getSingleton();
+    CEGUI::Window* tmpWin = Gui::getSingleton().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("ListPlayers");
+    CEGUI::Window* msgWin = Gui::getSingleton().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("LoadingText");
+    msgWin->setText("Loading...");
+    msgWin->setVisible(false);
+
+    const std::vector<std::string>& factions = ConfigManager::getSingleton().getFactions();
+    const CEGUI::Image* selImg = &CEGUI::ImageManager::getSingleton().get("OpenDungeonsSkin/SelectionBrush");
+    const std::vector<Seat*>& seats = gameMap->getSeats();
+
+    ODServer::ServerMode serverMode = ODServer::getSingleton().getServerMode();
+    int offset = 0;
+    int bestSeatHumanSeatId = -1;
+    // We start by searching for the most suitable seat for local player. If we find a seat
+    // for human only, it is the one. If not, we use the first a human can use
+    for(Seat* seat : seats)
+    {
+        if(seat->getPlayerTypeOriginal().compare(Seat::PLAYER_TYPE_HUMAN) == 0)
+        {
+            bestSeatHumanSeatId = seat->getId();
+            break;
+        }
+        else if((bestSeatHumanSeatId == -1) &&
+                (seat->getPlayerTypeOriginal().compare(Seat::PLAYER_TYPE_CHOICE) == 0))
+        {
+            bestSeatHumanSeatId = seat->getId();
+        }
+    }
+
+    bool enabled = ODServer::getSingleton().isConnected();
+
+    for(Seat* seat : seats)
+    {
+        mSeats.push_back(seat);
+        std::string name;
+        CEGUI::Combobox* combo;
+
+        name = TEXT_SEAT_ID_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        CEGUI::DefaultWindow* textSeatId = static_cast<CEGUI::DefaultWindow*>(winMgr.createWindow("OD/StaticText", name));
+        tmpWin->addChild(textSeatId);
+        textSeatId->setArea(CEGUI::UDim(0,20), CEGUI::UDim(0,65 + offset), CEGUI::UDim(0.3,0), CEGUI::UDim(0,30));
+        textSeatId->setText("Seat id "  + Ogre::StringConverter::toString(seat->getId()));
+        textSeatId->setProperty("FrameEnabled", "False");
+        textSeatId->setProperty("BackgroundEnabled", "False");
+
+        name = COMBOBOX_PLAYER_FACTION_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        combo = static_cast<CEGUI::Combobox*>(winMgr.createWindow("OD/Combobox", name));
+        tmpWin->addChild(combo);
+        combo->setArea(CEGUI::UDim(0,100), CEGUI::UDim(0,70 + offset), CEGUI::UDim(0.3,0), CEGUI::UDim(0,200));
+        combo->setReadOnly(true);
+        combo->setEnabled(enabled);
+        if(seat->getFactionOriginal().compare(Seat::PLAYER_FACTION_CHOICE) == 0)
+        {
+            uint32_t cptFaction = 0;
+            for(const std::string& faction : factions)
+            {
+                CEGUI::ListboxTextItem* item = new CEGUI::ListboxTextItem(faction, cptFaction);
+                item->setSelectionBrushImage(selImg);
+                combo->addItem(item);
+                // At creation, we set the combo to the first available choice
+                if(cptFaction == 0)
+                {
+                    combo->setItemSelectState(item, true);
+                    combo->setText(item->getText());
+                }
+                ++cptFaction;
+            }
+        }
+        else
+        {
+            CEGUI::ListboxTextItem* item = new CEGUI::ListboxTextItem(seat->getFactionOriginal(), 0);
+            item->setSelectionBrushImage(selImg);
+            combo->addItem(item);
+            combo->setText(item->getText());
+            combo->setEnabled(false);
+        }
+        combo->subscribeEvent(CEGUI::Combobox::EventListSelectionAccepted, CEGUI::SubscriberSlot(&MenuModeConfigureSeats::comboChanged, this));
+
+        name = COMBOBOX_PLAYER_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        combo = static_cast<CEGUI::Combobox*>(winMgr.createWindow("OD/Combobox", name));
+        tmpWin->addChild(combo);
+        combo->setArea(CEGUI::UDim(0.5,10), CEGUI::UDim(0,70 + offset), CEGUI::UDim(0.3,0), CEGUI::UDim(0,200));
+        combo->setReadOnly(true);
+        combo->setEnabled(enabled);
+        if(seat->getPlayerTypeOriginal().compare(Seat::PLAYER_TYPE_INACTIVE) == 0)
+        {
+            CEGUI::ListboxTextItem* item = new CEGUI::ListboxTextItem(seat->getPlayerTypeOriginal(), 0);
+            item->setSelectionBrushImage(selImg);
+            combo->addItem(item);
+            combo->setText(item->getText());
+            combo->setEnabled(false);
+        }
+        else if(seat->getPlayerTypeOriginal().compare(Seat::PLAYER_TYPE_AI) == 0)
+        {
+            CEGUI::ListboxTextItem* item = new CEGUI::ListboxTextItem(seat->getPlayerTypeOriginal(), 1);
+            item->setSelectionBrushImage(selImg);
+            combo->addItem(item);
+            combo->setText(item->getText());
+            combo->setEnabled(false);
+        }
+        else if(seat->getPlayerTypeOriginal().compare(Seat::PLAYER_TYPE_CHOICE) == 0)
+        {
+            CEGUI::ListboxTextItem* item = new CEGUI::ListboxTextItem(Seat::PLAYER_TYPE_AI, 1);
+            item->setSelectionBrushImage(selImg);
+            combo->addItem(item);
+
+            // If we are not in multiplayer mode, we set all the players to AI except the best we could find
+            // The unset players will be set when a player connects
+            if((serverMode != ODServer::ServerMode::ModeGameMultiPlayer) &&
+               (seat->getId() != bestSeatHumanSeatId))
+            {
+                combo->setItemSelectState(item, true);
+                combo->setText(item->getText());
+            }
+        }
+        combo->subscribeEvent(CEGUI::Combobox::EventListSelectionAccepted, CEGUI::SubscriberSlot(&MenuModeConfigureSeats::comboChanged, this));
+
+        offset += 30;
+    }
+
+    tmpWin = Gui::getSingleton().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("ListPlayers/LaunchGameButton");
+    tmpWin->setEnabled(enabled);
+
+    // We notify the server we are ready to recceive players and configure them
+    ClientNotification *clientNotification = new ClientNotification(
+        ClientNotification::readyForSeatConfiguration);
+    ODClient::getSingleton().queueClientNotification(clientNotification);
+}
+
+void MenuModeConfigureSeats::launchSelectedButtonPressed()
+{
+    // We send to the server the associations faction/seat/player
+    // It will be responsible to disconnect the unselected players
+    if(!ODServer::getSingleton().isConnected())
+        return;
+
+    fireSeatConfigurationToServer(true);
+}
+
+void MenuModeConfigureSeats::goBack()
+{
+    // We disconnect client and, if we are server, the server
+    ODClient::getSingleton().disconnect();
+    if(ODServer::getSingleton().isConnected())
+    {
+        ODServer::getSingleton().stopServer();
+    }
+    regressMode();
+}
+
+bool MenuModeConfigureSeats::comboChanged(const CEGUI::EventArgs& ea)
+{
+    if(!ODServer::getSingleton().isConnected())
+        return true;
+
+    // If the combo changed is a player and he was already in another combo, we remove him from the combo
+    CEGUI::Combobox* comboSel = static_cast<CEGUI::Combobox*>(static_cast<const CEGUI::WindowEventArgs&>(ea).window);
+    CEGUI::ListboxItem* selItem = comboSel->getSelectedItem();
+    if((selItem != nullptr) &&
+       (comboSel->getName().compare(0, COMBOBOX_PLAYER_PREFIX.length(), COMBOBOX_PLAYER_PREFIX) == 0) &&
+       (selItem->getID() != 0) && // Can be several inactive players
+       (selItem->getID() != 1)) // Can be several AI players
+    {
+        CEGUI::Window* playersWin = Gui::getSingleton().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("ListPlayers");
+        for(Seat* seat : mSeats)
+        {
+            // We only add players to combos where a human player can play
+            if((seat->getPlayerTypeOriginal().compare(Seat::PLAYER_TYPE_INACTIVE) == 0) ||
+               (seat->getPlayerTypeOriginal().compare(Seat::PLAYER_TYPE_AI) == 0))
+            {
+                continue;
+            }
+
+            std::string name = COMBOBOX_PLAYER_PREFIX + Ogre::StringConverter::toString(seat->getId());
+            CEGUI::Combobox* combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
+            if(combo == comboSel)
+                continue;
+
+            CEGUI::ListboxItem* item = combo->getSelectedItem();
+            if(item == nullptr)
+                continue;
+
+            if(item->getID() != selItem->getID())
+                continue;
+
+            combo->setItemSelectState(item, false);
+            combo->setText("");
+        }
+    }
+
+    fireSeatConfigurationToServer(false);
+    return true;
+}
+
+void MenuModeConfigureSeats::addPlayer(const std::string& nick, int32_t id)
+{
+    const CEGUI::Image* selImg = &CEGUI::ImageManager::getSingleton().get("OpenDungeonsSkin/SelectionBrush");
+    CEGUI::Window* playersWin = Gui::getSingleton().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("ListPlayers");
+    bool isPlayerSet = false;
+
+    mPlayers.push_back(std::pair<std::string, int32_t>(nick, id));
+    for(Seat* seat : mSeats)
+    {
+        std::string name = COMBOBOX_PLAYER_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        CEGUI::Combobox* combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
+        CEGUI::ListboxTextItem* item = new CEGUI::ListboxTextItem(nick, id);
+        item->setSelectionBrushImage(selImg);
+        combo->addItem(item);
+        // If a combo is empty, we set it to the player nick
+        if(!isPlayerSet && (combo->getSelectedItem() == nullptr))
+        {
+            combo->setItemSelectState(item, true);
+            combo->setText(item->getText());
+            isPlayerSet = true;
+        }
+    }
+
+    if(!ODServer::getSingleton().isConnected())
+        return;
+
+    fireSeatConfigurationToServer(false);
+}
+
+void MenuModeConfigureSeats::removePlayer(int32_t id)
+{
+    CEGUI::Window* playersWin = Gui::getSingleton().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("ListPlayers");
+    for(std::vector<std::pair<std::string, int32_t> >::iterator it = mPlayers.begin(); it != mPlayers.end();)
+    {
+        std::pair<std::string, int32_t>& player = *it;
+        if(player.second != id)
+        {
+            ++it;
+            continue;
+        }
+
+        mPlayers.erase(it);
+        for(Seat* seat : mSeats)
+        {
+            std::string name = COMBOBOX_PLAYER_PREFIX + Ogre::StringConverter::toString(seat->getId());
+            CEGUI::Combobox* combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
+            for(uint32_t i = 0; i < combo->getItemCount();)
+            {
+                CEGUI::ListboxItem* selItem = combo->getListboxItemFromIndex(i);
+                if(selItem->getID() == (uint32_t)id)
+                {
+                    if(selItem->isSelected())
+                        combo->setText("");
+
+                    combo->removeItem(selItem);
+                }
+                else
+                    ++i;
+            }
+        }
+        break;
+    }
+
+    if(!ODServer::getSingleton().isConnected())
+        return;
+
+    fireSeatConfigurationToServer(false);
+}
+
+void MenuModeConfigureSeats::fireSeatConfigurationToServer(bool isFinal)
+{
+    CEGUI::Window* playersWin = Gui::getSingleton().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("ListPlayers");
+    CEGUI::Combobox* combo;
+    CEGUI::ListboxItem*	selItem;
+    if(isFinal)
+    {
+        // We start by checking that every seat is well configured.
+        for(Seat* seat : mSeats)
+        {
+            std::string name;
+            name = COMBOBOX_PLAYER_FACTION_PREFIX + Ogre::StringConverter::toString(seat->getId());
+            combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
+            selItem = combo->getSelectedItem();
+            if(selItem == nullptr)
+            {
+                CEGUI::Window* msgWin = Gui::getSingleton().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("LoadingText");
+                msgWin->setText("Faction is not well configured for seat " + Ogre::StringConverter::toString(seat->getId()));
+                msgWin->setVisible(true);
+                return;
+            }
+            name = COMBOBOX_PLAYER_PREFIX + Ogre::StringConverter::toString(seat->getId());
+            combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
+            selItem = combo->getSelectedItem();
+            if(selItem == nullptr)
+            {
+                CEGUI::Window* msgWin = Gui::getSingleton().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("LoadingText");
+                msgWin->setText("Player is not well configured for seat " + Ogre::StringConverter::toString(seat->getId()));
+                msgWin->setVisible(true);
+                return;
+            }
+        }
+    }
+
+    ClientNotification* notif;
+    if(isFinal)
+        notif = new ClientNotification(ClientNotification::seatConfigurationSet);
+    else
+        notif = new ClientNotification(ClientNotification::seatConfigurationRefresh);
+
+    for(Seat* seat : mSeats)
+    {
+        std::string name;
+        notif->mPacket << seat->getId();
+        name = COMBOBOX_PLAYER_FACTION_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
+        selItem = combo->getSelectedItem();
+        if(selItem != nullptr)
+        {
+            uint32_t selIndex = selItem->getID();
+            notif->mPacket << true << selIndex;
+        }
+        else
+        {
+            notif->mPacket << false;
+        }
+
+        name = COMBOBOX_PLAYER_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
+        selItem = combo->getSelectedItem();
+        if(selItem != nullptr)
+        {
+            int32_t playerId = selItem->getID();
+            notif->mPacket << true << playerId;
+        }
+        else
+        {
+            notif->mPacket << false;
+        }
+    }
+    ODClient::getSingleton().queueClientNotification(notif);
+}
+
+void MenuModeConfigureSeats::refreshSeatConfiguration(ODPacket& packet)
+{
+    // We don't refresh seats on server side
+    if(ODServer::getSingleton().isConnected())
+        return;
+
+    CEGUI::Window* playersWin = Gui::getSingleton().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("ListPlayers");
+    CEGUI::Combobox* combo;
+    bool isSelected;
+    uint32_t selIndex = 0;
+    int32_t playerId = 0;
+    for(Seat* seat : mSeats)
+    {
+        int seatId;
+        OD_ASSERT_TRUE(packet >> seatId);
+        OD_ASSERT_TRUE(seat->getId() == seatId);
+        std::string name;
+        name = COMBOBOX_PLAYER_FACTION_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
+        OD_ASSERT_TRUE(packet >> isSelected);
+        if(isSelected)
+        {
+            OD_ASSERT_TRUE(packet >> selIndex);
+        }
+        for(uint32_t i = 0; i < combo->getItemCount(); ++i)
+        {
+            CEGUI::ListboxItem* selItem = combo->getListboxItemFromIndex(i);
+            if(isSelected && selItem->getID() == selIndex)
+            {
+                combo->setItemSelectState(selItem, true);
+                combo->setText(selItem->getText());
+            }
+            else
+                combo->setItemSelectState(selItem, false);
+        }
+
+        name = COMBOBOX_PLAYER_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
+        OD_ASSERT_TRUE(packet >> isSelected);
+        if(isSelected)
+        {
+            OD_ASSERT_TRUE(packet >> playerId);
+        }
+        for(uint32_t i = 0; i < combo->getItemCount(); ++i)
+        {
+            CEGUI::ListboxItem* selItem = combo->getListboxItemFromIndex(i);
+            if(isSelected && selItem->getID() == static_cast<uint32_t>(playerId))
+            {
+                combo->setItemSelectState(selItem, true);
+                combo->setText(selItem->getText());
+            }
+            else
+                combo->setItemSelectState(selItem, false);
+        }
+    }
+}
+
+bool MenuModeConfigureSeats::mouseMoved(const OIS::MouseEvent &arg)
+{
+    return CEGUI::System::getSingleton().getDefaultGUIContext().injectMousePosition((float)arg.state.X.abs, (float)arg.state.Y.abs);
+}
+
+bool MenuModeConfigureSeats::mousePressed(const OIS::MouseEvent &arg, OIS::MouseButtonID id)
+{
+    return CEGUI::System::getSingleton().getDefaultGUIContext().injectMouseButtonDown(
+        Gui::getSingletonPtr()->convertButton(id));
+}
+
+bool MenuModeConfigureSeats::mouseReleased(const OIS::MouseEvent &arg, OIS::MouseButtonID id)
+{
+    return CEGUI::System::getSingleton().getDefaultGUIContext().injectMouseButtonUp(
+        Gui::getSingletonPtr()->convertButton(id));
+}
+
+bool MenuModeConfigureSeats::keyPressed(const OIS::KeyEvent &arg)
+{
+    switch (arg.key)
+    {
+
+    case OIS::KC_ESCAPE:
+        regressMode();
+        break;
+    default:
+        break;
+    }
+    return true;
+}
+
+bool MenuModeConfigureSeats::keyReleased(const OIS::KeyEvent &arg)
+{
+    return true;
+}
+
+void MenuModeConfigureSeats::handleHotkeys(OIS::KeyCode keycode)
+{
+}

--- a/source/modes/MenuModeConfigureSeats.h
+++ b/source/modes/MenuModeConfigureSeats.h
@@ -15,17 +15,26 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MENUMODEMULTIPLAYERCLIENT_H
-#define MENUMODEMULTIPLAYERCLIENT_H
+#ifndef MENUMODECONFIGURESEATS_H
+#define MENUMODECONFIGURESEATS_H
 
 #include "AbstractApplicationMode.h"
 
-class MenuModeMultiplayerClient: public AbstractApplicationMode
+class Seat;
+class Player;
+class ODPacket;
+
+namespace CEGUI
+{
+    class EventArgs;
+}
+
+class MenuModeConfigureSeats: public AbstractApplicationMode
 {
 public:
-    MenuModeMultiplayerClient(ModeManager*);
+    MenuModeConfigureSeats(ModeManager*);
 
-    virtual ~MenuModeMultiplayerClient();
+    virtual ~MenuModeConfigureSeats();
 
     virtual bool mouseMoved     (const OIS::MouseEvent &arg);
     virtual bool mousePressed   (const OIS::MouseEvent &arg, OIS::MouseButtonID id);
@@ -41,7 +50,20 @@ public:
     //! Used to call the corresponding Gui Sheet.
     void activate();
 
-    void clientButtonPressed();
+    void launchSelectedButtonPressed();
+    void goBack();
+
+    bool comboChanged(const CEGUI::EventArgs& ea);
+    void addPlayer(const std::string& nick, int32_t id);
+    void removePlayer(int32_t id);
+
+    void refreshSeatConfiguration(ODPacket& packet);
+
+private:
+    std::vector<Seat*> mSeats;
+    std::vector<std::pair<std::string, int32_t> > mPlayers;
+
+    void fireSeatConfigurationToServer(bool isFinal);
 };
 
-#endif // MENUMODEMULTIPLAYERCLIENT_H
+#endif // MENUMODECONFIGURESEATS_H

--- a/source/modes/MenuModeEditor.cpp
+++ b/source/modes/MenuModeEditor.cpp
@@ -32,15 +32,15 @@
 #include "utils/ConfigManager.h"
 
 #include <CEGUI/CEGUI.h>
-#include "boost/filesystem.hpp"
+
+#include <boost/filesystem.hpp>
 
 const std::string LEVEL_PATH_SKIRMISH = "levels/skirmish/";
 const std::string LEVEL_PATH_MULTIPLAYER = "levels/multiplayer/";
 const std::string LEVEL_EXTENSION = ".level";
 
 MenuModeEditor::MenuModeEditor(ModeManager *modeManager):
-    AbstractApplicationMode(modeManager, ModeManager::MENU_EDITOR),
-    mReadyToStartMode(false)
+    AbstractApplicationMode(modeManager, ModeManager::MENU_EDITOR)
 {
 }
 
@@ -144,12 +144,15 @@ void MenuModeEditor::launchSelectedButtonPressed()
     std::string level = mFilesList[id];
 
     // In single player mode, we act as a server
-    if(!ODServer::getSingleton().startServer(level, true, ODServer::ServerMode::ModeEditor))
+    if(!ODServer::getSingleton().startServer(level, ODServer::ServerMode::ModeEditor))
     {
         LogManager::getSingleton().logMessage("ERROR: Could not start server for editor !!!");
+        tmpWin = Gui::getSingleton().getGuiSheet(Gui::editorMenu)->getChild(Gui::EDM_TEXT_LOADING);
+        tmpWin->setText("ERROR: Could not start server for editor !!!");
+        tmpWin->show();
     }
 
-    if(!ODClient::getSingleton().connect("", ConfigManager::getSingleton().getNetworkPort()))
+    if(!ODClient::getSingleton().connect("localhost", ConfigManager::getSingleton().getNetworkPort()))
     {
         LogManager::getSingleton().logMessage("ERROR: Could not connect to server for editor !!!");
         tmpWin = Gui::getSingleton().getGuiSheet(Gui::editorMenu)->getChild(Gui::EDM_TEXT_LOADING);
@@ -157,9 +160,6 @@ void MenuModeEditor::launchSelectedButtonPressed()
         tmpWin->show();
         return;
     }
-
-    // Makes the frame listener process client and server messages.
-    mReadyToStartMode = true;
 }
 
 void MenuModeEditor::updateDescription()

--- a/source/modes/MenuModeEditor.h
+++ b/source/modes/MenuModeEditor.h
@@ -47,17 +47,9 @@ public:
     void listLevelsClicked();
     void listLevelsDoubleClicked();
 
-    virtual bool waitForGameStart()
-    {
-        return mReadyToStartMode;
-    }
-
 private:
     std::vector<std::string> mFilesList;
     std::vector<std::string> mDescriptionList;
-
-    //! \brief Tells whether the menu is ready
-    bool mReadyToStartMode;
 };
 
 #endif // MENUMODEEDITOR_H

--- a/source/modes/MenuModeMultiplayerClient.cpp
+++ b/source/modes/MenuModeMultiplayerClient.cpp
@@ -33,8 +33,7 @@
 #include <boost/locale.hpp>
 
 MenuModeMultiplayerClient::MenuModeMultiplayerClient(ModeManager *modeManager):
-    AbstractApplicationMode(modeManager, ModeManager::MENU_MULTIPLAYER_CLIENT),
-    mReadyToStartGame(false)
+    AbstractApplicationMode(modeManager, ModeManager::MENU_MULTIPLAYER_CLIENT)
 {
 }
 
@@ -97,7 +96,7 @@ void MenuModeMultiplayerClient::clientButtonPressed()
     tmpWin->setText("Loading...");
     tmpWin->show();
 
-    ODFrameListener::getSingleton().getClientGameMap()->getLocalPlayer()->setNick(nick);
+    ODFrameListener::getSingleton().getClientGameMap()->setLocalPlayerNick(nick);
 
     if(!ODClient::getSingleton().connect(ip, ConfigManager::getSingleton().getNetworkPort()))
     {
@@ -106,9 +105,6 @@ void MenuModeMultiplayerClient::clientButtonPressed()
         tmpWin->setText("Could not connect to: " + ip);
         return;
     }
-
-    // Makes the frame listener process client and server messages.
-    mReadyToStartGame = true;
 }
 
 bool MenuModeMultiplayerClient::mouseMoved(const OIS::MouseEvent &arg)

--- a/source/modes/MenuModeMultiplayerServer.cpp
+++ b/source/modes/MenuModeMultiplayerServer.cpp
@@ -39,8 +39,7 @@ const std::string LEVEL_PATH = "levels/multiplayer/";
 const std::string LEVEL_EXTENSION = ".level";
 
 MenuModeMultiplayerServer::MenuModeMultiplayerServer(ModeManager *modeManager):
-    AbstractApplicationMode(modeManager, ModeManager::MENU_MULTIPLAYER_SERVER),
-    mReadyToStartGame(false)
+    AbstractApplicationMode(modeManager, ModeManager::MENU_MULTIPLAYER_SERVER)
 {
 }
 
@@ -128,8 +127,7 @@ void MenuModeMultiplayerServer::serverButtonPressed()
         return;
     }
 
-    Player* p = ODFrameListener::getSingleton().getClientGameMap()->getLocalPlayer();
-    p->setNick(nick);
+    ODFrameListener::getSingleton().getClientGameMap()->setLocalPlayerNick(nick);
 
     tmpWin = Gui::getSingleton().getGuiSheet(Gui::multiplayerServerMenu)->getChild(Gui::MPM_TEXT_LOADING);
     tmpWin->setText("Loading...");
@@ -141,13 +139,17 @@ void MenuModeMultiplayerServer::serverButtonPressed()
     std::string level = mFilesList[id];
 
     // We are a server
-    if(!ODServer::getSingleton().startServer(level, false, ODServer::ServerMode::ModeGame))
+    if(!ODServer::getSingleton().startServer(level, ODServer::ServerMode::ModeGameMultiPlayer))
     {
         LogManager::getSingleton().logMessage("ERROR: Could not start server for multi player game !!!");
+        tmpWin = Gui::getSingleton().getGuiSheet(Gui::multiplayerServerMenu)->getChild(Gui::MPM_TEXT_LOADING);
+        tmpWin->setText("ERROR: Could not start server for multi player game !!!");
+        tmpWin->show();
+        return;
     }
 
     // We connect ourself
-    if(!ODClient::getSingleton().connect("", ConfigManager::getSingleton().getNetworkPort()))
+    if(!ODClient::getSingleton().connect("localhost", ConfigManager::getSingleton().getNetworkPort()))
     {
         LogManager::getSingleton().logMessage("ERROR: Could not connect to server for multi player game !!!");
         tmpWin = Gui::getSingleton().getGuiSheet(Gui::multiplayerServerMenu)->getChild(Gui::MPM_TEXT_LOADING);
@@ -155,9 +157,6 @@ void MenuModeMultiplayerServer::serverButtonPressed()
         tmpWin->show();
         return;
     }
-
-    // Makes the frame listener process client and server messages.
-    mReadyToStartGame = true;
 }
 
 void MenuModeMultiplayerServer::updateDescription()

--- a/source/modes/MenuModeMultiplayerServer.h
+++ b/source/modes/MenuModeMultiplayerServer.h
@@ -47,17 +47,9 @@ public:
     void listLevelsClicked();
     void listLevelsDoubleClicked();
 
-    virtual bool waitForGameStart()
-    {
-        return mReadyToStartGame;
-    }
-
 private:
     std::vector<std::string> mFilesList;
     std::vector<std::string> mDescriptionList;
-
-    //! \brief Tells whether the menu is ready to start the game.
-    bool mReadyToStartGame;
 };
 
 #endif // MENUMODEMULTIPLAYERSERVER_H

--- a/source/modes/MenuModeSkirmish.cpp
+++ b/source/modes/MenuModeSkirmish.cpp
@@ -38,8 +38,7 @@ const std::string LEVEL_PATH = "levels/skirmish/";
 const std::string LEVEL_EXTENSION = ".level";
 
 MenuModeSkirmish::MenuModeSkirmish(ModeManager *modeManager):
-    AbstractApplicationMode(modeManager, ModeManager::MENU_SKIRMISH),
-    mReadyToStartGame(false)
+    AbstractApplicationMode(modeManager, ModeManager::MENU_SKIRMISH)
 {
 }
 
@@ -116,9 +115,13 @@ void MenuModeSkirmish::launchSelectedButtonPressed()
 
     std::string level = mFilesList[id];
     // In single player mode, we act as a server
-    if(!ODServer::getSingleton().startServer(level, true, ODServer::ServerMode::ModeGame))
+    if(!ODServer::getSingleton().startServer(level, ODServer::ServerMode::ModeGameSinglePlayer))
     {
         LogManager::getSingleton().logMessage("ERROR: Could not start server for single player game !!!");
+        tmpWin = Gui::getSingleton().getGuiSheet(Gui::skirmishMenu)->getChild(Gui::SKM_TEXT_LOADING);
+        tmpWin->setText("ERROR: Could not start server for single player game !!!");
+        tmpWin->show();
+        return;
     }
 
     if(!ODClient::getSingleton().connect("localhost", ConfigManager::getSingleton().getNetworkPort()))
@@ -129,9 +132,6 @@ void MenuModeSkirmish::launchSelectedButtonPressed()
         tmpWin->show();
         return;
     }
-
-    // Makes the frame listener process client and server messages.
-    mReadyToStartGame = true;
 }
 
 void MenuModeSkirmish::updateDescription()

--- a/source/modes/MenuModeSkirmish.h
+++ b/source/modes/MenuModeSkirmish.h
@@ -48,17 +48,9 @@ public:
     void listLevelsClicked();
     void listLevelsDoubleClicked();
 
-    virtual bool waitForGameStart()
-    {
-        return mReadyToStartGame;
-    }
-
 private:
     std::vector<std::string> mFilesList;
     std::vector<std::string> mDescriptionList;
-
-    //! \brief Tells whether the menu is ready to start the game.
-    bool mReadyToStartGame;
 };
 
 #endif // MENUMODESKIRMISH_H

--- a/source/modes/ModeManager.cpp
+++ b/source/modes/ModeManager.cpp
@@ -20,6 +20,7 @@
 #include "scripting/ASWrapper.h"
 #include "InputManager.h"
 #include "MenuMode.h"
+#include "modes/MenuModeConfigureSeats.h"
 #include "modes/MenuModeSkirmish.h"
 #include "modes/MenuModeMultiplayerClient.h"
 #include "modes/MenuModeMultiplayerServer.h"
@@ -114,6 +115,9 @@ void ModeManager::addMode(ModeType mt)
         break;
     case MENU_EDITOR:
         mApplicationModes.push_back(new MenuModeEditor(this));
+        break;
+    case MENU_CONFIGURE_SEATS:
+        mApplicationModes.push_back(new MenuModeConfigureSeats(this));
         break;
     case GAME:
         mApplicationModes.push_back(new GameMode(this));

--- a/source/modes/ModeManager.h
+++ b/source/modes/ModeManager.h
@@ -123,7 +123,7 @@ public:
         mDiscardActualMode = discardActualMode;
      }
 
-    //! \brief Request loading game mode at next update
+    //! \brief Request loading the game seat configuration screen
     void requestConfigureSeatsMode(bool discardActualMode = false)
     {
         mRequestedMode = ModeType::MENU_CONFIGURE_SEATS;

--- a/source/modes/ModeManager.h
+++ b/source/modes/ModeManager.h
@@ -46,6 +46,7 @@ public:
         MENU_MULTIPLAYER_CLIENT,
         MENU_MULTIPLAYER_SERVER,
         MENU_EDITOR,
+        MENU_CONFIGURE_SEATS,
         GAME,
         EDITOR,
         CONSOLE,
@@ -119,6 +120,13 @@ public:
     void requestGameMode(bool discardActualMode = false)
     {
         mRequestedMode = ModeType::GAME;
+        mDiscardActualMode = discardActualMode;
+     }
+
+    //! \brief Request loading game mode at next update
+    void requestConfigureSeatsMode(bool discardActualMode = false)
+    {
+        mRequestedMode = ModeType::MENU_CONFIGURE_SEATS;
         mDiscardActualMode = discardActualMode;
      }
 

--- a/source/network/ClientNotification.cpp
+++ b/source/network/ClientNotification.cpp
@@ -36,6 +36,12 @@ std::string ClientNotification::typeString(ClientNotificationType type)
             return "setNick";
         case ClientNotificationType::chat:
             return "chat";
+        case ClientNotificationType::readyForSeatConfiguration:
+            return "readyForSeatConfiguration";
+        case ClientNotificationType::seatConfigurationSet:
+            return "seatConfigurationSet";
+        case ClientNotificationType::seatConfigurationRefresh:
+            return "seatConfigurationRefresh";
         case ClientNotificationType::askEntityPickUp:
             return "askEntityPickUp";
         case ClientNotificationType::askHandDrop:

--- a/source/network/ClientNotification.h
+++ b/source/network/ClientNotification.h
@@ -36,6 +36,11 @@ public:
         hello,
         levelOK, // Tells the server the level loading was ok.
         setNick,
+        readyForSeatConfiguration,
+        // Messages that should be sent only by the client side of the server
+        // (where the game configuration is done)
+        seatConfigurationSet,
+        seatConfigurationRefresh,
 
         chat,
 

--- a/source/network/ODServer.h
+++ b/source/network/ODServer.h
@@ -51,13 +51,24 @@ class ODServer: public Ogre::Singleton<ODServer>,
  public:
      enum ServerMode
      {
-         ModeGame,
+         ModeNone,
+         ModeGameSinglePlayer,
+         ModeGameMultiPlayer,
          ModeEditor
+     };
+     enum ServerState
+     {
+         StateNone,
+         StateConfiguration,
+         StateGame
      };
     ODServer();
     virtual ~ODServer();
 
-    bool startServer(const std::string& levelFilename, bool replaceHumanPlayersByAi, ServerMode mode);
+    inline ServerMode getServerMode() const
+    { return mServerMode; }
+
+    bool startServer(const std::string& levelFilename, ServerMode mode);
     void stopServer();
 
     //! \brief Adds a server notification to the server notification queue.
@@ -85,10 +96,10 @@ protected:
 
 private:
     ServerMode mServerMode;
+    ServerState mServerState;
     GameMap *mGameMap;
     std::string mLevelFilename;
-
-    int32_t mNbClientsNotReady;
+    bool mSeatsConfigured;
 
     std::deque<ServerNotification*> mServerNotificationQueue;
     std::deque<ODConsoleCommand*> mConsoleCommandQueue;

--- a/source/network/ODSocketServer.cpp
+++ b/source/network/ODSocketServer.cpp
@@ -122,8 +122,8 @@ void ODSocketServer::doTask(int timeoutMs)
             }
             else
             {
-                std::vector<ODSocketClient*>::iterator it = mSockClients.begin();
-                while (it != mSockClients.end())
+
+                for(std::vector<ODSocketClient*>::iterator it = mSockClients.begin(); it != mSockClients.end();)
                 {
                     ODSocketClient* client = *it;
                     if((mSockSelector.isReady(client->mSockClient)) &&
@@ -131,6 +131,7 @@ void ODSocketServer::doTask(int timeoutMs)
                     {
                         // The server wants to remove the client
                         it = mSockClients.erase(it);
+                        mSockSelector.remove(client->mSockClient);
                         client->disconnect();
                         delete client;
                     }
@@ -159,7 +160,7 @@ void ODSocketServer::sendMsgToAllClients(ODPacket& packetReceived)
     for (std::vector<ODSocketClient*>::iterator it = mSockClients.begin(); it != mSockClients.end(); ++it)
     {
         ODSocketClient* client = *it;
-        if (!client)
+        if (!client || !client->isConnected())
             continue;
 
         client->send(packetReceived);

--- a/source/network/ServerNotification.cpp
+++ b/source/network/ServerNotification.cpp
@@ -34,14 +34,14 @@ std::string ServerNotification::typeString(ServerNotificationType type)
     {
         case ServerNotificationType::pickNick:
             return "pickNick";
-        case ServerNotificationType::yourSeat:
-            return "yourSeat";
-        case ServerNotificationType::addPlayer:
-            return "addPlayer";
+        case ServerNotificationType::addPlayers:
+            return "addPlayers";
+        case ServerNotificationType::removePlayers:
+            return "removePlayers";
+        case ServerNotificationType::startGameMode:
+            return "startGameMode";
         case ServerNotificationType::newMap:
             return "newMap";
-        case ServerNotificationType::turnsPerSecond:
-            return "turnsPerSecond";
         case ServerNotificationType::addTile:
             return "addTile";
         case ServerNotificationType::addMapLight:
@@ -52,6 +52,10 @@ std::string ServerNotification::typeString(ServerNotificationType type)
             return "addClass";
         case ServerNotificationType::clientAccepted:
             return "clientAccepted";
+        case ServerNotificationType::clientRejected:
+            return "clientRejected";
+        case ServerNotificationType::seatConfigurationRefresh:
+            return "seatConfigurationRefresh";
         case ServerNotificationType::chat:
             return "chat";
         case ServerNotificationType::chatServer:

--- a/source/network/ServerNotification.h
+++ b/source/network/ServerNotification.h
@@ -41,15 +41,17 @@ class ServerNotification
             // Negociation for multiplayer
             loadLevel, // Tells the client to load the level: + string LevelFilename
             pickNick,
-            yourSeat,
-            addPlayer,
+            addPlayers,
+            removePlayers,
+            startGameMode,
             newMap,
-            turnsPerSecond,
             addTile,
             addMapLight,
             removeMapLight,
             addClass,
             clientAccepted,
+            clientRejected,
+            seatConfigurationRefresh,
 
             chat,
             chatServer,

--- a/source/render/Gui.cpp
+++ b/source/render/Gui.cpp
@@ -38,6 +38,7 @@
 #include "modes/ModeManager.h"
 #include "modes/GameMode.h"
 #include "modes/EditorMode.h"
+#include "modes/MenuModeConfigureSeats.h"
 #include "modes/MenuModeSkirmish.h"
 #include "modes/MenuModeMultiplayerClient.h"
 #include "modes/MenuModeMultiplayerServer.h"
@@ -77,6 +78,7 @@ Gui::Gui()
     sheets[multiplayerServerMenu] = wmgr->loadLayoutFromFile("OpenDungeonsMenuMultiplayerServer.layout");
     sheets[editorModeGui] =  wmgr->loadLayoutFromFile("OpenDungeonsEditorModeMenu.layout");
     sheets[editorMenu] =  wmgr->loadLayoutFromFile("OpenDungeonsEditorMenu.layout");
+    sheets[configureSeats] =  wmgr->loadLayoutFromFile("OpenDungeonsMenuConfigureSeats.layout");
 
     assignEventHandlers();
 }
@@ -365,6 +367,15 @@ void Gui::assignEventHandlers()
     sheets[editorMenu]->getChild(EDM_LIST_LEVELS)->subscribeEvent(
         CEGUI::Listbox::EventMouseDoubleClick,
         CEGUI::Event::Subscriber(&mEDMListDoubleClicked));
+
+    // Configure seats windows
+    sheets[configureSeats]->getChild(CSM_BUTTON_BACK)->subscribeEvent(
+        CEGUI::PushButton::EventClicked,
+        CEGUI::Event::Subscriber(&mCSMBackButtonPressed));
+
+    sheets[configureSeats]->getChild(CSM_BUTTON_LAUNCH)->subscribeEvent(
+        CEGUI::PushButton::EventClicked,
+        CEGUI::Event::Subscriber(&mCSMLoadButtonPressed));
 
     // Set the game version
     sheets[mainMenu]->getChild("VersionText")->setText(ODApplication::VERSION);
@@ -823,6 +834,28 @@ bool Gui::mMPMClientButtonPressed(const CEGUI::EventArgs& e)
     return true;
 }
 
+bool Gui::mCSMLoadButtonPressed(const CEGUI::EventArgs& e)
+{
+    ModeManager* mm = ODFrameListener::getSingleton().getModeManager();
+    if (!mm || mm->getCurrentModeType() != ModeManager::MENU_CONFIGURE_SEATS)
+        return true;
+
+    SoundEffectsManager::getSingleton().playInterfaceSound(SoundEffectsManager::BUTTONCLICK);
+    static_cast<MenuModeConfigureSeats*>(mm->getCurrentMode())->launchSelectedButtonPressed();
+    return true;
+}
+
+bool Gui::mCSMBackButtonPressed(const CEGUI::EventArgs& e)
+{
+    ModeManager* mm = ODFrameListener::getSingleton().getModeManager();
+    if (!mm || mm->getCurrentModeType() != ModeManager::MENU_CONFIGURE_SEATS)
+        return true;
+
+    SoundEffectsManager::getSingleton().playInterfaceSound(SoundEffectsManager::BUTTONCLICK);
+    static_cast<MenuModeConfigureSeats*>(mm->getCurrentMode())->goBack();
+    return true;
+}
+
 /* These constants are used to access the GUI element
  * NOTE: when add/remove/rename a GUI element, don't forget to change it here
  */
@@ -881,6 +914,9 @@ const std::string Gui::EDM_TEXT_LOADING = "LoadingText";
 const std::string Gui::EDM_BUTTON_LAUNCH = "LevelWindowFrame/LaunchGameButton";
 const std::string Gui::EDM_BUTTON_BACK = "LevelWindowFrame/BackButton";
 const std::string Gui::EDM_LIST_LEVELS = "LevelWindowFrame/LevelSelect";
+
+const std::string Gui::CSM_BUTTON_LAUNCH = "ListPlayers/LaunchGameButton";
+const std::string Gui::CSM_BUTTON_BACK = "ListPlayers/BackButton";
 
 const std::string Gui::EDITOR = "MainTabControl";
 const std::string Gui::EDITOR_LAVA_BUTTON = "MainTabControl/Tiles/LavaButton";

--- a/source/render/Gui.h
+++ b/source/render/Gui.h
@@ -53,7 +53,8 @@ public:
         editorMenu,
         editorModeGui,
         optionsMenu,
-        inGameMenu
+        inGameMenu,
+        configureSeats
     };
 
     /*! \brief Constructor that initializes the whole CEGUI system
@@ -134,6 +135,8 @@ public:
     static const std::string EDM_BUTTON_LAUNCH;
     static const std::string EDM_BUTTON_BACK;
     static const std::string EDM_LIST_LEVELS;
+    static const std::string CSM_BUTTON_LAUNCH;
+    static const std::string CSM_BUTTON_BACK;
 
 private:
     //! \brief Assigns all event handlers to the GUI elements
@@ -198,6 +201,12 @@ private:
 
     //! \brief What happens after a double click on the level list in the multiplayer menu
     static bool mMPMListDoubleClicked   (const CEGUI::EventArgs& e);
+
+    //! \brief What happens after a click on Back in the level seat configuration menu
+    static bool mCSMBackButtonPressed   (const CEGUI::EventArgs& e);
+
+    //! \brief What happens after a click on Load in the level seat configuration menu
+    static bool mCSMLoadButtonPressed   (const CEGUI::EventArgs& e);
 
     // Button handlers game UI
     static bool miniMapclicked          (const CEGUI::EventArgs& e);

--- a/source/render/ODFrameListener.cpp
+++ b/source/render/ODFrameListener.cpp
@@ -215,25 +215,22 @@ bool ODFrameListener::frameStarted(const Ogre::FrameEvent& evt)
 
     int64_t currentTurn = mGameMap->getTurnNumber();
 
-    if ((currentTurn != -1) || (!currentMode->waitForGameStart()))
+    if(!mExitRequested)
     {
-        if(!mExitRequested)
-        {
-            // Updates animations independant from the server new turn event
-            updateAnimations(evt.timeSinceLastFrame);
-        }
-
-        currentMode->getKeyboard()->capture();
-        currentMode->getMouse()->capture();
-
-        mCameraManager->updateCameraFrameTime(evt.timeSinceLastFrame);
-        currentMode->onFrameStarted(evt);
-
-        mCameraManager->onFrameStarted();
-
-        if((mGameMap->getGamePaused()) && (!mExitRequested))
-            return true;
+        // Updates animations independant from the server new turn event
+        updateAnimations(evt.timeSinceLastFrame);
     }
+
+    currentMode->getKeyboard()->capture();
+    currentMode->getMouse()->capture();
+
+    mCameraManager->updateCameraFrameTime(evt.timeSinceLastFrame);
+    currentMode->onFrameStarted(evt);
+
+    mCameraManager->onFrameStarted();
+
+    if((currentTurn != -1) && (mGameMap->getGamePaused()) && (!mExitRequested))
+        return true;
 
     //If an exit has been requested, start cleaning up.
     if(mExitRequested == true || mContinue == false)

--- a/source/rooms/RoomPortal.cpp
+++ b/source/rooms/RoomPortal.cpp
@@ -116,7 +116,6 @@ void RoomPortal::doUpkeep()
 
     // Randomly choose to spawn a creature.
     const double maxCreatures = 15;
-    //TODO:  Improve this probability calculation.
     // Count how many creatures are controlled by this seat
     double numCreatures = getGameMap()->getCreaturesBySeat(getSeat()).size();
     double targetProbability = powl((maxCreatures - numCreatures) / maxCreatures, 1.5);

--- a/source/utils/ConfigManager.h
+++ b/source/utils/ConfigManager.h
@@ -52,6 +52,11 @@ public:
 
     const std::vector<const SpawnCondition*>& getCreatureSpawnConditions(const CreatureDefinition* def) const;
 
+    const std::vector<const CreatureDefinition*>& getFactionSpawnPool(const std::string& faction) const;
+
+    const std::vector<std::string>& getFactions() const
+    { return mFactions; }
+
 private:
     //! \brief Function used to load the global configuration. They should return true if the configuration
     //! is ok and false if a mandatory parameter is missing
@@ -62,6 +67,7 @@ private:
     bool loadCreatureDefinitions(const std::string& fileName);
     bool loadEquipements(const std::string& fileName);
     bool loadSpawnConditions(const std::string& fileName);
+    bool loadFactions(const std::string& fileName);
 
     std::map<std::string, Ogre::ColourValue> mSeatColors;
     std::vector<const CreatureDefinition*> mCreatureDefs;
@@ -69,9 +75,12 @@ private:
     std::string mFilenameCreatureDefinition;
     std::string mFilenameEquipmentDefinition;
     std::string mFilenameSpawnConditions;
+    std::string mFilenameFactions;
     uint32_t mNetworkPort;
     uint32_t mBaseSpawnPoint;
     std::map<const CreatureDefinition*, std::vector<const SpawnCondition*> > mCreatureSpawnConditions;
+    std::map<const std::string, std::vector<const CreatureDefinition*> > mFactionSpawnPool;
+    std::vector<std::string> mFactions;
 };
 
 #endif //CONFIGMANAGER_H

--- a/source/utils/ResourceManager.cpp
+++ b/source/utils/ResourceManager.cpp
@@ -128,7 +128,7 @@ void ResourceManager::setupDataPath()
     if(!path.empty())
     {
         mGameDataPath = path;
-        if (*mGameDataPath.end() != '/')
+        if (*mGameDataPath.rbegin() != '/')
         {
             mGameDataPath.append("/");
         }


### PR DESCRIPTION
I added a gui to configure seats before launching a game. You can choose faction and set the players on any available seat. Only the server can setup the seats.

In the level, for each seat, you can choose "Choice" to allow the player to choose or you can force one of the available factions (defined in factions.cfg).
For player type, you can choose between "Choice", "Human", "AI" or "Inactive" (pretty explicit)

Note that since the spawn pool is now defined in factions.cfg, I've removed them from all the level files.

For @akien-mga , since I know you like to hunt bugs, I've tried to make the seat configuration as final as I could. That means that during seat configuration, players can be added/can disconnect. In this case they should be added/removed from the combos.
Moreover, I've added network communication so that the clients see in real time how the server is configuring the seats.

Note that there can be more players connected than seats available or used. In any case, connected players that were not chosen for a game will get disconnected and return to main menu.

Note that in the skirmish empty level, you can launch the game with only AI players. In this case, like any not chosen player, you will get disconnected and return to main menu ^^
