### PR TITLE
Removed render manager queue + code conventions on gamemap + creature vision debug

### DIFF
--- a/source/entities/Building.cpp
+++ b/source/entities/Building.cpp
@@ -37,8 +37,8 @@ void Building::createMeshLocal()
     std::vector<Tile*> coveredTiles = getCoveredTiles();
     for (Tile* tile : coveredTiles)
     {
-        RenderRequest* request = new RenderRequestCreateBuilding(this, tile);
-        RenderManager::queueRenderRequest(request);
+        RenderRequestCreateBuilding request(this, tile);
+        RenderManager::executeRenderRequest(request);
     }
 }
 
@@ -52,8 +52,8 @@ void Building::destroyMeshLocal()
     std::vector<Tile*> coveredTiles = getCoveredTiles();
     for (Tile* tile : coveredTiles)
     {
-        RenderRequest* request = new RenderRequestDestroyBuilding(this, tile);
-        RenderManager::queueRenderRequest(request);
+        RenderRequestDestroyBuilding request(this, tile);
+        RenderManager::executeRenderRequest(request);
     }
 }
 
@@ -200,8 +200,8 @@ bool Building::removeCoveredTile(Tile* t)
                 return true;
 
             // Destroy the mesh for this tile.
-            RenderRequest *request = new RenderRequestDestroyBuilding(this, t);
-            RenderManager::queueRenderRequest(request);
+            RenderRequestDestroyBuilding request(this, t);
+            RenderManager::executeRenderRequest(request);
             return true;
         }
     }

--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -222,12 +222,12 @@ void Creature::createMeshLocal()
     MovableGameEntity::createMeshLocal();
     if(!getGameMap()->isServerGameMap())
     {
-        RenderRequest* request = new RenderRequestCreateCreature(this);
-        RenderManager::queueRenderRequest(request);
+        RenderRequestCreateCreature request1(this);
+        RenderManager::executeRenderRequest(request1);
 
         // By default, we set the creature in idle state
-        request = new RenderRequestSetObjectAnimationState(this, "Idle", true);
-        RenderManager::queueRenderRequest(request);
+        RenderRequestSetObjectAnimationState request2(this, "Idle", true);
+        RenderManager::executeRenderRequest(request2);
     }
 
     createMeshWeapons();
@@ -241,8 +241,8 @@ void Creature::destroyMeshLocal()
         return;
 
     destroyStatsWindow();
-    RenderRequest* request = new RenderRequestDestroyCreature(this);
-    RenderManager::queueRenderRequest(request);
+    RenderRequestDestroyCreature request(this);
+    RenderManager::executeRenderRequest(request);
 }
 
 void Creature::createMeshWeapons()
@@ -252,13 +252,13 @@ void Creature::createMeshWeapons()
 
     if(mWeaponL != nullptr)
     {
-        RenderRequest* request = new RenderRequestCreateWeapon(this, mWeaponL, "L");
-        RenderManager::queueRenderRequest(request);
+        RenderRequestCreateWeapon request(this, mWeaponL, "L");
+        RenderManager::executeRenderRequest(request);
     }
     if(mWeaponR != nullptr)
     {
-        RenderRequest* request = new RenderRequestCreateWeapon(this, mWeaponR, "R");
-        RenderManager::queueRenderRequest(request);
+        RenderRequestCreateWeapon request(this, mWeaponR, "R");
+        RenderManager::executeRenderRequest(request);
     }
 }
 
@@ -269,13 +269,13 @@ void Creature::destroyMeshWeapons()
 
     if(mWeaponL != nullptr)
     {
-        RenderRequest* request = new RenderRequestDestroyWeapon(this, mWeaponL, "L");
-        RenderManager::queueRenderRequest(request);
+        RenderRequestDestroyWeapon request(this, mWeaponL, "L");
+        RenderManager::executeRenderRequest(request);
     }
     if(mWeaponR != nullptr)
     {
-        RenderRequest* request = new RenderRequestDestroyWeapon(this, mWeaponR, "R");
-        RenderManager::queueRenderRequest(request);
+        RenderRequestDestroyWeapon request(this, mWeaponR, "R");
+        RenderManager::executeRenderRequest(request);
     }
 }
 
@@ -2734,8 +2734,8 @@ void Creature::refreshFromCreature(Creature *creatureNewState)
         if (scaleFactor > 1.04)
             scaleFactor = 1.04;
 
-        RenderRequest *request = new RenderRequestScaleSceneNode(mSceneNode, Ogre::Vector3(scaleFactor, scaleFactor, scaleFactor));
-        RenderManager::queueRenderRequest(request);
+        RenderRequestScaleSceneNode request(mSceneNode, Ogre::Vector3(scaleFactor, scaleFactor, scaleFactor));
+        RenderManager::executeRenderRequest(request);
     }
 }
 
