### PR TITLE
Add a man page and install it on Linux (fixes #357)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -560,6 +560,7 @@ else()
     set(OD_ICON_FULLPATH ${OD_SHARE_PATH}/icons/hicolor/scalable/apps/opendungeons.svg)
 endif()
 configure_file(${CMAKE_CONFIG_DIR}/opendungeons.desktop.in ${CMAKE_BINARY_DIR}/opendungeons.desktop)
+configure_file(${CMAKE_CONFIG_DIR}/opendungeons.6.in ${CMAKE_BINARY_DIR}/opendungeons.6)
 
 ##################################
 ### Run-in-place customisation ###
@@ -609,9 +610,13 @@ if(UNIX)
     install(DIRECTORY ${OD_RESOURCES}
             DESTINATION ${OD_DATA_PATH})
 
-    # Additional distribution content (desktop file, icons, etc.)
+    # Additional distribution content (desktop file, icons, man page, doc)
     install(FILES ${CMAKE_BINARY_DIR}/opendungeons.desktop
             DESTINATION ${OD_SHARE_PATH}/applications)
+    install(FILES ${CMAKE_BINARY_DIR}/opendungeons.6
+            DESTINATION ${OD_SHARE_PATH}/man/man6)
+    install(FILES ${CMAKE_SOURCE_DIR}/{CREDITS,FAQ.txt}
+            DESTINATION ${OD_SHARE_PATH}/doc/${PROJECT_NAME})
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/dist/hicolor
             DESTINATION ${OD_SHARE_PATH}/icons)
 endif()
@@ -622,11 +627,11 @@ endif()
 
 #Not used at the moment, more flexible to do the deb packages manually
 #TODO - set up for making tarballs
-set(CPACK_SOURCE_IGNORE_FILES "~$" "${CMAKE_SOURCE_DIR}.*/.svn/" "${CMAKE_SOURCE_DIR}/debian/")
-set(CPACK_PACKAGE_NAME opendungeons)
-set(CPACK_PACKAGE_VERSION ${${PROJECT_NAME}_MAJOR_VERSION}.${${PROJECT_NAME}_MINOR_VERSION}.${${PROJECT_NAME}_PATCH_LEVEL})
-set(CPACK_PACKAGE_CONTACT OpenDungeons Team)
-set(CPACK_GENERATOR "DEB")
-set(CPACK_SOURCE_GENERATOR "DEB")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libcegui (>= 0.8.3), libois-1.2.0, libsfml-audio2.0, libopenal1, libogremain-1.9.0")
-include(CPack)
+# set(CPACK_SOURCE_IGNORE_FILES "~$" "${CMAKE_SOURCE_DIR}.*/.svn/" "${CMAKE_SOURCE_DIR}/debian/")
+# set(CPACK_PACKAGE_NAME opendungeons)
+# set(CPACK_PACKAGE_VERSION ${${PROJECT_NAME}_MAJOR_VERSION}.${${PROJECT_NAME}_MINOR_VERSION}.${${PROJECT_NAME}_PATCH_LEVEL})
+# set(CPACK_PACKAGE_CONTACT OpenDungeons Team)
+# set(CPACK_GENERATOR "DEB")
+# set(CPACK_SOURCE_GENERATOR "DEB")
+# set(CPACK_DEBIAN_PACKAGE_DEPENDS "libcegui (>= 0.8.3), libois-1.2.0, libsfml-audio2.0, libopenal1, libogremain-1.9.0")
+# include(CPack)

--- a/cmake/config/opendungeons.6.in
+++ b/cmake/config/opendungeons.6.in
@@ -1,0 +1,43 @@
+.\" Process this file with: groff -man -Tlatin1 foo.1
+.\" Please report any issue with this man page at
+.\" https://github.com/OpenDungeons/OpenDungeons/issues
+.TH OPENDUNGEONS 6 "December 2014" Linux
+.SH NAME
+OpenDungeons \- RTS game in dark, damp and dangerous dungeons
+.SH SYNOPSIS
+.B opendungeons
+.SH DESCRIPTION
+OpenDungeons is an open source, real time strategy game sharing game
+elements with the Dungeon Keeper series and Evil Genius. Players build
+an underground dungeon which is inhabited by creatures. Players fight
+each other for control of the underground by indirectly commanding their
+minions, directly casting spells in combat, and luring enemies
+into sinister traps.
+.SH OPTIONS
+As of version 0.4.9, OpenDungeons is configured at startup via the
+OGRE Settings Manager, therefore there are no command-line options.
+.SH FILES
+~/.config/opendungeons/ogre.cfg
+.RS
+User-specific configuration file.
+.RE
+~/.local/share/opendungeons/
+.RS
+Holds logs (opendungeons.log and CEGUI.log), screenshots and replays.
+.RE
+@OD_DATA_PATH@/
+.RS
+Arch-independant game data files
+.RE
+@OD_SHARE_PATH@/doc/opendungeons/
+.RS
+Additional documentation files
+.RE
+.SH BUGS
+OpenDungeons is ongoing steady development and has both known and unnoticed
+bugs. If you encounter a bug, please visit OpenDungeon's issue tracker at
+\fIhttps://github.com/OpenDungeons/OpenDungeons/issues\fR and report it there.
+.SH AUTHOR
+Man page written by Rémi Verschelde <remi@verschelde.fr> on behalf of the
+OpenDungeons development team. Please report any issue to the whole team
+using the bug tracker linked in the \fBBUGS\fR section.


### PR DESCRIPTION
This commit adds a man page to $prefix/share/man/man6/opendungeons.6 ("6" being the category for games man pages).
I added the paths to the installation and doc folders in the man page, so it has to be configured via CMake (that's debatable, I can also drop the mention and make it a static file in dist/).

I also added instructions to install CREDITS and FAQ.txt to the typical doc dir on Linux: $prefix/doc/<name>. I did not install the README since it's aimed at developers (describes the source code and how to compile) and the source is not included in system installations).
