### PR TITLE
When the XP table is overriden in a level file, it should be written by the editor when the level is saved

### DIFF
--- a/source/entities/CreatureDefinition.cpp
+++ b/source/entities/CreatureDefinition.cpp
@@ -570,7 +570,7 @@ void CreatureDefinition::writeCreatureDefinitionDiff(const CreatureDefinition* d
     file << "    [/Stats]" << std::endl;
 
     bool isSame = true;
-    for(uint32_t i = 0; i < MAX_LEVEL; ++i)
+    for(uint32_t i = 0; i < (MAX_LEVEL - 1); ++i)
     {
         if(def1 == nullptr || (def1->mXPTable[i] != def2->mXPTable[i]))
         {

--- a/source/entities/CreatureDefinition.cpp
+++ b/source/entities/CreatureDefinition.cpp
@@ -568,6 +568,37 @@ void CreatureDefinition::writeCreatureDefinitionDiff(const CreatureDefinition* d
         file << "    WeaponSpawnL\t" << def2->mWeaponSpawnR << std::endl;
 
     file << "    [/Stats]" << std::endl;
+
+    bool isSame = true;
+    for(uint32_t i = 0; i < MAX_LEVEL; ++i)
+    {
+        if(def1 == nullptr || (def1->mXPTable[i] != def2->mXPTable[i]))
+        {
+            isSame = false;
+            break;
+        }
+    }
+    if(!isSame)
+    {
+        file << "    [XP]" << std::endl;
+        uint32_t i = 2;
+        uint32_t levelMax;
+        while(i <= MAX_LEVEL)
+        {
+            levelMax = std::min(i + 10U - (i % 10), MAX_LEVEL);
+            file << "    # " << i <<"-" << levelMax << std::endl;
+            file << "    ";
+
+            while(i < levelMax)
+            {
+                file << def2->mXPTable[i - 2] << "\t";
+                ++i;
+            }
+            file << def2->mXPTable[i - 2] << std::endl;
+            ++i;
+        }
+        file << "    [/XP]" << std::endl;
+    }
     file << "[/Creature]" << std::endl;
 }
 

--- a/source/entities/CreatureDefinition.h
+++ b/source/entities/CreatureDefinition.h
@@ -28,7 +28,7 @@
 class ODPacket;
 
 //! \brief The maximum level of a creature
-static const int MAX_LEVEL = 30;
+static const uint32_t MAX_LEVEL = 30;
 
 class CreatureDefinition
 {


### PR DESCRIPTION
To test it, you can open a level where the XP table is overriden for a creature and save it. In the saved level, the xp table should be the same