@@ -2914,8 +2914,8 @@ void Creature::refreshVisualDebugEntities(const std::vector<Tile*>& tiles)
         if(std::find(mVisualDebugEntityTiles.begin(), mVisualDebugEntityTiles.end(), tile) != mVisualDebugEntityTiles.end())
             continue;
 
-        RenderRequest *request = new RenderRequestCreateCreatureVisualDebug(this, tile);
-        RenderManager::queueRenderRequest(request);
+        RenderRequestCreateCreatureVisualDebug request(this, tile);
+        RenderManager::executeRenderRequest(request);
 
         mVisualDebugEntityTiles.push_back(tile);
     }
@@ -2932,8 +2932,8 @@ void Creature::refreshVisualDebugEntities(const std::vector<Tile*>& tiles)
 
         it = mVisualDebugEntityTiles.erase(it);
 
-        RenderRequest *request = new RenderRequestDestroyCreatureVisualDebug(this, tile);
-        RenderManager::queueRenderRequest(request);
+        RenderRequestDestroyCreatureVisualDebug request(this, tile);
+        RenderManager::executeRenderRequest(request);
     }
 }
 
@@ -2964,8 +2964,8 @@ void Creature::destroyVisualDebugEntities()
         if (tile == nullptr)
             continue;
 
-        RenderRequest *request = new RenderRequestDestroyCreatureVisualDebug(this, tile);
-        RenderManager::queueRenderRequest(request);
+        RenderRequestDestroyCreatureVisualDebug request(this, tile);
+        RenderManager::executeRenderRequest(request);
     }
     mVisualDebugEntityTiles.clear();
 }
@@ -3556,8 +3556,8 @@ void Creature::carryEntity(GameEntity* carriedEntity)
     }
     else
     {
-        RenderRequest *request = new RenderRequestCarryEntity(this, carriedEntity);
-        RenderManager::queueRenderRequest(request);
+        RenderRequestCarryEntity request(this, carriedEntity);
+        RenderManager::executeRenderRequest(request);
     }
 }
 
@@ -3576,8 +3576,8 @@ void Creature::releaseCarriedEntity()
 
     if(!getGameMap()->isServerGameMap())
     {
-        RenderRequest *request = new RenderRequestReleaseCarriedEntity(this, carriedEntity);
-        RenderManager::queueRenderRequest(request);
+        RenderRequestReleaseCarriedEntity request(this, carriedEntity);
+        RenderManager::executeRenderRequest(request);
     }
     else
     {

--- a/source/entities/Creature.h
+++ b/source/entities/Creature.h
@@ -243,10 +243,17 @@ public:
     //! \brief Clears the action queue, except for the Idle action at the end.
     void clearActionQueue();
 
-    //! \brief Displays a mesh on all of the tiles visible to the creature.
-    void createVisualDebugEntities();
+    //! \brief Computes the tiles visible for the creature and sends a message to the clients to mark those tiles. This function
+    //! should be called on server side only
+    void computeVisualDebugEntities();
 
-    //! \brief Destroy the meshes created by createVisualDebuggingEntities().
+    //! \brief Displays a mesh on all of the tiles in the list. This function should be called on client side only
+    void refreshVisualDebugEntities(const std::vector<Tile*>& tiles);
+
+    //! \brief Sends a message to the clients to stop displaying the tiles this creature sees
+    void stopComputeVisualDebugEntities();
+
+    //! \brief Destroy the meshes created by createVisualDebuggingEntities(). This function should be called on client side only
     void destroyVisualDebugEntities();
 
     //! \brief An accessor to return whether or not the creature has OGRE entities for its visual debugging entities.
@@ -393,7 +400,6 @@ private:
     //! \brief The number of turns we are doing the same action. If the action is popped or pushed, mNbTurnAction is set to 0
     int             mNbTurnAction;
 
-    Tile*           mPreviousPositionTile;
     Room*           mJobRoom;
     Room*           mEatRoom;
     CEGUI::Window*  mStatsWindow;
@@ -414,7 +420,7 @@ private:
     std::vector<GameEntity*>        mVisibleAlliedObjects;
     std::vector<GameEntity*>        mReachableAlliedObjects;
     std::deque<CreatureAction>      mActionQueue;
-    std::list<Tile*>                mVisualDebugEntityTiles;
+    std::vector<Tile*>              mVisualDebugEntityTiles;
 
 
     //! \brief Allows to keep track of the entity we are currently attacking

--- a/source/entities/GameEntity.cpp
+++ b/source/entities/GameEntity.cpp
@@ -82,8 +82,8 @@ void GameEntity::setMeshOpacity(float opacity)
         return;
     }
 
-    RenderRequest* request = new RenderRequestUpdateEntityOpacity(this);
-    RenderManager::queueRenderRequest(request);
+    RenderRequestUpdateEntityOpacity request(this);
+    RenderManager::executeRenderRequest(request);
 }
 
 std::string GameEntity::getNodeNameWithoutPostfix()

--- a/source/entities/GameEntity.h
+++ b/source/entities/GameEntity.h
@@ -163,14 +163,14 @@ class GameEntity
 
     inline void show()
     {
-        RenderRequest* request = new RenderRequestAttachEntity(this);
-        RenderManager::queueRenderRequest(request);
+        RenderRequestAttachEntity request(this);
+        RenderManager::executeRenderRequest(request);
     }
 
     inline void hide()
     {
-        RenderRequest* request = new RenderRequestDetachEntity(this);
-        RenderManager::queueRenderRequest(request);
+        RenderRequestDetachEntity request(this);
+        RenderManager::executeRenderRequest(request);
     }
 
     //! \brief Retrieves the position tile from the game map

--- a/source/entities/MapLight.cpp
+++ b/source/entities/MapLight.cpp
@@ -71,8 +71,8 @@ void MapLight::createOgreEntity()
 
     ModeManager* mm = ODFrameListener::getSingleton().getModeManager();
     // Only show the visual light entity if we are in editor mode
-    RenderRequest* request = new RenderRequestCreateMapLight(this, mm && mm->getCurrentModeType() == ModeManager::EDITOR);
-    RenderManager::queueRenderRequest(request);
+    RenderRequestCreateMapLight request(this, mm && mm->getCurrentModeType() == ModeManager::EDITOR);
+    RenderManager::executeRenderRequest(request);
 
     mOgreEntityVisualIndicatorExists = true;
 }
@@ -89,8 +89,8 @@ void MapLight::destroyOgreEntity()
 
     destroyOgreEntityVisualIndicator();
 
-    RenderRequest* request = new RenderRequestDestroyMapLight(this);
-    RenderManager::queueRenderRequest(request);
+    RenderRequestDestroyMapLight request(this);
+    RenderManager::executeRenderRequest(request);
 }
 
 void MapLight::destroyOgreEntityVisualIndicator()
@@ -98,8 +98,8 @@ void MapLight::destroyOgreEntityVisualIndicator()
     if (!mOgreEntityVisualIndicatorExists)
         return;
 
-    RenderRequest* request = new RenderRequestDestroyMapLightVisualIndicator(this);
-    RenderManager::queueRenderRequest(request);
+    RenderRequestDestroyMapLightVisualIndicator request(this);
+    RenderManager::executeRenderRequest(request);
 
     mOgreEntityVisualIndicatorExists = false;
 }
@@ -121,8 +121,8 @@ void MapLight::setPosition(const Ogre::Vector3& nPosition)
 {
     mPosition = nPosition;
 
-    RenderRequest* request = new RenderRequestMoveSceneNode(getOgreNamePrefix() + mName + "_node", mPosition);
-    RenderManager::queueRenderRequest(request);
+    RenderRequestMoveSceneNode request(getOgreNamePrefix() + mName + "_node", mPosition);
+    RenderManager::executeRenderRequest(request);
 }
 
 void MapLight::advanceFlicker(Ogre::Real time)
@@ -141,8 +141,8 @@ void MapLight::advanceFlicker(Ogre::Real time)
 
     mFlickerPosition = Ogre::Vector3(sin(mThetaX), sin(mThetaY), sin(mThetaZ));
 
-    RenderRequest* request = new RenderRequestMoveSceneNode(getOgreNamePrefix() + mName + "_flicker_node", mFlickerPosition);
-    RenderManager::queueRenderRequest(request);
+    RenderRequestMoveSceneNode request(getOgreNamePrefix() + mName + "_flicker_node", mFlickerPosition);
+    RenderManager::executeRenderRequest(request);
 }
 
 std::string MapLight::getFormat()

--- a/source/entities/MovableGameEntity.cpp
+++ b/source/entities/MovableGameEntity.cpp
@@ -154,8 +154,8 @@ void MovableGameEntity::setWalkDirection(Ogre::Vector3& direction)
     if(getGameMap()->isServerGameMap())
         return;
 
-    RenderRequest* request = new RenderRequestOrientSceneNodeToward(this, direction);
-    RenderManager::queueRenderRequest(request);
+    RenderRequestOrientSceneNodeToward request(this, direction);
+    RenderManager::executeRenderRequest(request);
 }
 
 void MovableGameEntity::setAnimationState(const std::string& state, bool loop, Ogre::Vector3* direction)
@@ -193,8 +193,8 @@ void MovableGameEntity::setAnimationState(const std::string& state, bool loop, O
         return;
     }
 
-    RenderRequest* request = new RenderRequestSetObjectAnimationState(this, state, loop);
-    RenderManager::queueRenderRequest(request);
+    RenderRequestSetObjectAnimationState request(this, state, loop);
+    RenderManager::executeRenderRequest(request);
 }
 
 double MovableGameEntity::getAnimationSpeedFactor()
@@ -270,7 +270,7 @@ void MovableGameEntity::setPosition(const Ogre::Vector3& v)
     if(getGameMap()->isServerGameMap())
         return;
 
-    RenderRequest* request = new RenderRequestMoveSceneNode(getOgreNamePrefix() + getName() + "_node", v);
-    RenderManager::queueRenderRequest(request);
+    RenderRequestMoveSceneNode request(getOgreNamePrefix() + getName() + "_node", v);
+    RenderManager::executeRenderRequest(request);
 
 }

--- a/source/entities/RenderedMovableEntity.cpp
+++ b/source/entities/RenderedMovableEntity.cpp
@@ -63,8 +63,8 @@ void RenderedMovableEntity::createMeshLocal()
     if(getGameMap()->isServerGameMap())
         return;
 
-    RenderRequest* request = new RenderRequestCreateRenderedMovableEntity(this);
-    RenderManager::queueRenderRequest(request);
+    RenderRequestCreateRenderedMovableEntity request(this);
+    RenderManager::executeRenderRequest(request);
 }
 
 void RenderedMovableEntity::destroyMeshLocal()
@@ -74,8 +74,8 @@ void RenderedMovableEntity::destroyMeshLocal()
     if(getGameMap()->isServerGameMap())
         return;
 
-    RenderRequest* request = new RenderRequestDestroyRenderedMovableEntity(this);
-    RenderManager::queueRenderRequest(request);
+    RenderRequestDestroyRenderedMovableEntity request(this);
+    RenderManager::executeRenderRequest(request);
 }
 
 void RenderedMovableEntity::pickup()

--- a/source/entities/Tile.cpp
+++ b/source/entities/Tile.cpp
@@ -56,8 +56,8 @@ void Tile::createMeshLocal()
     if(getGameMap()->isServerGameMap())
         return;
 
-    RenderRequest* request = new RenderRequestCreateTile(this);
-    RenderManager::queueRenderRequest(request);
+    RenderRequestCreateTile request(this);
+    RenderManager::executeRenderRequest(request);
 }
 
 void Tile::destroyMeshLocal()
@@ -67,8 +67,8 @@ void Tile::destroyMeshLocal()
     if(getGameMap()->isServerGameMap())
         return;
 
-    RenderRequest* request = new RenderRequestDestroyTile(this);
-    RenderManager::queueRenderRequest(request);
+    RenderRequestDestroyTile request(this);
+    RenderManager::executeRenderRequest(request);
 }
 
 void Tile::setType(TileType t)
@@ -839,8 +839,8 @@ void Tile::refreshMesh()
     if(getGameMap()->isServerGameMap())
         return;
 
-    RenderRequest *request = new RenderRequestRefreshTile(this);
-    RenderManager::queueRenderRequest(request);
+    RenderRequestRefreshTile request(this);
+    RenderManager::executeRenderRequest(request);
 }
 
 void Tile::setMarkedForDigging(bool ss, Player *pp)
@@ -869,8 +869,8 @@ void Tile::setSelected(bool ss, Player* pp)
     {
         selected = ss;
 
-        RenderRequest *request = new RenderRequestTemporalMarkTile(this);
-        RenderManager::queueRenderRequest(request);
+        RenderRequestTemporalMarkTile request(this);
+        RenderManager::executeRenderRequest(request);
     }
 }
 

--- a/source/game/Player.cpp
+++ b/source/game/Player.cpp
@@ -99,11 +99,6 @@ void Player::pickUpEntity(GameEntity *entity, bool isEditorMode)
            return;
 
        creature->pickup();
-
-        // Destroy the creature's visual debugging entities if it has them
-        if (!mGameMap->isServerGameMap() && creature->getHasVisualDebuggingEntities())
-            creature->destroyVisualDebugEntities();
-
     }
     else if(entity->getObjectType() == GameEntity::ObjectType::renderedMovableEntity)
     {

--- a/source/game/Player.cpp
+++ b/source/game/Player.cpp
@@ -142,14 +142,14 @@ void Player::pickUpEntity(GameEntity *entity, bool isEditorMode)
     if (this == mGameMap->getLocalPlayer())
     {
         // Send a render request to move the crature into the "hand"
-        RenderRequest *request = new RenderRequestPickUpEntity(entity);
-        RenderManager::queueRenderRequest(request);
+        RenderRequestPickUpEntity request(entity);
+        RenderManager::executeRenderRequest(request);
     }
     else // it is just a message indicating another player has picked up a creature
     {
         // Hide the creature
-        RenderRequest *request = new RenderRequestDetachEntity(entity);
-        RenderManager::queueRenderRequest(request);
+        RenderRequestDetachEntity request(entity);
+        RenderManager::executeRenderRequest(request);
     }
 }
 
@@ -236,14 +236,14 @@ GameEntity* Player::dropHand(Tile *t, unsigned int index)
     //cout.flush();
     if (this != mGameMap->getLocalPlayer())
     {
-        RenderRequest *request = new RenderRequestAttachEntity(entity);
-        RenderManager::queueRenderRequest(request);
+        RenderRequestAttachEntity request(entity);
+        RenderManager::executeRenderRequest(request);
     }
     else // This is the result of the player on the local computer dropping the creature
     {
         // Send a render request to rearrange the creatures in the hand to move them all forward 1 place
-        RenderRequest *request = new RenderRequestDropHand(entity);
-        RenderManager::queueRenderRequest(request);
+        RenderRequestDropHand request(entity);
+        RenderManager::executeRenderRequest(request);
     }
 
     return entity;
@@ -278,8 +278,8 @@ void Player::rotateHand(int n)
     }
 
     // Send a render request to move the entity into the "hand"
-    RenderRequest *request = new RenderRequestRotateHand;
-    RenderManager::queueRenderRequest(request);
+    RenderRequestRotateHand request;
+    RenderManager::executeRenderRequest(request);
 }
 
 void Player::notifyNoMoreDungeonTemple()

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -2869,16 +2869,28 @@ void GameMap::logFloodFileTiles()
 void GameMap::consoleSetCreatureDestination(const std::string& creatureName, int x, int y)
 {
     Creature* creature = getCreature(creatureName);
-    if(creature == NULL)
+    if(creature == nullptr)
         return;
     Tile* tile = getTile(x, y);
-    if(tile == NULL)
+    if(tile == nullptr)
         return;
-    if(creature->getPositionTile() == NULL)
+    if(creature->getPositionTile() == nullptr)
         return;
     creature->clearActionQueue();
     creature->clearDestinations();
     creature->setDestination(tile);
+}
+
+void GameMap::consoleDisplayCreatureVisualDebug(const std::string& creatureName, bool enable)
+{
+    Creature* creature = getCreature(creatureName);
+    if(creature == nullptr)
+        return;
+
+    if(enable)
+        creature->computeVisualDebugEntities();
+    else
+        creature->stopComputeVisualDebugEntities();
 }
 
 Creature* GameMap::getKoboldForPathFinding(Seat* seat)

--- a/source/gamemap/GameMap.h
+++ b/source/gamemap/GameMap.h
@@ -449,6 +449,7 @@ public:
 
     void logFloodFileTiles();
     void consoleSetCreatureDestination(const std::string& creatureName, int x, int y);
+    void consoleDisplayCreatureVisualDebug(const std::string& creatureName, bool enable);
 
     //! \brief This functions create unique names. They check that there
     //! is no entity with the same name before returning

--- a/source/gamemap/GameMap.h
+++ b/source/gamemap/GameMap.h
@@ -271,14 +271,17 @@ public:
     int getTotalGoldForSeat(Seat* seat);
     bool withdrawFromTreasuries(int gold, Seat* seat);
 
-    inline void setCullingManger(CullingManager* tempCulm)
-    { culm = tempCulm; }
+    inline void setCullingManger(CullingManager* cullingManager)
+    { mCullingManager = cullingManager; }
+
+    inline CullingManager* getCullingManger() const
+    { return mCullingManager; }
 
     inline const std::string& getLevelFileName() const
-    { return levelFileName; }
+    { return mLevelFileName; }
 
-    inline void setLevelFileName(const std::string& nlevelFileName)
-    { levelFileName = nlevelFileName; }
+    inline void setLevelFileName(const std::string& levelFileName)
+    { mLevelFileName = levelFileName; }
 
     inline const std::string& getLevelName() const
     { return mMapInfoName; }
@@ -372,7 +375,7 @@ public:
 
     //! \brief Temporarily disables the flood fill computations on this game map.
     void disableFloodFill()
-    { floodFillEnabled = false; }
+    { mFloodFillEnabled = false; }
 
     /** \brief Re-enables the flood filling on the game map, also recomputes the painting on the
      * whole map since the passabilities may have changed since the flood filling was disabled.
@@ -475,14 +478,11 @@ public:
     void fillBuildableTilesAndPriceForPlayerInArea(int x1, int y1, int x2, int y2,
         Player* player, Room::RoomType type, std::vector<Tile*>& tiles, int& goldRequired);
 
-    // FIXME: Needs to be private
-    CullingManager* culm;
-
-    std::vector<Creature*> creatures;
-
 private:
     void replaceFloodFill(Tile::FloodFillType floodFillType, int colorOld, int colorNew);
     bool mIsServerGameMap;
+
+    CullingManager* mCullingManager;
     //! \brief the Local player reference. The local player will also be in the player list so this pointer
     //! should not be deleted as it will be handled like every other in the list.
     Player* mLocalPlayer;
@@ -504,13 +504,15 @@ private:
     bool mIsPaused;
 
     //! \brief Level related filenames.
-    std::string levelFileName;
+    std::string mLevelFileName;
 
     //! \brief Map info
     std::string mMapInfoName;
     std::string mMapInfoDescription;
     std::string mMapInfoMusicFile;
     std::string mMapInfoFightMusicFile;
+
+    std::vector<Creature*> mCreatures;
 
     //! \brief The creature definition data. We use a pair to be able to make the difference between the original
     //! data from the global creature definition file and the specific data from the level file. With this trick,
@@ -520,23 +522,23 @@ private:
     std::vector<std::pair<const Weapon*,Weapon*> > mWeapons;
 
     //Mutable to allow locking in const functions.
-    std::vector<MovableGameEntity*> animatedObjects;
+    std::vector<MovableGameEntity*> mAnimatedObjects;
 
     //! \brief Map Entities
-    std::vector<Room*> rooms;
-    std::vector<Trap*> traps;
-    std::vector<MapLight*> mapLights;
+    std::vector<Room*> mRooms;
+    std::vector<Trap*> mTraps;
+    std::vector<MapLight*> mMapLights;
 
     //! \brief Players and available game player slots (Seats)
     std::vector<Player*> mPlayers;
     std::vector<Seat*> mSeats;
-    std::vector<Seat*> winningSeats;
+    std::vector<Seat*> mWinningSeats;
 
     //! \brief Common player goals
-    std::vector<Goal*> goalsForAllSeats;
+    std::vector<Goal*> mGoalsForAllSeats;
 
     //! \brief Tells whether the map color flood filling is enabled.
-    bool floodFillEnabled;
+    bool mFloodFillEnabled;
 
     std::vector<GameEntity*> mActiveObjects;
 
@@ -547,20 +549,20 @@ private:
     std::deque<GameEntity*> mActiveObjectsToRemove;
 
     //! \brief Useless entities that need to be deleted. They will be deleted when processDeletionQueues is called
-    std::vector<GameEntity*> entitiesToDelete;
+    std::vector<GameEntity*> mEntitiesToDelete;
 
     //! \brief Useless MapLights that need to be deleted. They will be deleted when processDeletionQueues is called
-    std::vector<MapLight*> mapLightsToDelete;
+    std::vector<MapLight*> mMapLightsToDelete;
 
     //! \brief Debug member used to know how many call to pathfinding has been made within the same turn.
-    unsigned int numCallsTo_path;
+    unsigned int mNumCallsTo_path;
 
-    TileCoordinateMap* tileCoordinateMap;
+    TileCoordinateMap* mTileCoordinateMap;
 
     std::vector<RenderedMovableEntity*> mRenderedMovableEntities;
 
     //! AI Handling manager
-    AIManager aiManager;
+    AIManager mAiManager;
 
     //! \brief Updates different entities states.
     //! Updates active objects (creatures, rooms, ...), goals, count each team Workers, gold, mana and claimed tiles.

--- a/source/modes/Console_executePromptCommand.cpp
+++ b/source/modes/Console_executePromptCommand.cpp
@@ -759,14 +759,24 @@ bool Console::executePromptCommand(const std::string& command, std::string argum
                 {
                     if (!tempCreature->getHasVisualDebuggingEntities())
                     {
-                        tempCreature->createVisualDebugEntities();
+                        if(ODClient::getSingleton().isConnected())
+                        {
+                            const std::string& name = tempCreature->getName();
+                            ODConsoleCommand* cc = new ODConsoleCommandDisplayCreatureVisualDebug(name, true);
+                            ODServer::getSingleton().queueConsoleCommand(cc);
+                        }
                         frameListener->mCommandOutput
                                 += "\nVisual debugging entities created for creature:  "
                                         + arguments + "\n";
                     }
                     else
                     {
-                        tempCreature->destroyVisualDebugEntities();
+                        if(ODClient::getSingleton().isConnected())
+                        {
+                            const std::string& name = tempCreature->getName();
+                            ODConsoleCommand* cc = new ODConsoleCommandDisplayCreatureVisualDebug(name, false);
+                            ODServer::getSingleton().queueConsoleCommand(cc);
+                        }
                         frameListener->mCommandOutput
                                 += "\nVisual debugging entities destroyed for creature:  "
                                         + arguments + "\n";

--- a/source/modes/Console_executePromptCommand.cpp
+++ b/source/modes/Console_executePromptCommand.cpp
@@ -986,20 +986,20 @@ bool Console::executePromptCommand(const std::string& command, std::string argum
     }
     else if (command.compare("starttileculling") == 0)
     {
-            gameMap->culm->startTileCulling();
+            gameMap->getCullingManger()->startTileCulling();
     }
     else if (command.compare("stoptileculling") == 0)
     {
-            gameMap->culm->stopTileCulling();
+            gameMap->getCullingManger()->stopTileCulling();
     }
 
     else if (command.compare("startcreatureculling") == 0)
     {
-            gameMap->culm->startCreatureCulling();
+            gameMap->getCullingManger()->startCreatureCulling();
     }
     else if (command.compare("startdb") == 0)
     {
-            gameMap->culm->startDebugging();
+            gameMap->getCullingManger()->startDebugging();
     }
 
     else if (command.compare("triggercompositor") == 0)

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -862,11 +862,7 @@ void EditorMode::exitMode()
         ODServer::getSingleton().stopServer();
 
     // Now that the server is stopped, we can clear the client game map
-    // We process RenderRequests in case there is graphical things pending
-    RenderManager::getSingleton().processRenderRequests();
     ODFrameListener::getSingleton().getClientGameMap()->clearAll();
-    // We process again RenderRequests to destroy/delete what clearAll has put in the queue
-    RenderManager::getSingleton().processRenderRequests();
     ODFrameListener::getSingleton().getClientGameMap()->processDeletionQueues();
 }
 

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -958,11 +958,7 @@ void GameMode::exitMode()
         ODServer::getSingleton().stopServer();
 
     // Now that the server is stopped, we can clear the client game map
-    // We process RenderRequests in case there is graphical things pending
-    RenderManager::getSingleton().processRenderRequests();
     ODFrameListener::getSingleton().getClientGameMap()->clearAll();
-    // We process again RenderRequests to destroy/delete what clearAll has put in the queue
-    RenderManager::getSingleton().processRenderRequests();
     ODFrameListener::getSingleton().getClientGameMap()->processDeletionQueues();
 }
 

--- a/source/modes/ODConsoleCommand.h
+++ b/source/modes/ODConsoleCommand.h
@@ -83,4 +83,23 @@ private:
     int mY;
 };
 
+class ODConsoleCommandDisplayCreatureVisualDebug : public ODConsoleCommand
+{
+public:
+    ODConsoleCommandDisplayCreatureVisualDebug(const std::string& creatureName, bool enable):
+        mCreatureName(creatureName),
+        mEnable(enable)
+    {
+    }
+
+protected:
+    virtual void execute(GameMap* gameMap)
+    {
+        gameMap->consoleDisplayCreatureVisualDebug(mCreatureName, mEnable);
+    }
+private:
+    std::string mCreatureName;
+    bool mEnable;
+};
+
 #endif // ODCONSOLECOMMAND_H

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -98,7 +98,6 @@ bool ODClient::processOneClientSocketMessage()
             OD_ASSERT_TRUE(packetReceived >> levelFilename);
             // Read in the map. The map loading should happen here and not in the server thread to
             // make sure it is valid before launching the server.
-            RenderManager::getSingletonPtr()->processRenderRequests();
             ODFrameListener::getSingleton().getClientGameMap()->processDeletionQueues();
             if (!gameMap->loadLevel(levelFilename))
             {

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -210,7 +210,7 @@ void ODServer::startNewTurn(double timeSinceLastFrame)
         {
             std::string& name = *itCreatures;
             Creature* creature = gameMap->getCreature(name);
-            if(creature == NULL)
+            if(creature == nullptr)
                 itCreatures = creatures.erase(itCreatures);
             else
             {

--- a/source/network/ServerNotification.cpp
+++ b/source/network/ServerNotification.cpp
@@ -116,6 +116,8 @@ std::string ServerNotification::typeString(ServerNotificationType type)
             return "playSpatialSound";
         case ServerNotificationType::notifyCreatureInfo:
             return "notifyCreatureInfo";
+        case ServerNotificationType::refreshCreatureVisDebug:
+            return "refreshCreatureVisDebug";
         case ServerNotificationType::playCreatureSound:
             return "playCreatureSound";
         case ServerNotificationType::refreshTiles:

--- a/source/network/ServerNotification.h
+++ b/source/network/ServerNotification.h
@@ -88,6 +88,7 @@ class ServerNotification
             removeRenderedMovableEntity,
             setEntityOpacity,
             notifyCreatureInfo,
+            refreshCreatureVisDebug,
 
             playSpatialSound, // Makes the client play a sound at tile coordinates.
             playCreatureSound, // Play a sound at the creature position

--- a/source/render/ODFrameListener.cpp
+++ b/source/render/ODFrameListener.cpp
@@ -141,7 +141,6 @@ ODFrameListener::~ODFrameListener()
         delete mModeManager;
     delete mCameraManager;
     mGameMap->clearAll();
-    RenderManager::getSingletonPtr()->processRenderRequests();
     mGameMap->processDeletionQueues();
     delete mGameMap;
     delete mMiniMap;
@@ -168,7 +167,6 @@ void ODFrameListener::exitApplication()
 
     ODClient::getSingleton().notifyExit();
     ODServer::getSingleton().notifyExit();
-    RenderManager::getSingletonPtr()->processRenderRequests();
     mGameMap->clearAll();
     mGameMap->processDeletionQueues();
     RenderManager::getSingletonPtr()->getSceneManager()->destroyQuery(mRaySceneQuery);
@@ -186,7 +184,7 @@ void ODFrameListener::exitApplication()
 void ODFrameListener::updateAnimations(Ogre::Real timeSinceLastFrame)
 {
     MusicPlayer::getSingleton().update(static_cast<float>(timeSinceLastFrame));
-    RenderManager::getSingletonPtr()->processRenderRequests(timeSinceLastFrame);
+    RenderManager::getSingleton().updateRenderAnimations(timeSinceLastFrame);
     mGameMap->processDeletionQueues();
 
     mGameMap->updateAnimations(timeSinceLastFrame);

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -78,7 +78,6 @@ RenderManager::RenderManager(Ogre::OverlaySystem* overlaySystem) :
     mSceneManager = Ogre::Root::getSingleton().createSceneManager(Ogre::ST_INTERIOR, "SceneManager");
     mSceneManager->addRenderQueueListener(overlaySystem);
 
-    mRockSceneNode = mSceneManager->getRootSceneNode()->createChildSceneNode("Rock_scene_node");
     mCreatureSceneNode = mSceneManager->getRootSceneNode()->createChildSceneNode("Creature_scene_node");
     mRoomSceneNode = mSceneManager->getRootSceneNode()->createChildSceneNode("Room_scene_node");
     mLightSceneNode = mSceneManager->getRootSceneNode()->createChildSceneNode("Light_scene_node");
@@ -164,21 +163,8 @@ void RenderManager::createScene(Ogre::Viewport* nViewport)
     Ogre::CompositorManager::getSingleton().addCompositor(mViewport, "B&W");
 }
 
-void RenderManager::processRenderRequests(Ogre::Real timeSinceLastFrame)
+void RenderManager::updateRenderAnimations(Ogre::Real timeSinceLastFrame)
 {
-    while (!mRenderQueue.empty())
-    {
-        // Remove the first item from the render queue
-        RenderRequest *curReq = mRenderQueue.front();
-        mRenderQueue.pop_front();
-
-        // Handle the request
-        curReq->executeRequest(this);
-
-        delete curReq;
-        curReq = NULL;
-    }
-
     if(mHandAnimationState == nullptr)
         return;
 
@@ -193,9 +179,9 @@ void RenderManager::processRenderRequests(Ogre::Real timeSinceLastFrame)
 
 }
 
-void RenderManager::queueRenderRequest_priv(RenderRequest* renderRequest)
+void RenderManager::executeRenderRequest_priv(RenderRequest& renderRequest)
 {
-    mRenderQueue.push_back(renderRequest);
+    renderRequest.executeRequest(this);
 }
 
 void RenderManager::rrRefreshTile(Tile* curTile)
@@ -742,7 +728,7 @@ void RenderManager::rrRotateHand()
 
 void RenderManager::rrCreateCreatureVisualDebug(Creature* curCreature, Tile* curTile)
 {
-    if (curTile != NULL && curCreature != NULL)
+    if (curTile != nullptr && curCreature != nullptr)
     {
         std::stringstream tempSS;
         tempSS << "Vision_indicator_" << curCreature->getName() << "_"

--- a/source/render/RenderManager.h
+++ b/source/render/RenderManager.h
@@ -66,7 +66,7 @@ public:
     { mGameMap = gameMap; }
 
     //! \brief Loop through the render requests in the queue and process them
-    void processRenderRequests(Ogre::Real timeSinceLastFrame = 0);
+    void updateRenderAnimations(Ogre::Real timeSinceLastFrame);
 
     //! \brief starts the compositor compositorName.
     void triggerCompositor(const std::string& compositorName);
@@ -74,10 +74,10 @@ public:
     //! \brief setup the scene
     void createScene(Ogre::Viewport*);
 
-    //! \brief Put a render request in the queue (helper function to avoid having to fetch the singleton)
-    static void queueRenderRequest(RenderRequest* renderRequest)
+    //! \brief Executes a render request in the queue (helper function to avoid having to fetch the singleton)
+    static void executeRenderRequest(RenderRequest& renderRequest)
     {
-        msSingleton->queueRenderRequest_priv(renderRequest);
+        msSingleton->executeRenderRequest_priv(renderRequest);
     }
 
     void rtssTest();
@@ -101,7 +101,7 @@ public:
 
 private:
     //! \brief Put a render request in the queue (implementation)
-    void queueRenderRequest_priv(RenderRequest* renderRequest);
+    void executeRenderRequest_priv(RenderRequest& renderRequest);
 
     //Render request functions
     void rrRefreshTile(Tile* curTile);
@@ -151,8 +151,6 @@ private:
     //! \returns The new material name according to the current opacity.
     std::string setMaterialOpacity(const std::string& materialName, float opacity);
 
-    std::deque<RenderRequest*> mRenderQueue;
-
     //! \brief The main scene manager reference. Don't delete it.
     Ogre::SceneManager* mSceneManager;
 
@@ -160,7 +158,6 @@ private:
     Ogre::SceneNode* mRoomSceneNode;
     Ogre::SceneNode* mCreatureSceneNode;
     Ogre::SceneNode* mLightSceneNode;
-    Ogre::SceneNode* mRockSceneNode;
 
     Ogre::AnimationState* mHandAnimationState;
 


### PR DESCRIPTION
To test the creature vision debug, open the console and write "visdebug creatureName"
That will display every tile the given creature sees. Note that it clearly shows that there is a problem on how visible tiles are computed (especially on a 1 tile wide corridor).
Note also that this command is available on the server only. And if you use it, every client will see the visible tiles.

If the creature whose vision is displayed is pickedup, the tiles won't be displayed until it is dropped.
