### PR TITLE
Implementation of server side FOW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,7 @@ set(OD_SOURCEFILES
     ${SRC}/camera/SlopeWalk.cpp
 
     ${SRC}/entities/Building.cpp
+    ${SRC}/entities/BuildingObject.cpp
     ${SRC}/entities/ChickenEntity.cpp
     ${SRC}/entities/CraftedTrap.cpp
     ${SRC}/entities/Creature.cpp

--- a/levels/skirmish/TestSingleplayerSmall.level
+++ b/levels/skirmish/TestSingleplayerSmall.level
@@ -35,16 +35,76 @@ ProtectDungeonTemple	NULL
 50 # MapSizeY
 # posX	posY	type	fullness
 0	1	1	0
+0	9	6	100	3
+0	10	6	100	3
+0	11	6	100	3
+0	13	6	0	1
+0	14	6	0	1
+0	18	6	0	1
+0	19	6	100	1
+0	20	6	100	1
+0	21	6	0	1
 1	1	1	0
+1	8	6	100	3
+1	9	6	0	3
+1	10	6	0	3
+1	11	6	0	3
+1	12	6	100	3
+1	13	6	100	1
+1	14	6	100	1
+1	15	6	100	3
+1	16	6	100	3
+1	17	6	100	3
+1	18	6	100	1
+1	19	6	0	3
+1	20	6	0	3
+1	21	6	100	1
+1	22	6	0	1
 1	24	2	100
 1	25	2	100
 2	1	1	0
+2	8	6	100	3
+2	9	6	0	3
+2	10	6	0	3
+2	11	6	0	3
+2	12	6	0	3
+2	13	6	0	3
+2	14	6	0	3
+2	15	6	0	3
+2	16	6	0	3
+2	17	6	0	3
+2	18	6	0	3
+2	19	6	0	3
+2	20	6	0	3
+2	21	6	100	1
+2	22	6	0	1
 2	24	2	100
 2	25	2	100
 3	1	1	0
+3	8	6	100	3
+3	9	6	0	3
+3	10	6	0	3
+3	11	6	0	3
+3	12	6	100	3
+3	13	6	100	3
+3	14	6	100	3
+3	15	6	100	3
+3	16	6	100	3
+3	17	6	100	3
+3	18	6	100	1
+3	19	6	0	3
+3	20	6	0	3
+3	21	6	100	1
+3	22	6	0	1
 3	24	2	100
 3	25	2	100
 4	1	1	0
+4	9	6	100	3
+4	10	6	100	3
+4	11	6	100	3
+4	18	6	0	1
+4	19	6	100	1
+4	20	6	100	1
 4	24	2	100
 4	25	2	100
 5	1	1	0
@@ -53,6 +113,8 @@ ProtectDungeonTemple	NULL
 5	11	1	0
 5	13	1	0
 5	15	1	0
+5	19	6	0	1
+5	20	6	0	1
 5	24	2	100
 5	25	2	100
 6	1	1	0
@@ -724,6 +786,18 @@ ProtectDungeonTemple	NULL
 12	39
 [/Room]
 [Room]
+9	3	9
+1	9
+1	10
+1	11
+2	9
+2	10
+2	11
+3	9
+3	10
+3	11
+[/Room]
+[Room]
 1	3	25
 37	7
 37	8
@@ -932,27 +1006,36 @@ ProtectDungeonTemple	NULL
 [Creatures]
 # SeatId	ClassName	Name	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	PosX	PosY	PosZ	LeftWeapon	RightWeapon
 [Creature]
-1	BigKnight	BigKnight1	1	0	4	100	0	0	7	7	0	Longsword	none
+1	BigKnight	BigKnight1	1	0	10	100	0	0	7	7	0	Longsword	none
 [/Creature]
 [Creature]
-1	Adventurer	Adventurer2	1	0	max	100	0	0	7	8	0	none	SpecialStaff
+1	Adventurer	Adventurer2	1	0	10	100	0	0	7	8	0	none	SpecialStaff
 [/Creature]
 [Creature]
-3	BigDragon	Dragon1	1	0	max	100	0	0	10	4	0	none	none
+2	Adventurer	Adventurer3	1	0	10	100	0	0	7	40	0	none	none
+[/Creature]
+[Creature]
+3	BigDragon	Dragon1	1	0	10	100	0	0	10	4	0	none	none
 [/Creature]
 [Creature]
 3	Tentacle1	Tentacle11	1	0	max	100	0	0	5	15	0	none	none
 [/Creature]
 [Creature]
-3	Tentacle1	Tentacle12	10	0	max	100	0	0	5	11	0	none	none
+3	Tentacle1	Tentacle12	10	0	10	100	0	0	5	11	0	none	none
 [/Creature]
 [Creature]
-3	Tentacle1	Tentacle13	25	0	max	100	0	0	5	13	0	none	none
+3	Tentacle1	Tentacle13	25	0	10	100	0	0	5	13	0	none	none
 [/Creature]
 [Creature]
 3	Tentacle1	Tentacle14	1	0	max	100	0	0	5	9	0	none	none
 [/Creature]
 [Creature]
 3	Tentacle1	Tentacle15	1	0	max	100	0	0	5	7	0	none	none
+[/Creature]
+[Creature]
+3	Kobold	Kobold2	1	0	max	100	0	0	1	19	0	none	none
+[/Creature]
+[Creature]
+3	Orc	Orc3	1	0	0	100	0	0	3	20	0	none	none
 [/Creature]
 [/Creatures]

--- a/source/ODApplication.cpp
+++ b/source/ODApplication.cpp
@@ -235,6 +235,7 @@ For information on how to use a particular command, type help followed by the co
 \n\tfarclip - sets the far clipping distance\
 \n\tvisdebug - turns on visual debugging for a creature\
 \n\tseatvisdebug - turns on visual debugging for a seat\
+\n\ticanseedeadpeople - toggles on/off fog of war for every connected player\
 \n\tsetlevel - sets the level of a given creature\
 \n\tdisconnect - stops a running server or client and returns to the map editor\
 +\n\taithreads - sets the maximum number of creature AI threads on the server\

--- a/source/ai/BaseAI.cpp
+++ b/source/ai/BaseAI.cpp
@@ -52,11 +52,10 @@ Room* BaseAI::getDungeonTemple()
 bool BaseAI::buildRoom(Room* room, const std::vector<Tile*>& tiles)
 {
     room->setupRoom(mGameMap.nextUniqueNameRoom(room->getMeshName()), mPlayer.getSeat(), tiles);
-    mGameMap.addRoom(room, false);
+    mGameMap.addRoom(room);
     room->createMesh();
     room->checkForRoomAbsorbtion();
     room->updateActiveSpots();
-    mGameMap.refreshBorderingTilesOf(tiles);
 
     return true;
 }

--- a/source/entities/Building.h
+++ b/source/entities/Building.h
@@ -51,7 +51,7 @@ public:
 
     virtual ~Building() {}
 
-    Ogre::Vector3 getScale() const;
+    const Ogre::Vector3& getScale() const;
 
     //! \brief Updates the active spot lists. Active spots are places where objects can be added
     virtual void updateActiveSpots() = 0;
@@ -98,7 +98,7 @@ public:
     }
 
     //! \brief Tells whether the building wants the given entity to be brought
-    virtual bool hasCarryEntitySpot(GameEntity* carriedEntity)
+    virtual bool hasCarryEntitySpot(MovableGameEntity* carriedEntity)
     { return false; }
 
     //! \brief Tells where the building wants the given entity to be brought
@@ -106,20 +106,17 @@ public:
     //! the carriedEntity is not wanted anymore (if no free spot for example).
     //! If askSpotForCarriedEntity returns a valid tile, a spot may be booked and in
     //! any case, notifyCarryingStateChanged should be called to release it
-    virtual Tile* askSpotForCarriedEntity(GameEntity* carriedEntity)
+    virtual Tile* askSpotForCarriedEntity(MovableGameEntity* carriedEntity)
     { return nullptr; }
 
     //! \brief Tells whether the carrying state changed. One should check the carrier
     //! tile position to check if it is in the requested Tile. If yes, the carriedEntity
     //! is at the wanted place. If not, it means that the carrier stopped carrying (for
     //! example, if it was killed or picked up during process)
-    virtual void notifyCarryingStateChanged(Creature* carrier, GameEntity* carriedEntity)
+    virtual void notifyCarryingStateChanged(Creature* carrier, MovableGameEntity* carriedEntity)
     {}
 
 protected:
-    virtual void createMeshLocal();
-    virtual void destroyMeshLocal();
-
     std::map<Tile*, RenderedMovableEntity*> mBuildingObjects;
     std::vector<Tile*> mCoveredTiles;
     std::map<Tile*, double> mTileHP;

--- a/source/entities/BuildingObject.cpp
+++ b/source/entities/BuildingObject.cpp
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (C) 2011-2014  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "entities/BuildingObject.h"
+
+#include "network/ODPacket.h"
+
+#include "gamemap/GameMap.h"
+
+#include "traps/TrapBoulder.h"
+#include "traps/TrapCannon.h"
+#include "traps/TrapSpike.h"
+
+#include "utils/Random.h"
+#include "utils/LogManager.h"
+
+#include <iostream>
+
+BuildingObject::BuildingObject(GameMap* gameMap, const std::string& buildingName, const std::string& meshName,
+        const Ogre::Vector3& position, Ogre::Real rotationAngle, bool hideCoveredTile, float opacity) :
+    RenderedMovableEntity(gameMap, buildingName, meshName, rotationAngle, hideCoveredTile, opacity)
+{
+    mPosition = position;
+}
+
+BuildingObject::BuildingObject(GameMap* gameMap) :
+    RenderedMovableEntity(gameMap)
+{
+}
+
+BuildingObject* BuildingObject::getBuildingObjectFromPacket(GameMap* gameMap, ODPacket& is)
+{
+    BuildingObject* obj = new BuildingObject(gameMap);
+    return obj;
+}

--- a/source/entities/BuildingObject.h
+++ b/source/entities/BuildingObject.h
@@ -15,12 +15,10 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef CRAFTEDTRAP_H
-#define CRAFTEDTRAP_H
+#ifndef BUILDINGOBJECT_H
+#define BUILDINGOBJECT_H
 
 #include "entities/RenderedMovableEntity.h"
-
-#include "traps/Trap.h"
 
 #include <string>
 #include <istream>
@@ -32,30 +30,17 @@ class GameMap;
 class Tile;
 class ODPacket;
 
-class CraftedTrap: public RenderedMovableEntity
+class BuildingObject: public RenderedMovableEntity
 {
 public:
-    CraftedTrap(GameMap* gameMap, const std::string& forgeName, Trap::TrapType trapType);
-    CraftedTrap(GameMap* gameMap);
+    BuildingObject(GameMap* gameMap, const std::string& buildingName, const std::string& meshName,
+        const Ogre::Vector3& position, Ogre::Real rotationAngle, bool hideCoveredTile, float opacity = 1.0f);
+    BuildingObject(GameMap* gameMap);
 
     virtual RenderedMovableEntityType getRenderedMovableEntityType()
-    { return RenderedMovableEntityType::craftedTrap; }
+    { return RenderedMovableEntityType::buildingObject; }
 
-    virtual const Ogre::Vector3& getScale() const;
-
-    Trap::TrapType getTrapType() const
-    { return mTrapType; }
-
-    virtual void notifyEntityCarryOn();
-    virtual void notifyEntityCarryOff(const Ogre::Vector3& position);
-
-    static CraftedTrap* getCraftedTrapFromStream(GameMap* gameMap, std::istream& is);
-    static CraftedTrap* getCraftedTrapFromPacket(GameMap* gameMap, ODPacket& is);
-    static const char* getFormat();
-private:
-    Trap::TrapType mTrapType;
-
-    const std::string& getMeshFromTrapType(Trap::TrapType trapType);
+    static BuildingObject* getBuildingObjectFromPacket(GameMap* gameMap, ODPacket& is);
 };
 
-#endif // CRAFTEDTRAP_H
+#endif // BUILDINGOBJECT_H

--- a/source/entities/ChickenEntity.cpp
+++ b/source/entities/ChickenEntity.cpp
@@ -217,6 +217,10 @@ bool ChickenEntity::tryDrop(Seat* seat, Tile* tile, bool isEditorMode)
     if(isEditorMode && (tile->getType() == Tile::dirt || tile->getType() == Tile::gold || tile->getType() == Tile::claimed))
         return true;
 
+    // we cannot drop a chicken on a tile we don't see
+    if(!seat->hasVisionOnTile(tile))
+        return false;
+
     // Otherwise, we allow to drop an object only on allied claimed tiles
     if(tile->getType() == Tile::claimed && tile->getSeat() != NULL && tile->getSeat()->isAlliedSeat(seat))
         return true;

--- a/source/entities/ChickenEntity.h
+++ b/source/entities/ChickenEntity.h
@@ -44,9 +44,7 @@ public:
     virtual bool tryPickup(Seat* seat, bool isEditorMode);
     virtual void pickup();
     virtual bool tryDrop(Seat* seat, Tile* tile, bool isEditorMode);
-    virtual void drop(const Ogre::Vector3& v);
 
-    virtual void setPosition(const Ogre::Vector3& v);
     bool eatChicken(Creature* creature);
 
     bool canSlap(Seat* seat, bool isEditorMode);
@@ -68,7 +66,6 @@ private:
     ChickenState mChickenState;
     int32_t mNbTurnOutsideHatchery;
     int32_t mNbTurnDie;
-    bool mIsDropped;
     bool mIsSlapped;
 
     void addTileToListIfPossible(int x, int y, Room* currentHatchery, std::vector<Tile*>& possibleTileMove);

--- a/source/entities/CraftedTrap.cpp
+++ b/source/entities/CraftedTrap.cpp
@@ -30,9 +30,9 @@
 
 #include <iostream>
 
-const int32_t NB_TURNS_OUTSIDE_HATCHERY_BEFORE_DIE = 30;
-const int32_t NB_TURNS_DIE_BEFORE_REMOVE = 5;
 const std::string EMPTY_STRING;
+
+const Ogre::Vector3 SCALE(0.5,0.5,0.5);
 
 CraftedTrap::CraftedTrap(GameMap* gameMap, const std::string& forgeName, Trap::TrapType trapType) :
     RenderedMovableEntity(gameMap, forgeName, getMeshFromTrapType(trapType), 0.0f, false),
@@ -43,6 +43,11 @@ CraftedTrap::CraftedTrap(GameMap* gameMap, const std::string& forgeName, Trap::T
 CraftedTrap::CraftedTrap(GameMap* gameMap) :
     RenderedMovableEntity(gameMap)
 {
+}
+
+const Ogre::Vector3& CraftedTrap::getScale() const
+{
+    return SCALE;
 }
 
 const std::string& CraftedTrap::getMeshFromTrapType(Trap::TrapType trapType)
@@ -63,39 +68,28 @@ const std::string& CraftedTrap::getMeshFromTrapType(Trap::TrapType trapType)
     return EMPTY_STRING;
 }
 
-void CraftedTrap::setPosition(const Ogre::Vector3& v)
-{
-    Tile* oldTile = getPositionTile();
-    RenderedMovableEntity::setPosition(v);
-    Tile* tile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(tile != nullptr, "entityName=" + getName());
-    if(tile == nullptr)
-        return;
-    if(tile == oldTile)
-        return;
-
-    if(oldTile != nullptr)
-        oldTile->removeCraftedTrap(this);
-
-    OD_ASSERT_TRUE(tile->addCraftedTrap(this));
-}
-
-void CraftedTrap::notifyEntityCarried(bool isCarried)
+void CraftedTrap::notifyEntityCarryOn()
 {
     Tile* myTile = getPositionTile();
     OD_ASSERT_TRUE_MSG(myTile != nullptr, "name=" + getName());
     if(myTile == nullptr)
         return;
-    if(isCarried)
-    {
-        setIsOnMap(false);
-        myTile->removeCraftedTrap(this);
-    }
-    else
-    {
-        setIsOnMap(true);
-        myTile->addCraftedTrap(this);
-    }
+
+    setIsOnMap(false);
+    myTile->removeEntity(this);
+}
+
+void CraftedTrap::notifyEntityCarryOff(const Ogre::Vector3& position)
+{
+    mPosition = position;
+    setIsOnMap(true);
+
+    Tile* myTile = getPositionTile();
+    OD_ASSERT_TRUE_MSG(myTile != nullptr, "name=" + getName());
+    if(myTile == nullptr)
+        return;
+
+    myTile->addEntity(this);
 }
 
 CraftedTrap* CraftedTrap::getCraftedTrapFromStream(GameMap* gameMap, std::istream& is)

--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -414,10 +414,10 @@ Creature* Creature::getCreatureFromPacket(GameMap* gameMap, ODPacket& is)
 
 void Creature::exportToPacket(ODPacket& os) const
 {
-    std::string className = mDefinition->getClassName();
+    const std::string& className = mDefinition->getClassName();
     os << className;
 
-    std::string name = getName();
+    const std::string& name = getName();
     os << name;
 
     int seatId = getSeat()->getId();
@@ -3413,7 +3413,7 @@ void Creature::releaseCarriedEntity()
     if(carriedEntity == nullptr)
         return;
 
-    Ogre::Vector3 pos = getPosition();
+    const Ogre::Vector3& pos = getPosition();
     carriedEntity->notifyEntityCarryOff(pos);
 
     for(Seat* seat : mSeatsWithVisionNotified)
@@ -3584,7 +3584,7 @@ void Creature::fireCreatureSound(CreatureSound::SoundType sound)
             continue;
 
         const std::string& name = getDefinition()->getClassName();
-        Ogre::Vector3 position = getPosition();
+        const Ogre::Vector3& position = getPosition();
         ServerNotification *serverNotification = new ServerNotification(
             ServerNotification::playCreatureSound, seat->getPlayer());
         serverNotification->mPacket << name << sound << position;

--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -3122,6 +3122,10 @@ bool Creature::tryDrop(Seat* seat, Tile* tile, bool isEditorMode)
     if(isEditorMode && canGoThroughTile(tile))
         return true;
 
+    // we cannot drop a creature on a tile we don't see
+    if(!seat->hasVisionOnTile(tile))
+        return false;
+
     // If it is a worker, he can be dropped on dirt
     if (getDefinition()->isWorker() && (tile->getType() == Tile::dirt || tile->getType() == Tile::gold))
         return true;

--- a/source/entities/Creature.h
+++ b/source/entities/Creature.h
@@ -78,7 +78,7 @@ public:
 
     Ogre::Vector2 get2dPosition()
     {
-        Ogre::Vector3 tmp = getPosition();
+        const Ogre::Vector3& tmp = getPosition();
         return Ogre::Vector2(tmp.x,tmp.y);
     }
 

--- a/source/entities/Creature.h
+++ b/source/entities/Creature.h
@@ -116,9 +116,10 @@ public:
     { return mDefinition; }
 
     /*! \brief Changes the creature's position to a new position.
-     *  This is an overloaded function which just calls Creature::setPosition(double x, double y, double z).
+     *  This is an overloaded function which just calls MovableGameEntity::setPosition and
+     *  handles culling.
      */
-    void setPosition(const Ogre::Vector3& v);
+    void setPosition(const Ogre::Vector3& v, bool isMove);
 
     //! \brief Gets the move speed on the current tile.
     virtual double getMoveSpeed() const;
@@ -262,7 +263,8 @@ public:
     //! \brief An accessor to return whether or not the creature has OGRE entities for its visual debugging entities.
     bool getHasVisualDebuggingEntities();
 
-    virtual Ogre::Vector3 getScale() const;
+    virtual const Ogre::Vector3& getScale() const
+    { return mScale; }
 
     //! \FIXME Those functions are lacking parameters to be actually functional
     //! \brief Get the text format of creatures in level files (already spawned at startup).
@@ -271,9 +273,9 @@ public:
 
     static Creature* getCreatureFromStream(GameMap* gameMap, std::istream& is);
     static Creature* getCreatureFromPacket(GameMap* gameMap, ODPacket& is);
-    virtual void exportToPacket(ODPacket& os);
+    virtual void exportToPacket(ODPacket& os) const;
     virtual void importFromPacket(ODPacket& is);
-    virtual void exportToStream(std::ostream& os);
+    virtual void exportToStream(std::ostream& os) const;
     virtual void importFromStream(std::istream& is);
     inline void setQuad(CullingQuad* cq)
     { mTracingCullingQuad = cq; }
@@ -322,20 +324,22 @@ public:
     //! \brief Makes the creature stop eating (releases the hatchery)
     void stopEating();
 
-    //! \brief Play a spatial sound at the creature position of the corresponding type.
-    void playSound(CreatureSound::SoundType soundType);
-
     //! \brief Tells whether the creature can go through the given tile.
     bool canGoThroughTile(const Tile* tile) const;
 
-    virtual void notifyEntityCarried(bool isCarried);
+    virtual void notifyEntityCarryOn();
+    virtual void notifyEntityCarryOff(const Ogre::Vector3& position);
 
     bool canSlap(Seat* seat, bool isEditorMode);
     void slap(bool isEditorMode);
 
+    void fireCreatureSound(CreatureSound::SoundType sound);
+
 protected:
     virtual void createMeshLocal();
     virtual void destroyMeshLocal();
+    virtual void fireAddEntity(Seat* seat, bool async);
+    virtual void fireRemoveEntity(Seat* seat);
 private:
     enum ForceAction
     {
@@ -351,6 +355,8 @@ private:
 
     //! \brief Constructor for sending creatures through network. It should not be used in game.
     Creature(GameMap* gameMap);
+
+    void fireCreatureRefresh();
 
     CullingQuad* mTracingCullingQuad;
 
@@ -432,16 +438,14 @@ private:
     Tile*                           mAttackedTile;
     GameEntity*                     mAttackedObject;
 
-    //! \brief The creature sounds library reference.
-    //! \warning Do not delete it. The pointer in handled in SoundEffectsManager.
-    CreatureSound*                  mSound;
-
     ForceAction                     mForceAction;
 
     bool                            mIsCarryActionTested;
-    GameEntity*                     mCarriedEntity;
+    MovableGameEntity*              mCarriedEntity;
     GameEntity::ObjectType          mCarriedEntityDestType;
     std::string                     mCarriedEntityDestName;
+
+    Ogre::Vector3                   mScale;
 
     void pushAction(CreatureAction action);
     void popAction();
@@ -547,7 +551,7 @@ private:
     //! \brief Restores the creature's stats according to its current level
     void buildStats();
 
-    void carryEntity(GameEntity* carriedEntity);
+    void carryEntity(MovableGameEntity* carriedEntity);
 
     void releaseCarriedEntity();
 };

--- a/source/entities/CreatureDefinition.cpp
+++ b/source/entities/CreatureDefinition.cpp
@@ -57,7 +57,7 @@ std::string CreatureDefinition::creatureJobToString(CreatureJob c)
     }
 }
 
-ODPacket& operator<<(ODPacket& os, CreatureDefinition* c)
+ODPacket& operator<<(ODPacket& os, const CreatureDefinition* c)
 {
     std::string creatureJob = CreatureDefinition::creatureJobToString(c->mCreatureJob);
     os << c->mClassName

--- a/source/entities/CreatureDefinition.h
+++ b/source/entities/CreatureDefinition.h
@@ -128,7 +128,7 @@ public:
     inline bool isWorker() const
     { return (mCreatureJob == Worker); }
 
-    friend ODPacket& operator <<(ODPacket& os, CreatureDefinition *c);
+    friend ODPacket& operator <<(ODPacket& os, const CreatureDefinition *c);
     friend ODPacket& operator >>(ODPacket& is, CreatureDefinition *c);
 
     //! \brief Loads a definition from the creature definition file sub [Creature][/Creature] part

--- a/source/entities/GameEntity.cpp
+++ b/source/entities/GameEntity.cpp
@@ -71,7 +71,7 @@ std::string GameEntity::getNodeNameWithoutPostfix()
 
 Tile* GameEntity::getPositionTile() const
 {
-    Ogre::Vector3 tempPosition = getPosition();
+    const Ogre::Vector3& tempPosition = getPosition();
 
     return getGameMap()->getTile(Helper::round(tempPosition.x),
                                  Helper::round(tempPosition.y));

--- a/source/entities/GameEntity.cpp
+++ b/source/entities/GameEntity.cpp
@@ -64,26 +64,6 @@ void GameEntity::deleteYourself()
     getGameMap()->queueEntityForDeletion(this);
 }
 
-
-void GameEntity::setMeshOpacity(float opacity)
-{
-    if (opacity < 0.0f || opacity > 1.0f)
-        return;
-
-    mOpacity = opacity;
-
-    if(getGameMap()->isServerGameMap())
-    {
-        ServerNotification* serverNotification = new ServerNotification(ServerNotification::setEntityOpacity, nullptr);
-        std::string name = getName();
-        serverNotification->mPacket << getObjectType() << name << opacity;
-        ODServer::getSingleton().queueServerNotification(serverNotification);
-        return;
-    }
-
-    RenderManager::getSingleton().rrUpdateEntityOpacity(this);
-}
-
 std::string GameEntity::getNodeNameWithoutPostfix()
 {
     return getOgreNamePrefix() + getName();

--- a/source/entities/GameEntity.h
+++ b/source/entities/GameEntity.h
@@ -57,11 +57,9 @@ class GameEntity
           GameMap*        gameMap,
           std::string     name       = std::string(),
           std::string     meshName   = std::string(),
-          float           opacity     = 1.0f,
           Seat*           seat        = nullptr
           ) :
     mPosition          (Ogre::Vector3(0, 0, 0)),
-    mOpacity           (opacity),
     mName              (name),
     mMeshName          (meshName),
     mMeshExists        (false),
@@ -97,10 +95,6 @@ class GameEntity
     inline bool isMeshExisting() const
     { return mMeshExists; }
 
-    //! \brief Get if the mesh is already existing
-    inline float getOpacity() const
-    { return mOpacity; }
-
     //! \brief Get if the object can be attacked or not
     virtual bool isAttackable() const
     { return false; }
@@ -122,7 +116,7 @@ class GameEntity
     inline Ogre::SceneNode* getEntityNode() const
     { return mEntityNode; }
 
-    virtual Ogre::Vector3 getScale() const
+    virtual const Ogre::Vector3& getScale() const
     { return Ogre::Vector3::UNIT_SCALE; }
 
     // ===== SETTERS =====
@@ -142,18 +136,14 @@ class GameEntity
     inline void setMeshExisting(bool isExisting)
     { mMeshExists = isExisting; }
 
-    //! \brief Set the entity opacity
-    void setMeshOpacity(float opacity);
-
-    //! \brief Set the entity opacity value whithout refreshing it. Useful at construction.
-    void setOpacity(float opacity)
-    { mOpacity = opacity; }
-
     //! \brief Set the type of the object. Should be done in all final derived constructors
     inline void setObjectType (ObjectType type)
     { mObjectType = type; }
 
-    virtual void setPosition(const Ogre::Vector3& v)
+    //! \brief Set the new entity position. If isMove is true, that means that the entity was
+    //! already on map and is moving. If false, it means that the entity was not on map (for example
+    //! if being dropped or created).
+    virtual void setPosition(const Ogre::Vector3& v, bool isMove)
     { mPosition = v; }
 
     inline void setParentSceneNode(Ogre::SceneNode* sceneNode)
@@ -198,10 +188,6 @@ class GameEntity
     //! the entity damaging
     virtual double takeDamage(GameEntity* attacker, double physicalDamage, double magicalDamage, Tile *tileTakingDamage) = 0;
 
-    //! \brief Called when the entity is being carried
-    virtual void notifyEntityCarried(bool isCarried)
-    {}
-
     virtual bool getIsOnMap()
     { return mIsOnMap; }
 
@@ -230,6 +216,11 @@ class GameEntity
     virtual void drop(const Ogre::Vector3& v)
     {}
 
+    //! \brief Called each turn with the list of seats that have vision on the tile where the entity is. It should handle
+    //! messages to notify players that gain/loose vision
+    virtual void notifySeatsWithVision(const std::vector<Seat*>& seats)
+    {}
+
     friend ODPacket& operator<<(ODPacket& os, const GameEntity::ObjectType& ot);
     friend ODPacket& operator>>(ODPacket& is, GameEntity::ObjectType& ot);
 
@@ -242,9 +233,6 @@ class GameEntity
 
     //! \brief The position of this object
     Ogre::Vector3 mPosition;
-
-    //! \brief The model current opacity
-    float mOpacity;
 
     //! \brief Convinience function to get ogreNamePrefix + name
     //! Used for nodes. The name does not include the _node and similar postfixes which are

--- a/source/entities/GameEntity.h
+++ b/source/entities/GameEntity.h
@@ -107,7 +107,7 @@ class GameEntity
     inline GameMap* getGameMap() const
     { return mGameMap; }
 
-    virtual Ogre::Vector3 getPosition() const
+    virtual const Ogre::Vector3& getPosition() const
     { return mPosition; }
 
     inline Ogre::SceneNode* getParentSceneNode() const

--- a/source/entities/MapLight.cpp
+++ b/source/entities/MapLight.cpp
@@ -32,7 +32,7 @@ const std::string MapLight::MAPLIGHT_INDICATOR_PREFIX = "MapLightIndicator_";
 
 MapLight::MapLight(GameMap* gameMap, Ogre::Real red, Ogre::Real green, Ogre::Real blue,
         Ogre::Real range, Ogre::Real constant, Ogre::Real linear, Ogre::Real quadratic) :
-    MovableGameEntity                   (gameMap),
+    MovableGameEntity                   (gameMap, 1.0f),
     mThetaX                             (0.0),
     mThetaY                             (0.0),
     mThetaZ                             (0.0),

--- a/source/entities/MapLight.cpp
+++ b/source/entities/MapLight.cpp
@@ -100,6 +100,8 @@ std::string MapLight::getFormat()
 
 ODPacket& operator<<(ODPacket& os, MapLight* m)
 {
+    const std::string& name = m->getName();
+    os << name;
     os << m->mPosition.x << m->mPosition.y << m->mPosition.z;
     os << m->mDiffuseColor.r << m->mDiffuseColor.g << m->mDiffuseColor.b;
     os << m->mSpecularColor.r << m->mSpecularColor.g << m->mSpecularColor.b;
@@ -111,6 +113,9 @@ ODPacket& operator<<(ODPacket& os, MapLight* m)
 
 ODPacket& operator>>(ODPacket& is, MapLight* m)
 {
+    std::string name;
+    is >> name;
+    m->setName(name);
     is >> m->mPosition.x >> m->mPosition.y >> m->mPosition.z;
     is >> m->mDiffuseColor.r >> m->mDiffuseColor.g >> m->mDiffuseColor.b;
     is >> m->mSpecularColor.r >> m->mSpecularColor.g >> m->mSpecularColor.b;

--- a/source/entities/MapLight.h
+++ b/source/entities/MapLight.h
@@ -94,6 +94,14 @@ public:
      */
     void update(Ogre::Real timeSinceLastFrame);
 
+    //! \brief For now, MapLights are sent by the server during map initialization. There is
+    //! no need to remove/add them. If we want to add MapLights on claimed tiles, we
+    //! should consider letting notifySeatsWithVision default behaviour or, even better, create
+    //! another class
+    void notifySeatsWithVision(const std::vector<Seat*>& seats)
+    {}
+
+    void fireAddEntityToAll();
 
     static std::string getFormat();
     friend ODPacket& operator<<(ODPacket& os, MapLight *m);
@@ -107,6 +115,11 @@ public:
 protected:
     virtual void createMeshLocal();
     virtual void destroyMeshLocal();
+    //! MapLights are sent by the server during map initialization. Nothing more to do
+    virtual void fireAddEntity(Seat* seat, bool async)
+    {}
+    virtual void fireRemoveEntity(Seat* seat)
+    {}
 
 private:
     Ogre::ColourValue mDiffuseColor;

--- a/source/entities/RenderedMovableEntity.h
+++ b/source/entities/RenderedMovableEntity.h
@@ -58,8 +58,7 @@ public:
     virtual void doUpkeep()
     {}
 
-    virtual Ogre::Vector3 getScale() const
-    { return Ogre::Vector3(0.7,0.7,0.7); }
+    virtual const Ogre::Vector3& getScale() const;
 
     void receiveExp(double experience)
     {}
@@ -76,8 +75,7 @@ public:
     Ogre::Real getRotationAngle() const
     { return mRotationAngle; }
 
-    virtual RenderedMovableEntityType getRenderedMovableEntityType()
-    { return RenderedMovableEntityType::buildingObject; }
+    virtual RenderedMovableEntityType getRenderedMovableEntityType() = 0;
 
     virtual void pickup();
     virtual void drop(const Ogre::Vector3& v);
@@ -90,9 +88,9 @@ public:
     virtual void exportHeadersToStream(std::ostream& os);
     virtual void exportHeadersToPacket(ODPacket& os);
     //! \brief Exports the data of the RenderedMovableEntity
-    virtual void exportToStream(std::ostream& os);
+    virtual void exportToStream(std::ostream& os) const;
     virtual void importFromStream(std::istream& is);
-    virtual void exportToPacket(ODPacket& os);
+    virtual void exportToPacket(ODPacket& os) const;
     virtual void importFromPacket(ODPacket& is);
 
     static RenderedMovableEntity* getRenderedMovableEntityFromLine(GameMap* gameMap, const std::string& line);
@@ -107,7 +105,10 @@ public:
 protected:
     virtual void createMeshLocal();
     virtual void destroyMeshLocal();
+    virtual void fireAddEntity(Seat* seat, bool async);
+    virtual void fireRemoveEntity(Seat* seat);
 private:
+    std::vector<Seat*> mSeatsWithVisionNotified;
     Ogre::Real mRotationAngle;
     bool mHideCoveredTile;
 };

--- a/source/entities/Tile.cpp
+++ b/source/entities/Tile.cpp
@@ -1426,6 +1426,15 @@ Trap* Tile::getCoveringTrap() const
 
 void Tile::computeVisibleTiles()
 {
+    if(!getGameMap()->getIsFOWActivated())
+    {
+        // If the FOW is deactivated, we allow vision for every seat
+        for(Seat* seat : getGameMap()->getSeats())
+            notifyVision(seat);
+
+        return;
+    }
+
     if(type != claimed)
         return;
 

--- a/source/entities/Tile.cpp
+++ b/source/entities/Tile.cpp
@@ -64,7 +64,8 @@ Tile::Tile(GameMap* gameMap, int nX, int nY, TileType nType, double nFullness) :
     mCoveringBuilding   (nullptr),
     mClaimedPercentage  (0.0),
     mScale              (Ogre::Vector3::ZERO),
-    mIsBuilding         (false)
+    mIsBuilding         (false),
+    mLocalPlayerHasVision   (false)
 {
     for(int i = 0; i < Tile::FloodFillTypeMax; i++)
     {

--- a/source/entities/Tile.h
+++ b/source/entities/Tile.h
@@ -146,6 +146,9 @@ public:
     bool getSelected() const
     { return selected; }
 
+    bool getIsBuilding() const
+    { return mIsBuilding; }
+
     //! \brief Set the tile digging mark for the given player.
     void setMarkedForDigging(bool s, Player *p);
 
@@ -331,6 +334,7 @@ private:
     int mFloodFillColor[FloodFillTypeMax];
     double mClaimedPercentage;
     Ogre::Vector3 mScale;
+    bool mIsBuilding;
 
     /*! \brief Set the fullness value for the tile.
      *  This only sets the fullness variable. This function is here to change the value

--- a/source/entities/Tile.h
+++ b/source/entities/Tile.h
@@ -39,6 +39,7 @@ class Trap;
 class TreasuryObject;
 class ChickenEntity;
 class CraftedTrap;
+class BuildingObject;
 class ODPacket;
 
 /*! \brief The tile class contains information about tile type and contents and is the basic level bulding block.
@@ -67,25 +68,7 @@ public:
         claimed = 6
     };
 
-    Tile(GameMap* gameMap, int nX = 0, int nY = 0, TileType nType = dirt, double nFullness = 100.0) :
-        GameEntity          (gameMap),
-        x                   (nX),
-        y                   (nY),
-        rotation            (0.0),
-        type                (nType),
-        selected            (false),
-        fullness            (nFullness),
-        fullnessMeshNumber  (-1),
-        mCoveringBuilding   (nullptr),
-        mClaimedPercentage  (0.0)
-    {
-        for(int i = 0; i < Tile::FloodFillTypeMax; i++)
-        {
-            mFloodFillColor[i] = -1;
-        }
-        setSeat(NULL);
-        setObjectType(GameEntity::tile);
-    }
+    Tile(GameMap* gameMap, int nX = 0, int nY = 0, TileType nType = dirt, double nFullness = 100.0);
 
     std::string getOgreNamePrefix() const { return "Tile_"; }
 
@@ -153,16 +136,15 @@ public:
     //! \brief This function puts a message in the renderQueue to change the mesh for this tile.
     void refreshMesh();
 
-    virtual Ogre::Vector3 getScale() const;
+    virtual const Ogre::Vector3& getScale() const
+    { return mScale; }
 
     //! \brief This function marks the tile as being selected through a mouse click or drag.
     void setSelected(bool ss, Player *pp);
 
     //! \brief This accessor function returns whether or not the tile has been selected.
     bool getSelected() const
-    {
-        return selected;
-    }
+    { return selected; }
 
     //! \brief Set the tile digging mark for the given player.
     void setMarkedForDigging(bool s, Player *p);
@@ -184,11 +166,11 @@ public:
     unsigned numPlayersMarkingTile() const;
     Player* getPlayerMarkingTile(int index);
 
-    //! \brief This function adds a creature to the list of creatures in this tile.
-    bool addCreature(Creature *c);
+    //! \brief This function adds an entity to the list of entities in this tile.
+    bool addEntity(GameEntity *entity);
 
-    //! \brief This function removes a creature to the list of creatures in this tile.
-    bool removeCreature(Creature *c);
+    //! \brief This function removes an entity to the list of entities in this tile.
+    bool removeEntity(GameEntity *entity);
 
     //! \brief This function returns the count of the number of creatures in the tile.
     unsigned int numEntitiesInTile() const
@@ -215,7 +197,6 @@ public:
     void setCoveringBuilding(Building *building);
     //! \brief Add a tresaury object in this tile. There can be only one per tile so if there is already one, they are merged
     bool addTreasuryObject(TreasuryObject* object);
-    bool removeTreasuryObject(TreasuryObject* object);
 
     //! \brief Tells whether the tile is diggable by dig-capable creatures.
     //! \brief The player seat.
@@ -302,19 +283,20 @@ public:
     void fillWithAttackableCreatures(std::vector<GameEntity*>& entities, Seat* seat, bool invert);
     void fillWithAttackableRoom(std::vector<GameEntity*>& entities, Seat* seat, bool invert);
     void fillWithAttackableTrap(std::vector<GameEntity*>& entities, Seat* seat, bool invert);
-    void fillWithCarryableEntities(std::vector<GameEntity*>& entities);
+    void fillWithCarryableEntities(std::vector<MovableGameEntity*>& entities);
     void fillWithChickenEntities(std::vector<GameEntity*>& entities);
     void fillWithCraftedTraps(std::vector<GameEntity*>& entities);
 
-    bool addChickenEntity(ChickenEntity* chicken);
-    bool removeChickenEntity(ChickenEntity* chicken);
-
-    bool addCraftedTrap(CraftedTrap* craftedTrap);
-    bool removeCraftedTrap(CraftedTrap* craftedTrap);
-
     //! \brief Computes the visible tiles and tags them to know which are visible
     void computeVisibleTiles();
+    void clearVision();
     void notifyVision(Seat* seat);
+
+    void setSeats(const std::vector<Seat*>& seats);
+    bool hasChangedForSeat(Seat* seat) const;
+    void changeNotifiedForSeat(Seat* seat);
+
+    virtual void notifySeatsWithVision();
 
 protected:
     virtual void createMeshLocal();
@@ -339,6 +321,8 @@ private:
 
     std::vector<Tile*> mNeighbors;
     std::vector<Player*> mPlayersMarkingTile;
+    std::vector<std::pair<Seat*, bool>> mTileChangedForSeats;
+    std::vector<Seat*> mSeatsWithVision;
 
     /*! \brief List of the entities actually on this tile. Most of the creatures actions will rely on this list
      */
@@ -346,6 +330,7 @@ private:
     Building* mCoveringBuilding;
     int mFloodFillColor[FloodFillTypeMax];
     double mClaimedPercentage;
+    Ogre::Vector3 mScale;
 
     /*! \brief Set the fullness value for the tile.
      *  This only sets the fullness variable. This function is here to change the value
@@ -354,6 +339,8 @@ private:
     void setFullnessValue(double f);
 
     int getFloodFill(FloodFillType type);
+
+    void setDirtyForAllSeats();
 };
 
 #endif // TILE_H

--- a/source/entities/Tile.h
+++ b/source/entities/Tile.h
@@ -146,8 +146,14 @@ public:
     bool getSelected() const
     { return selected; }
 
-    bool getIsBuilding() const
+    inline bool getIsBuilding() const
     { return mIsBuilding; }
+
+    inline void setLocalPlayerHasVision(bool localPlayerHasVision)
+    { mLocalPlayerHasVision = localPlayerHasVision; }
+
+    inline bool getLocalPlayerHasVision() const
+    { return mLocalPlayerHasVision; }
 
     //! \brief Set the tile digging mark for the given player.
     void setMarkedForDigging(bool s, Player *p);
@@ -338,6 +344,9 @@ private:
     //! true if a building is on this tile. False otherwise. It is used on client side because the clients do not know about
     //! buildings. However, it needs to know the tiles where a building is to display the room/trap costs.
     bool mIsBuilding;
+
+    //! Used on client side. true if the local player has vision, false otherwise.
+    bool mLocalPlayerHasVision;
 
     /*! \brief Set the fullness value for the tile.
      *  This only sets the fullness variable. This function is here to change the value

--- a/source/entities/Tile.h
+++ b/source/entities/Tile.h
@@ -235,19 +235,17 @@ public:
 
     friend std::ostream& operator<<(std::ostream& os, Tile *t);
 
-    /*! \brief The << operator is used for saving tiles to a file and sending them over the net.
-     *
-     * This operator is used in conjunction with the >> operator to standardize
-     * tile format in the level files, as well as sending tiles over the network.
+    /*! \brief Exports the tile data to the packet so that the client associated to the seat have the needed information
+     *         to display the tile correctly
      */
-    friend ODPacket& operator<<(ODPacket& os, Tile *t);
+    void exportToPacket(ODPacket& os, Seat* seat);
 
-    /*! \brief The >> operator is used for loading tiles from a file and for receiving them over the net.
-     *
-     * This operator is used in conjunction with the << operator to standardize
-     * tile format in the level files, as well as sending tiles over the network.
+    /*! \brief Updates the tile from the data sent by the server so that it is correctly displayed and used
      */
-    friend ODPacket& operator>>(ODPacket& is, Tile *t);
+     void updateFromPacket(ODPacket& is);
+
+    friend ODPacket& operator<<(ODPacket& os, const Tile::TileType& rot);
+    friend ODPacket& operator>>(ODPacket& is, Tile::TileType& rot);
 
     /*! \brief This is a helper function which just converts the tile type enum into a string.
      *
@@ -283,7 +281,6 @@ public:
     { return 0.0; }
     double getHP(Tile *tile) const {return 0;}
     std::vector<Tile*> getCoveredTiles() { return std::vector<Tile*>() ;}
-    void refreshFromTile(const Tile& tile);
 
     //! \brief Fills entities with all the attackable creatures in the Tile. If invert is true,
     //! the list will be filled with the ennemies with the given seat. If invert is false, it will be filled
@@ -347,6 +344,9 @@ private:
 
     //! Used on client side. true if the local player has vision, false otherwise.
     bool mLocalPlayerHasVision;
+
+    //! Used on client side. Set when a tile is refreshed. It allows to know if the tile can be marked for digging by the local player
+    bool mLocalPlayerCanMarkTile;
 
     /*! \brief Set the fullness value for the tile.
      *  This only sets the fullness variable. This function is here to change the value

--- a/source/entities/Tile.h
+++ b/source/entities/Tile.h
@@ -334,6 +334,9 @@ private:
     int mFloodFillColor[FloodFillTypeMax];
     double mClaimedPercentage;
     Ogre::Vector3 mScale;
+
+    //! true if a building is on this tile. False otherwise. It is used on client side because the clients do not know about
+    //! buildings. However, it needs to know the tiles where a building is to display the room/trap costs.
     bool mIsBuilding;
 
     /*! \brief Set the fullness value for the tile.

--- a/source/entities/TreasuryObject.cpp
+++ b/source/entities/TreasuryObject.cpp
@@ -119,6 +119,10 @@ bool TreasuryObject::tryDrop(Seat* seat, Tile* tile, bool isEditorMode)
     if(isEditorMode && (tile->getType() == Tile::dirt || tile->getType() == Tile::gold || tile->getType() == Tile::claimed))
         return true;
 
+    // we cannot drop an object on a tile we don't see
+    if(!seat->hasVisionOnTile(tile))
+        return false;
+
     // Otherwise, we allow to drop an object only on allied claimed tiles
     if(tile->getType() == Tile::claimed && tile->getSeat() != NULL && tile->getSeat()->isAlliedSeat(seat))
         return true;

--- a/source/entities/TreasuryObject.cpp
+++ b/source/entities/TreasuryObject.cpp
@@ -72,7 +72,7 @@ void TreasuryObject::doUpkeep()
     // If we are empty, we can remove safely
     if(mGoldValue <= 0)
     {
-        tile->removeTreasuryObject(this);
+        tile->removeEntity(this);
         getGameMap()->removeRenderedMovableEntity(this);
         deleteYourself();
     }
@@ -107,7 +107,7 @@ void TreasuryObject::pickup()
     if(tile == nullptr)
         return;
 
-    tile->removeTreasuryObject(this);
+    tile->removeEntity(this);
 }
 
 bool TreasuryObject::tryDrop(Seat* seat, Tile* tile, bool isEditorMode)
@@ -126,34 +126,38 @@ bool TreasuryObject::tryDrop(Seat* seat, Tile* tile, bool isEditorMode)
     return false;
 }
 
-void TreasuryObject::setPosition(const Ogre::Vector3& v)
+bool TreasuryObject::addEntityToTile(Tile* tile)
 {
-    RenderedMovableEntity::setPosition(v);
-    Tile* tile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(tile != nullptr, "entityName=" + getName());
-    if(tile == nullptr)
-        return;
-
-    tile->addTreasuryObject(this);
-
+    return tile->addTreasuryObject(this);
 }
 
-void TreasuryObject::notifyEntityCarried(bool isCarried)
+bool TreasuryObject::removeEntityFromTile(Tile* tile)
+{
+    return tile->removeEntity(this);
+}
+
+void TreasuryObject::notifyEntityCarryOn()
 {
     Tile* myTile = getPositionTile();
     OD_ASSERT_TRUE_MSG(myTile != nullptr, "name=" + getName());
     if(myTile == nullptr)
         return;
-    if(isCarried)
-    {
-        setIsOnMap(false);
-        myTile->removeTreasuryObject(this);
-    }
-    else
-    {
-        setIsOnMap(true);
-        myTile->addTreasuryObject(this);
-    }
+
+    setIsOnMap(false);
+    myTile->removeEntity(this);
+}
+
+void TreasuryObject::notifyEntityCarryOff(const Ogre::Vector3& position)
+{
+    mPosition = position;
+    setIsOnMap(true);
+
+    Tile* myTile = getPositionTile();
+    OD_ASSERT_TRUE_MSG(myTile != nullptr, "name=" + getName());
+    if(myTile == nullptr)
+        return;
+
+    myTile->addTreasuryObject(this);
 }
 
 const char* TreasuryObject::getFormat()
@@ -174,7 +178,7 @@ TreasuryObject* TreasuryObject::getTreasuryObjectFromPacket(GameMap* gameMap, OD
     return obj;
 }
 
-void TreasuryObject::exportToPacket(ODPacket& os)
+void TreasuryObject::exportToPacket(ODPacket& os) const
 {
     RenderedMovableEntity::exportToPacket(os);
     os << mGoldValue;
@@ -186,7 +190,7 @@ void TreasuryObject::importFromPacket(ODPacket& is)
     OD_ASSERT_TRUE(is >> mGoldValue);
 }
 
-void TreasuryObject::exportToStream(std::ostream& os)
+void TreasuryObject::exportToStream(std::ostream& os) const
 {
     RenderedMovableEntity::exportToStream(os);
     os << mGoldValue << "\t";

--- a/source/entities/TreasuryObject.h
+++ b/source/entities/TreasuryObject.h
@@ -44,19 +44,23 @@ public:
     void mergeGold(TreasuryObject* obj);
     void addGold(int goldValue);
 
-    virtual void exportToStream(std::ostream& os);
+    virtual void exportToStream(std::ostream& os) const;
     virtual void importFromStream(std::istream& is);
-    virtual void exportToPacket(ODPacket& os);
+    virtual void exportToPacket(ODPacket& os) const;
     virtual void importFromPacket(ODPacket& is);
 
     virtual void pickup();
-    virtual void setPosition(const Ogre::Vector3& v);
 
-    virtual void notifyEntityCarried(bool isCarried);
+    virtual void notifyEntityCarryOn();
+    virtual void notifyEntityCarryOff(const Ogre::Vector3& position);
 
     static const char* getFormat();
     static TreasuryObject* getTreasuryObjectFromStream(GameMap* gameMap, std::istream& is);
     static TreasuryObject* getTreasuryObjectFromPacket(GameMap* gameMap, ODPacket& is);
+protected:
+    virtual bool addEntityToTile(Tile* tile);
+    virtual bool removeEntityFromTile(Tile* tile);
+
 private:
     int mGoldValue;
 };

--- a/source/entities/Weapon.cpp
+++ b/source/entities/Weapon.cpp
@@ -17,6 +17,8 @@
 
 #include "entities/Weapon.h"
 
+#include "network/ODPacket.h"
+
 #include "utils/ConfigManager.h"
 #include "utils/Helper.h"
 #include "utils/LogManager.h"
@@ -182,4 +184,30 @@ void Weapon::writeWeaponDiff(const Weapon* def1, const Weapon* def2, std::ofstre
 
     file << "    [/Stats]" << std::endl;
     file << "[/Equipment]" << std::endl;
+}
+
+ODPacket& operator <<(ODPacket& os, const Weapon *weapon)
+{
+    os << weapon->mName;
+    os << weapon->mBaseDefinition;
+    os << weapon->mMeshName;
+    os << weapon->mPhysicalDamage;
+    os << weapon->mMagicalDamage;
+    os << weapon->mRange;
+    os << weapon->mPhysicalDefense;
+    os << weapon->mMagicalDefense;
+    return os;
+}
+
+ODPacket& operator >>(ODPacket& is, Weapon *weapon)
+{
+    OD_ASSERT_TRUE(is >> weapon->mName);
+    OD_ASSERT_TRUE(is >> weapon->mBaseDefinition);
+    OD_ASSERT_TRUE(is >> weapon->mMeshName);
+    OD_ASSERT_TRUE(is >> weapon->mPhysicalDamage);
+    OD_ASSERT_TRUE(is >> weapon->mMagicalDamage);
+    OD_ASSERT_TRUE(is >> weapon->mRange);
+    OD_ASSERT_TRUE(is >> weapon->mPhysicalDefense);
+    OD_ASSERT_TRUE(is >> weapon->mMagicalDefense);
+    return is;
 }

--- a/source/entities/Weapon.h
+++ b/source/entities/Weapon.h
@@ -28,6 +28,7 @@ class WeaponDefinition;
 
 class Weapon
 {
+    friend class ODClient;
 public:
     Weapon(const std::string& name) :
        mName(name),
@@ -73,6 +74,9 @@ public:
 
     inline double getMagicalDefense() const
     { return mMagicalDefense; }
+
+    friend ODPacket& operator <<(ODPacket& os, const Weapon *weapon);
+    friend ODPacket& operator >>(ODPacket& is, Weapon *weapon);
 
 private:
     Weapon() :

--- a/source/game/Player.h
+++ b/source/game/Player.h
@@ -82,13 +82,13 @@ public:
      * hand is false we just hide the creature (and stop its AI, etc.), rather than
      * making it follow the cursor.
      */
-    void pickUpEntity(GameEntity *entity, bool isEditorMode);
+    void pickUpEntity(MovableGameEntity *entity, bool isEditorMode);
 
     //! \brief Check to see the first object in hand can be dropped on Tile t and do so if possible.
     bool isDropHandPossible(Tile *t, unsigned int index = 0, bool isEditorMode = false);
 
     //! \brief Drops the creature on tile t. Returns the dropped creature
-    GameEntity* dropHand(Tile *t, unsigned int index = 0);
+    MovableGameEntity* dropHand(Tile *t, unsigned int index = 0);
 
     void rotateHand(int n);
 
@@ -104,7 +104,7 @@ public:
     inline void setIsHuman(bool isHuman)
     { mIsHuman = isHuman; }
 
-    inline const std::vector<GameEntity*>& getObjectsInHand()
+    inline const std::vector<MovableGameEntity*>& getObjectsInHand()
     { return mObjectsInHand; }
 
     inline const Room::RoomType getNewRoomType()
@@ -149,7 +149,7 @@ private:
     std::string mNickname;
 
     //! \brief The creature the player has got in hand.
-    std::vector<GameEntity*> mObjectsInHand;
+    std::vector<MovableGameEntity*> mObjectsInHand;
 
     //! True: player is human. False: player is a computer/inactive.
     bool mIsHuman;
@@ -166,7 +166,7 @@ private:
     //! \brief A simple mutator function to put the given entity into the player's hand,
     //! note this should NOT be called directly for creatures on the map,
     //! for that you should use the correct function like pickUpEntity() instead.
-    void addEntityToHand(GameEntity *entity);
+    void addEntityToHand(MovableGameEntity *entity);
 };
 
 #endif // PLAYER_H

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -422,7 +422,8 @@ void Seat::notifyChangedVisibleTiles()
     serverNotification->mPacket << nbTiles;
     for(Tile* tile : tilesToNotify)
     {
-        serverNotification->mPacket << tile;
+        mGameMap->tileToPacket(serverNotification->mPacket, tile);
+        tile->exportToPacket(serverNotification->mPacket, this);
     }
     ODServer::getSingleton().queueServerNotification(serverNotification);
 }

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -53,6 +53,7 @@ Seat::Seat(GameMap* gameMap) :
     mHasGoalsChanged(true),
     mGold(0),
     mId(-1),
+    mNbTreasuries(0),
     mIsDebuggingVision(false)
 {
 }
@@ -500,6 +501,14 @@ void Seat::displaySeatVisualDebug(bool enable)
     }
 }
 
+void Seat::computeSeatBeforeSendingToClient()
+{
+    if(mPlayer != nullptr)
+    {
+        mNbTreasuries = mGameMap->numRoomsByTypeAndSeat(Room::treasury, this);
+    }
+}
+
 std::string Seat::getFormat()
 {
     return "seatId\tteamId\tplayer\tfaction\tstartingX\tstartingY\tcolor\tstartingGold";
@@ -512,6 +521,7 @@ ODPacket& operator<<(ODPacket& os, Seat *s)
     os << s->mColorId;
     os << s->mGold << s->mMana << s->mManaDelta << s->mNumClaimedTiles;
     os << s->mHasGoalsChanged;
+    os << s->mNbTreasuries;
     uint32_t nb = s->mAvailableTeamIds.size();
     os << nb;
     for(int teamId : s->mAvailableTeamIds)
@@ -527,6 +537,7 @@ ODPacket& operator>>(ODPacket& is, Seat *s)
     is >> s->mColorId;
     is >> s->mGold >> s->mMana >> s->mManaDelta >> s->mNumClaimedTiles;
     is >> s->mHasGoalsChanged;
+    is >> s->mNbTreasuries;
     s->mColorValue = ConfigManager::getSingleton().getColorFromId(s->mColorId);
     uint32_t nb;
     is >> nb;
@@ -580,6 +591,7 @@ void Seat::refreshFromSeat(Seat* s)
     mManaDelta = s->mManaDelta;
     mNumClaimedTiles = s->mNumClaimedTiles;
     mHasGoalsChanged = s->mHasGoalsChanged;
+    mNbTreasuries = s->mNbTreasuries;
 }
 
 bool Seat::sortForMapSave(Seat* s1, Seat* s2)

--- a/source/game/Seat.h
+++ b/source/game/Seat.h
@@ -155,6 +155,8 @@ public:
 
     void setPlayer(Player* player);
 
+    void addAlliedSeat(Seat* seat);
+
     void initSpawnPool();
 
     const CreatureDefinition* getNextCreatureClassToSpawn();
@@ -175,12 +177,19 @@ public:
     //! \brief Returns true if this seat can see the given tile and false otherwise
     bool hasVisionOnTile(Tile* tile);
 
+    //! \brief Checks if the visible tiles seen by this seat have changed and notify
+    //! the players if yes
+    void notifyChangedVisibleTiles();
+
     //! \brief Server side to display the tile this seat has vision on
     void displaySeatVisualDebug(bool enable);
 
     //! \brief Client side to display the tile this seat has vision on
     void refreshVisualDebugEntities(const std::vector<Tile*>& tiles);
     void stopVisualDebugEntities();
+
+    const std::vector<Seat*>& getAlliedSeats()
+    { return mAlliedSeats; }
 
     static bool sortForMapSave(Seat* s1, Seat* s2);
 
@@ -249,6 +258,9 @@ private:
 
     //! \brief Team ids this seat can use defined in the level file.
     std::vector<int> mAvailableTeamIds;
+
+    //! \brief Contains all the seats allied with the current one, not including it. Used on server side only.
+    std::vector<Seat*> mAlliedSeats;
 
     //! \brief The creatures the current seat is allowed to spawn (when following the conditions). CreatureDefinition
     //! are managed by the configuration manager and should NOT be deleted. The boolean will be set to false at beginning

--- a/source/game/Seat.h
+++ b/source/game/Seat.h
@@ -187,6 +187,9 @@ public:
     //! \brief Server side to display the tile this seat has vision on
     void displaySeatVisualDebug(bool enable);
 
+    //! Sends a message to the player on this seat to refresh the list of tiles he has vision on
+    void sendVisibleTiles();
+
     //! \brief Client side to display the tile this seat has vision on
     void refreshVisualDebugEntities(const std::vector<Tile*>& tiles);
     void stopVisualDebugEntities();
@@ -273,6 +276,7 @@ private:
     std::vector<std::pair<const CreatureDefinition*, bool> > mSpawnPool;
 
     //! \brief List of the tiles this seat has vision on
+    std::vector<Tile*> mTilesWithVisionLast;
     std::vector<Tile*> mTilesWithVision;
     std::vector<Tile*> mVisualDebugEntityTiles;
 

--- a/source/game/Seat.h
+++ b/source/game/Seat.h
@@ -147,6 +147,9 @@ public:
     inline bool getIsDebuggingVision()
     { return mIsDebuggingVision; }
 
+    inline int getNbTreasuries() const
+    { return mNbTreasuries; }
+
     const std::string& getPlayerType() const
     { return mPlayerType; }
 
@@ -190,6 +193,8 @@ public:
 
     const std::vector<Seat*>& getAlliedSeats()
     { return mAlliedSeats; }
+
+    void computeSeatBeforeSendingToClient();
 
     static bool sortForMapSave(Seat* s1, Seat* s2);
 
@@ -281,6 +286,9 @@ private:
 
     //! \brief The seat id. Allows to identify this seat. Must be unique per level file.
     int mId;
+
+    //! \brief The number of treasuries the player owns. Useful to display the first free tile on client side.
+    int mNbTreasuries;
 
     bool mIsDebuggingVision;
 };

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -1156,6 +1156,10 @@ unsigned long int GameMap::doMiscUpkeep()
         seat->displaySeatVisualDebug(true);
     }
 
+    // We send to each seat the list of tiles he has vision on
+    for (Seat* seat : mSeats)
+        seat->sendVisibleTiles();
+
     // Carry out the upkeep round of all the active objects in the game.
     unsigned int activeObjectCount = 0;
     unsigned int nbActiveObjectCount = mActiveObjects.size();

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -206,7 +206,6 @@ bool GameMap::createNewMap(int sizeX, int sizeY)
         {
             Tile* tile = new Tile(this, ii, jj);
             tile->setName(Tile::buildName(ii, jj));
-            tile->setFullness(tile->getFullness());
             tile->setType(Tile::dirt);
             addTile(tile);
         }
@@ -279,6 +278,10 @@ void GameMap::clearClasses()
     {
         if(def.second != nullptr)
             delete def.second;
+
+        // On client side, classes are sent by network so they should be deleted
+        if(!isServerGameMap())
+            delete def.first;
     }
     mClassDescriptions.clear();
 }
@@ -289,6 +292,10 @@ void GameMap::clearWeapons()
     {
         if(def.second != nullptr)
             delete def.second;
+
+        // On client side, weapons are sent by network so they should be deleted
+        if(!isServerGameMap())
+            delete def.first;
     }
     mWeapons.clear();
 }
@@ -339,6 +346,19 @@ void GameMap::addClassDescription(const CreatureDefinition *c)
 void GameMap::addWeapon(const Weapon* weapon)
 {
     mWeapons.push_back(std::pair<const Weapon*,Weapon*>(weapon, nullptr));
+}
+
+const Weapon* GameMap::getWeapon(int index)
+{
+    OD_ASSERT_TRUE_MSG(index < static_cast<int>(mWeapons.size()), "index=" + Ogre::StringConverter::toString(index));
+    if(index >= static_cast<int>(mWeapons.size()))
+        return nullptr;
+
+    std::pair<const Weapon*,Weapon*>& def = mWeapons[index];
+    if(def.second != nullptr)
+        return def.second;
+
+    return def.first;
 }
 
 const Weapon* GameMap::getWeapon(const std::string& name)
@@ -403,8 +423,7 @@ void GameMap::addCreature(Creature *cc)
 
     mCreatures.push_back(cc);
 
-    cc->getPositionTile()->addCreature(cc);
-    if(!mIsServerGameMap)
+    if(!isServerGameMap())
         mCullingManager->mMyCullingQuad.insert(cc);
 
     addAnimatedObject(cc);
@@ -421,22 +440,18 @@ void GameMap::removeCreature(Creature *c)
 
     // Creature found
     mCreatures.erase(it);
-    // Remove the creature from the tile it's in
-    c->getPositionTile()->removeCreature(c);
-
     removeAnimatedObject(c);
     removeActiveObject(c);
-    c->setIsOnMap(false);
+
+    if(!isServerGameMap())
+        return;
+
+    c->fireRemoveEntityToSeatsWithVision();
 }
 
 void GameMap::queueEntityForDeletion(GameEntity *ge)
 {
     mEntitiesToDelete.push_back(ge);
-}
-
-void GameMap::queueMapLightForDeletion(MapLight *ml)
-{
-    mMapLightsToDelete.push_back(ml);
 }
 
 const CreatureDefinition* GameMap::getClassDescription(const std::string& className)
@@ -780,25 +795,11 @@ void GameMap::addRenderedMovableEntity(RenderedMovableEntity *obj)
 {
     LogManager::getSingleton().logMessage(serverStr() + "Adding rendered object " + obj->getName()
         + ",MeshName=" + obj->getMeshName());
-    if(isServerGameMap())
-    {
-        try
-        {
-            ServerNotification *serverNotification = new ServerNotification(
-                ServerNotification::addRenderedMovableEntity, nullptr);
-            obj->exportHeadersToPacket(serverNotification->mPacket);
-            obj->exportToPacket(serverNotification->mPacket);
-            ODServer::getSingleton().queueServerNotification(serverNotification);
-        }
-        catch (std::bad_alloc&)
-        {
-            OD_ASSERT_TRUE(false);
-            exit(1);
-        }
-    }
     mRenderedMovableEntities.push_back(obj);
+
     addActiveObject(obj);
     addAnimatedObject(obj);
+    obj->setIsOnMap(true);
 }
 
 void GameMap::removeRenderedMovableEntity(RenderedMovableEntity *obj)
@@ -811,25 +812,13 @@ void GameMap::removeRenderedMovableEntity(RenderedMovableEntity *obj)
         return;
 
     mRenderedMovableEntities.erase(it);
-
-    if(isServerGameMap())
-    {
-        try
-        {
-            ServerNotification *serverNotification = new ServerNotification(
-                ServerNotification::removeRenderedMovableEntity, NULL);
-            const std::string& name = obj->getName();
-            serverNotification->mPacket << name;
-            ODServer::getSingleton().queueServerNotification(serverNotification);
-        }
-        catch (std::bad_alloc&)
-        {
-            Ogre::LogManager::getSingleton().logMessage("ERROR: bad alloc in Room::removeRenderedMovableEntity", Ogre::LML_CRITICAL);
-            exit(1);
-        }
-    }
     removeAnimatedObject(obj);
     removeActiveObject(obj);
+
+    if(!isServerGameMap())
+        return;
+
+    obj->fireRemoveEntityToSeatsWithVision();
 }
 
 RenderedMovableEntity* GameMap::getRenderedMovableEntity(const std::string& name)
@@ -862,6 +851,12 @@ void GameMap::removeActiveObject(GameEntity *a)
     // Active objects are only used on server side
     if(!isServerGameMap())
         return;
+
+    Tile* posTile = a->getPositionTile();
+    if(posTile != nullptr)
+        posTile->removeEntity(a);
+
+    a->setIsOnMap(false);
 
     if(std::find(mActiveObjects.begin(), mActiveObjects.end(), a) != mActiveObjects.end())
     {
@@ -928,12 +923,14 @@ void GameMap::createAllEntities()
     for (Creature* creature : mCreatures)
     {
         creature->createMesh();
+        creature->setPosition(creature->getPosition(), false);
     }
 
     // Create OGRE entities for the map lights.
     for (MapLight* mapLight: mMapLights)
     {
         mapLight->createMesh();
+        mapLight->setPosition(mapLight->getPosition(), false);
     }
 
     // Create OGRE entities for the rooms
@@ -1126,8 +1123,16 @@ unsigned long int GameMap::doMiscUpkeep()
     {
         seat->clearTilesWithVision();
     }
+    for (int jj = 0; jj < getMapSizeY(); ++jj)
+    {
+        for (int ii = 0; ii < getMapSizeX(); ++ii)
+        {
+            getTile(ii,jj)->clearVision();
+        }
+    }
 
-    // Compute vision
+    // Compute vision. We need to compute every seats including AI because
+    // a human can be allied with an AI and they would share vision
     for (int jj = 0; jj < getMapSizeY(); ++jj)
     {
         for (int ii = 0; ii < getMapSizeX(); ++ii)
@@ -1135,6 +1140,7 @@ unsigned long int GameMap::doMiscUpkeep()
             getTile(ii,jj)->computeVisibleTiles();
         }
     }
+
     for (Creature* creature : mCreatures)
     {
         creature->computeVisibleTiles();
@@ -1239,6 +1245,7 @@ void GameMap::updateAnimations(Ogre::Real timeSinceLastFrame)
     if(!isServerGameMap() && getTurnNumber() == 0)
     {
         LogManager::getSingleton().logMessage("Starting game map");
+
         setGamePaused(false);
 
         // Create ogre entities for the tiles, rooms, and creatures
@@ -1272,7 +1279,7 @@ void GameMap::updatePlayerFightingTime(Ogre::Real timeSinceLastFrame)
     // Updates fighting time for server players
     for (Player* player : mPlayers)
     {
-        if (player == NULL)
+        if (player == nullptr)
             continue;
 
         float fightingTime = player->getFightingTime();
@@ -1284,18 +1291,10 @@ void GameMap::updatePlayerFightingTime(Ogre::Real timeSinceLastFrame)
         if (fightingTime <= 0.0f)
         {
             fightingTime = 0.0f;
-            try
-            {
-                // Notify the player he is no longer under attack.
-                ServerNotification *serverNotification = new ServerNotification(
-                    ServerNotification::playerNoMoreFighting, player);
-                ODServer::getSingleton().queueServerNotification(serverNotification);
-            }
-            catch (std::bad_alloc&)
-            {
-                OD_ASSERT_TRUE(false);
-                exit(1);
-            }
+            // Notify the player he is no longer under attack.
+            ServerNotification *serverNotification = new ServerNotification(
+                ServerNotification::playerNoMoreFighting, player);
+            ODServer::getSingleton().queueServerNotification(serverNotification);
         }
         player->setFightingTime(fightingTime);
     }
@@ -1325,18 +1324,10 @@ void GameMap::playerIsFighting(Player* player)
         // Warn the ally about the battle
         if (ally->getFightingTime() == 0.0f)
         {
-            try
-            {
-                // Notify the player he is now under attack.
-                ServerNotification *serverNotification = new ServerNotification(
-                    ServerNotification::playerFighting, ally);
-                ODServer::getSingleton().queueServerNotification(serverNotification);
-            }
-            catch (std::bad_alloc&)
-            {
-                OD_ASSERT_TRUE(false);
-                exit(1);
-            }
+            // Notify the player he is now under attack.
+            ServerNotification *serverNotification = new ServerNotification(
+                ServerNotification::playerFighting, ally);
+            ODServer::getSingleton().queueServerNotification(serverNotification);
         }
 
         // Reset its fighting time anyway
@@ -1848,9 +1839,9 @@ std::vector<GameEntity*> GameMap::getVisibleCreatures(std::vector<Tile*> visible
     return returnList;
 }
 
-std::vector<GameEntity*> GameMap::getVisibleCarryableEntities(std::vector<Tile*> visibleTiles)
+std::vector<MovableGameEntity*> GameMap::getVisibleCarryableEntities(std::vector<Tile*> visibleTiles)
 {
-    std::vector<GameEntity*> returnList;
+    std::vector<MovableGameEntity*> returnList;
 
     // Loop over the visible tiles
     for (Tile* tile : visibleTiles)
@@ -1877,7 +1868,7 @@ void GameMap::clearRooms()
     mRooms.clear();
 }
 
-void GameMap::addRoom(Room *r, bool sendAsyncMsg)
+void GameMap::addRoom(Room *r)
 {
     int nbTiles = r->getCoveredTiles().size();
     LogManager::getSingleton().logMessage(serverStr() + "Adding room " + r->getName() + ", nbTiles="
@@ -1887,25 +1878,9 @@ void GameMap::addRoom(Room *r, bool sendAsyncMsg)
         LogManager::getSingleton().logMessage(serverStr() + "Adding room " + r->getName() + ", tile=" + Tile::displayAsString(tile));
     }
 
-    if(isServerGameMap())
-    {
-        if(sendAsyncMsg)
-        {
-            ServerNotification notif(ServerNotification::buildRoom, getPlayerBySeat(r->getSeat()));
-            r->exportHeadersToPacket(notif.mPacket);
-            r->exportToPacket(notif.mPacket);
-            ODServer::getSingleton().sendAsyncMsgToAllClients(notif);
-        }
-        else
-        {
-            ServerNotification* serverNotification = new ServerNotification(ServerNotification::buildRoom, getPlayerBySeat(r->getSeat()));
-            r->exportHeadersToPacket(serverNotification->mPacket);
-            r->exportToPacket(serverNotification->mPacket);
-            ODServer::getSingleton().queueServerNotification(serverNotification);
-        }
-    }
     mRooms.push_back(r);
     addActiveObject(r);
+    r->setIsOnMap(true);
 }
 
 void GameMap::removeRoom(Room *r)
@@ -2073,15 +2048,9 @@ void GameMap::addTrap(Trap *trap)
     LogManager::getSingleton().logMessage(serverStr() + "Adding trap " + trap->getName() + ", nbTiles="
         + Ogre::StringConverter::toString(nbTiles) + ", seatId=" + Ogre::StringConverter::toString(trap->getSeat()->getId()));
 
-    if(isServerGameMap())
-    {
-        ServerNotification notif(ServerNotification::buildTrap, getPlayerBySeat(trap->getSeat()));
-        trap->exportHeadersToPacket(notif.mPacket);
-        trap->exportToPacket(notif.mPacket);
-        ODServer::getSingleton().sendAsyncMsgToAllClients(notif);
-    }
     mTraps.push_back(trap);
     addActiveObject(trap);
+    trap->setIsOnMap(true);
 }
 
 void GameMap::removeTrap(Trap *t)
@@ -2152,6 +2121,7 @@ void GameMap::addMapLight(MapLight *m)
     mMapLights.push_back(m);
 
     addAnimatedObject(m);
+    m->setIsOnMap(true);
 }
 
 void GameMap::removeMapLight(MapLight *m)
@@ -2231,7 +2201,9 @@ void GameMap::addWinningSeat(Seat *s)
     Player* player = getPlayerBySeat(s);
     if (player && player->getIsHuman())
     {
-        ServerNotification* serverNotification = new ServerNotification(ServerNotification::playerWon, player);
+        ServerNotification* serverNotification = new ServerNotification(
+            ServerNotification::chatServer, player);
+        serverNotification->mPacket << "You Won";
         ODServer::getSingleton().queueServerNotification(serverNotification);
     }
 
@@ -2636,13 +2608,6 @@ void GameMap::processDeletionQueues()
         mEntitiesToDelete.erase(mEntitiesToDelete.begin());
         delete entity;
     }
-
-    while (!mMapLightsToDelete.empty())
-    {
-        MapLight* ml = *mMapLightsToDelete.begin();
-        mMapLightsToDelete.erase(mMapLightsToDelete.begin());
-        delete ml;
-    }
 }
 
 void GameMap::refreshBorderingTilesOf(const std::vector<Tile*>& affectedTiles)
@@ -2654,8 +2619,8 @@ void GameMap::refreshBorderingTilesOf(const std::vector<Tile*>& affectedTiles)
 
     // Loop over all the affected tiles and force them to examine their neighbors.  This allows
     // them to switch to a mesh with fewer polygons if some are hidden by the neighbors, etc.
-    for (std::vector<Tile*>::iterator itr = borderTiles.begin(); itr != borderTiles.end() ; ++itr)
-        (*itr)->refreshMesh();
+    for (Tile* tile : borderTiles)
+        tile->refreshMesh();
 }
 
 std::vector<Tile*> GameMap::getDiggableTilesForPlayerInArea(int x1, int y1, int x2, int y2,
@@ -2708,7 +2673,6 @@ void GameMap::markTilesForPlayer(std::vector<Tile*>& tiles, bool isDigSet, Playe
         Tile* tile = *it;
         tile->setMarkedForDigging(isDigSet, player);
     }
-    refreshBorderingTilesOf(tiles);
 }
 
 std::string GameMap::getGoalsStringForPlayer(Player* player)
@@ -2854,7 +2818,7 @@ std::string GameMap::nextUniqueNameMapLight()
     return ret;
 }
 
-GameEntity* GameMap::getEntityFromTypeAndName(GameEntity::ObjectType entityType,
+MovableGameEntity* GameMap::getEntityFromTypeAndName(GameEntity::ObjectType entityType,
     const std::string& entityName)
 {
     switch(entityType)
@@ -3059,5 +3023,29 @@ void GameMap::fillBuildableTilesAndPriceForPlayerInArea(int x1, int y1, int x2, 
             && numRoomsByTypeAndSeat(Room::treasury, player->getSeat()) == 0)
     {
         goldRequired -= costPerTile;
+    }
+}
+
+void GameMap::updateVisibleEntities()
+{
+    // Notify changes on visible tiles
+    for(Seat* seat : mSeats)
+    {
+        if(seat->getPlayer() == nullptr)
+            continue;
+        if(!seat->getPlayer()->getIsHuman())
+            continue;
+
+        seat->notifyChangedVisibleTiles();
+    }
+
+    // Notify what happened to entities on visible tiles
+    for (int jj = 0; jj < getMapSizeY(); ++jj)
+    {
+        for (int ii = 0; ii < getMapSizeX(); ++ii)
+        {
+            Tile* tile = getTile(ii,jj);
+            tile->notifySeatsWithVision();
+        }
     }
 }

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -148,6 +148,7 @@ GameMap::GameMap(bool isServerGameMap) :
         mTurnNumber(-1),
         mIsPaused(false),
         mFloodFillEnabled(false),
+        mIsFOWActivated(true),
         mNumCallsTo_path(0),
         mTileCoordinateMap(new TileCoordinateMap(100)),
         mAiManager(*this)
@@ -254,6 +255,7 @@ void GameMap::clearAll()
     mLocalPlayerNick = DEFAULT_NICK;
     mTurnNumber = -1;
     resetUniqueNumbers();
+    mIsFOWActivated = true;
 }
 
 void GameMap::clearCreatures()
@@ -2904,6 +2906,11 @@ void GameMap::consoleSetLevelCreature(const std::string& creatureName, uint32_t 
         return;
 
     creature->setLevel(level);
+}
+
+void GameMap::consoleAskToggleFOW()
+{
+    mIsFOWActivated = !mIsFOWActivated;
 }
 
 Creature* GameMap::getKoboldForPathFinding(Seat* seat)

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -2645,23 +2645,28 @@ std::vector<Tile*> GameMap::getBuildableTilesForPlayerInArea(int x1, int y1, int
     Player* player)
 {
     std::vector<Tile*> tiles = rectangularRegion(x1, y1, x2, y2);
-    std::vector<Tile*>::iterator it = tiles.begin();
-    while (it != tiles.end())
+    for (std::vector<Tile*>::iterator it = tiles.begin(); it != tiles.end();)
     {
         Tile* tile = *it;
         if (!tile->isBuildableUpon())
         {
             it = tiles.erase(it);
+            continue;
         }
-        else if (!(tile->getFullness() == 0.0
-                    && tile->getType() == Tile::claimed
-                    && tile->getClaimedPercentage() >= 1.0
-                    && tile->isClaimedForSeat(player->getSeat())))
+
+        if (tile->getClaimedPercentage() < 1.0)
         {
             it = tiles.erase(it);
+            continue;
         }
-        else
-            ++it;
+
+        if (!tile->isClaimedForSeat(player->getSeat()))
+        {
+            it = tiles.erase(it);
+            continue;
+        }
+
+         ++it;
     }
     return tiles;
 }

--- a/source/gamemap/GameMap.h
+++ b/source/gamemap/GameMap.h
@@ -116,6 +116,9 @@ public:
     //! \brief Returns the total number of creatures stored in this game map.
     unsigned int numCreatures() const;
 
+    bool getIsFOWActivated() const
+    { return mIsFOWActivated; }
+
     //! \brief Returns a vector containing all the creatures controlled by the given seat.
     std::vector<Creature*> getCreaturesByAlliedSeat(Seat* seat);
     std::vector<Creature*> getCreaturesBySeat(Seat* seat);
@@ -449,6 +452,7 @@ public:
     void consoleDisplayCreatureVisualDebug(const std::string& creatureName, bool enable);
     void consoleDisplaySeatVisualDebug(int seatId, bool enable);
     void consoleSetLevelCreature(const std::string& creatureName, uint32_t level);
+    void consoleAskToggleFOW();
 
     //! \brief This functions create unique names. They check that there
     //! is no entity with the same name before returning
@@ -541,6 +545,9 @@ private:
 
     //! \brief Tells whether the map color flood filling is enabled.
     bool mFloodFillEnabled;
+
+    //! When true, fog of war will work normally. When false, every connected client will see the whole map
+    bool mIsFOWActivated;
 
     std::vector<GameEntity*> mActiveObjects;
 

--- a/source/gamemap/GameMap.h
+++ b/source/gamemap/GameMap.h
@@ -162,6 +162,7 @@ public:
     void saveLevelClassDescriptions(std::ofstream& levelFile);
 
     void addWeapon(const Weapon *weapon);
+    const Weapon* getWeapon(int index);
     const Weapon* getWeapon(const std::string& name);
     Weapon* getWeaponForTuning(const std::string& name);
     uint32_t numWeapons();
@@ -170,12 +171,8 @@ public:
     //! \brief Calls the deleteYourself() method on each of the rooms in the game map as well as clearing the vector of stored rooms.
     void clearRooms();
 
-    //! \brief A simple mutator method to add the given Room to the GameMap. If sendAsyncMsg is true, an asynchronous server message
-    //! will be sent to every players. If false, it will be synchronous. Asynchronous messages should be used for human players
-    //! to increase time reaction. This is useful because when AI looses a room, it could try to rebuild it during the same turn. But
-    //! because the remove tile is sent synchronously, if the build message was sent asynchronously, it would be received before the
-    //! remove message. That would result in Ogre crashing because there are 2 identical tiles.
-    void addRoom(Room *r, bool sendAsyncMsg);
+    //! \brief A simple mutator method to add the given Room to the GameMap.
+    void addRoom(Room *r);
 
     void removeRoom(Room *r);
 
@@ -358,7 +355,7 @@ public:
     std::vector<GameEntity*> getVisibleCreatures(std::vector<Tile*> visibleTiles, Seat* seat, bool invert);
 
     //! \brief Loops over the visibleTiles and returns any carryable entity in those tiles
-    std::vector<GameEntity*> getVisibleCarryableEntities(std::vector<Tile*> visibleTiles);
+    std::vector<MovableGameEntity*> getVisibleCarryableEntities(std::vector<Tile*> visibleTiles);
 
     /** \brief Returns the as the crow flies distance between tiles located at the two coordinates given.
      * If tiles do not exist at these locations the function returns -1.0.
@@ -467,7 +464,7 @@ public:
     RenderedMovableEntity* getRenderedMovableEntity(const std::string& name);
     void clearRenderedMovableEntities();
     void clearActiveObjects();
-    GameEntity* getEntityFromTypeAndName(GameEntity::ObjectType entityType,
+    MovableGameEntity* getEntityFromTypeAndName(GameEntity::ObjectType entityType,
         const std::string& entityName);
 
     //! \brief Tells the game map a given player is attacking or under attack.
@@ -480,6 +477,8 @@ public:
 
     void fillBuildableTilesAndPriceForPlayerInArea(int x1, int y1, int x2, int y2,
         Player* player, Room::RoomType type, std::vector<Tile*>& tiles, int& goldRequired);
+
+    void updateVisibleEntities();
 
 private:
     void replaceFloodFill(Tile::FloodFillType floodFillType, int colorOld, int colorNew);
@@ -553,9 +552,6 @@ private:
 
     //! \brief Useless entities that need to be deleted. They will be deleted when processDeletionQueues is called
     std::vector<GameEntity*> mEntitiesToDelete;
-
-    //! \brief Useless MapLights that need to be deleted. They will be deleted when processDeletionQueues is called
-    std::vector<MapLight*> mMapLightsToDelete;
 
     //! \brief Debug member used to know how many call to pathfinding has been made within the same turn.
     unsigned int mNumCallsTo_path;

--- a/source/gamemap/MapLoader.cpp
+++ b/source/gamemap/MapLoader.cpp
@@ -41,7 +41,6 @@ namespace MapLoader {
 
 bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
 {
-
     std::stringstream levelFile;
     if(!Helper::readFileWithoutComments(fileName, levelFile))
         return false;
@@ -230,8 +229,11 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
         if (nextParam == "[/Rooms]")
             break;
 
-        if (nextParam != "[Room]")
+        if (gameMap.isServerGameMap() && (nextParam != "[Room]"))
             return false;
+
+        if(!gameMap.isServerGameMap())
+            continue;
 
         Room* tempRoom = Room::getRoomFromStream(&gameMap, levelFile);
         OD_ASSERT_TRUE(tempRoom != nullptr);
@@ -239,7 +241,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
             return false;
 
         tempRoom->setName(gameMap.nextUniqueNameRoom(tempRoom->getMeshName()));
-        gameMap.addRoom(tempRoom, false);
+        gameMap.addRoom(tempRoom);
 
         levelFile >> nextParam;
         if (nextParam != "[/Room]")
@@ -306,7 +308,9 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
         MapLight* tempLight = new MapLight(&gameMap);
         MapLight::loadFromLine(entire_line, tempLight);
         tempLight->setName(gameMap.nextUniqueNameMapLight());
-
+        OD_ASSERT_TRUE(tempLight != nullptr);
+        if(tempLight == nullptr)
+            return false;
         gameMap.addMapLight(tempLight);
     }
 
@@ -407,6 +411,8 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
 
         Creature* tempCreature = Creature::getCreatureFromStream(&gameMap, levelFile);
         OD_ASSERT_TRUE(tempCreature != nullptr);
+        if(tempCreature == nullptr)
+            return false;
         gameMap.addCreature(tempCreature);
         ++nbCreatures;
 

--- a/source/modes/Console_executePromptCommand.cpp
+++ b/source/modes/Console_executePromptCommand.cpp
@@ -851,6 +851,26 @@ bool Console::executePromptCommand(const std::string& command, std::string argum
         }
     }
 
+    // Start the visual debugging indicators for a given creature
+    else if (command.compare("icanseedeadpeople") == 0)
+    {
+        if (ODServer::getSingleton().isConnected())
+        {
+            if(ODClient::getSingleton().isConnected())
+            {
+                ODConsoleCommand* cc = new ODConsoleCommandAskToggleFOW();
+                ODServer::getSingleton().queueConsoleCommand(cc);
+            }
+            frameListener->mCommandOutput
+                    += "\nAsking to toggle fog of war\n";
+        }
+        else
+        {
+            frameListener->mCommandOutput
+                    += "\nERROR:  You can toggle fog of war only when you are hosting a game.\n";
+        }
+    }
+
     // Changes the level of a given creature
     else if (command.compare("setlevel") == 0)
     {

--- a/source/modes/Console_executePromptCommand.cpp
+++ b/source/modes/Console_executePromptCommand.cpp
@@ -314,19 +314,11 @@ bool Console::executePromptCommand(const std::string& command, std::string argum
 
             if (ODServer::getSingleton().isConnected())
             {
-                try
-                {
-                    // Inform any connected clients about the change
-                    ServerNotification *serverNotification = new ServerNotification(
-                        ServerNotification::setTurnsPerSecond, NULL);
-                    serverNotification->mPacket << ODApplication::turnsPerSecond;
-                    ODServer::getSingleton().queueServerNotification(serverNotification);
-                }
-                catch (std::bad_alloc&)
-                {
-                    Ogre::LogManager::getSingleton().logMessage("ERROR: bad alloc in terminal command \'turnspersecond\'\n\n", Ogre::LML_CRITICAL);
-                    exit(1);
-                }
+                // Inform any connected clients about the change
+                ServerNotification *serverNotification = new ServerNotification(
+                    ServerNotification::setTurnsPerSecond, nullptr);
+                serverNotification->mPacket << ODApplication::turnsPerSecond;
+                ODServer::getSingleton().queueServerNotification(serverNotification);
             }
 
             frameListener->mCommandOutput += "\nMaximum turns per second set to "

--- a/source/modes/Console_getHelp.cpp
+++ b/source/modes/Console_getHelp.cpp
@@ -172,6 +172,11 @@ string Console::getHelpText(std::string arg)
                 + "seatvisdebug 1\n\nThe above command will show every tiles seat 1 can see.  The same command will turn it off.";
     }
 
+    else if (arg.compare("icanseedeadpeople") == 0)
+    {
+        return "Toggles on/off fog of war for every connected player";
+    }
+
     else if (arg.compare("setlevel") == 0)
     {
         return "Sets the level of a given creature.\n\nExample:\n"

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -459,7 +459,7 @@ bool EditorMode::mousePressed(const OIS::MouseEvent &arg, OIS::MouseButtonID id)
         std::string resultName = itr->movable->getName();
 
         GameEntity* entity = getEntityFromOgreName(resultName);
-        if (entity == nullptr || !entity->tryPickup(player->getSeat(), false))
+        if (entity == nullptr || !entity->tryPickup(player->getSeat(), true))
             continue;
 
         if (ODClient::getSingleton().isConnected())

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -618,6 +618,18 @@ bool GameMode::mouseReleased(const OIS::MouseEvent &arg, OIS::MouseButtonID id)
             clientNotification->mPacket << mDigSetBool;
             ODClient::getSingleton().queueClientNotification(clientNotification);
             mGameMap->getLocalPlayer()->setCurrentAction(Player::SelectedAction::none);
+
+            // We mark the selected tiles
+            std::vector<Tile*> tiles = mGameMap->getDiggableTilesForPlayerInArea(inputManager->mXPos,
+                inputManager->mYPos, inputManager->mLStartDragX, inputManager->mLStartDragY,
+                mGameMap->getLocalPlayer());
+            if(!tiles.empty())
+            {
+                mGameMap->markTilesForPlayer(tiles, mDigSetBool, mGameMap->getLocalPlayer());
+                SoundEffectsManager::getSingleton().playInterfaceSound(SoundEffectsManager::DIGSELECT);
+                for(Tile* tile : tiles)
+                    tile->refreshMesh();
+            }
             break;
         }
         case Player::SelectedAction::buildRoom:

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -184,7 +184,7 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
                 // Check whether the room type is the first treasury tile.
                 // In that case, the cost of the first tile is 0, to prevent the player from being stuck
                 // with no means to earn money.
-                if (selectedRoomType == Room::treasury && mGameMap->numRoomsByTypeAndSeat(Room::treasury, player->getSeat()) == 0)
+                if (nbTile > 0 && selectedRoomType == Room::treasury && player->getSeat()->getNbTreasuries() == 0)
                     price -= Room::costPerTile(selectedRoomType);
 
                 Ogre::ColourValue& textColor = (gold < price) ? red : white;

--- a/source/modes/MenuModeConfigureSeats.cpp
+++ b/source/modes/MenuModeConfigureSeats.cpp
@@ -25,7 +25,6 @@
 
 #include "network/ODServer.h"
 #include "network/ODClient.h"
-#include "network/ServerNotification.h"
 
 #include "sound/MusicPlayer.h"
 

--- a/source/modes/MenuModeEditor.cpp
+++ b/source/modes/MenuModeEditor.cpp
@@ -59,7 +59,10 @@ void MenuModeEditor::activate()
     // TODO: Make this configurable.
     MusicPlayer::getSingleton().play("Pal_Zoltan_Illes_OpenDungeons_maintheme.ogg");
 
-    ODFrameListener::getSingleton().getClientGameMap()->setGamePaused(true);
+    GameMap* gameMap = ODFrameListener::getSingleton().getClientGameMap();
+    gameMap->clearAll();
+    gameMap->processDeletionQueues();
+    gameMap->setGamePaused(true);
 
     CEGUI::Window* tmpWin = Gui::getSingleton().getGuiSheet(Gui::editorMenu)->getChild(Gui::EDM_LIST_LEVELS);
     CEGUI::Listbox* levelSelectList = static_cast<CEGUI::Listbox*>(tmpWin);

--- a/source/modes/MenuModeMultiplayerClient.cpp
+++ b/source/modes/MenuModeMultiplayerClient.cpp
@@ -52,7 +52,10 @@ void MenuModeMultiplayerClient::activate()
     // TODO: Make this configurable.
     MusicPlayer::getSingleton().play("Pal_Zoltan_Illes_OpenDungeons_maintheme.ogg");
 
-    ODFrameListener::getSingleton().getClientGameMap()->setGamePaused(true);
+    GameMap* gameMap = ODFrameListener::getSingleton().getClientGameMap();
+    gameMap->clearAll();
+    gameMap->processDeletionQueues();
+    gameMap->setGamePaused(true);
 
     CEGUI::Window* mainWin = Gui::getSingleton().getGuiSheet(Gui::multiplayerClientMenu);
     mainWin->getChild(Gui::MPM_TEXT_LOADING)->hide();

--- a/source/modes/MenuModeMultiplayerServer.cpp
+++ b/source/modes/MenuModeMultiplayerServer.cpp
@@ -58,7 +58,10 @@ void MenuModeMultiplayerServer::activate()
     // TODO: Make this configurable.
     MusicPlayer::getSingleton().play("Pal_Zoltan_Illes_OpenDungeons_maintheme.ogg");
 
-    ODFrameListener::getSingleton().getClientGameMap()->setGamePaused(true);
+    GameMap* gameMap = ODFrameListener::getSingleton().getClientGameMap();
+    gameMap->clearAll();
+    gameMap->processDeletionQueues();
+    gameMap->setGamePaused(true);
 
     CEGUI::Window* tmpWin = Gui::getSingleton().getGuiSheet(Gui::multiplayerServerMenu)->getChild(Gui::MPM_LIST_LEVELS);
     CEGUI::Listbox* levelSelectList = static_cast<CEGUI::Listbox*>(tmpWin);

--- a/source/modes/MenuModeReplay.cpp
+++ b/source/modes/MenuModeReplay.cpp
@@ -57,7 +57,11 @@ void MenuModeReplay::activate()
     // TODO: Make this configurable.
     MusicPlayer::getSingleton().play("Pal_Zoltan_Illes_OpenDungeons_maintheme.ogg");
 
-    ODFrameListener::getSingleton().getClientGameMap()->setGamePaused(true);
+
+    GameMap* gameMap = ODFrameListener::getSingleton().getClientGameMap();
+    gameMap->clearAll();
+    gameMap->processDeletionQueues();
+    gameMap->setGamePaused(true);
 
     CEGUI::Window* tmpWin = Gui::getSingleton().getGuiSheet(Gui::replayMenu)->getChild(Gui::REM_LIST_REPLAYS);
     CEGUI::Listbox* replaySelectList = static_cast<CEGUI::Listbox*>(tmpWin);

--- a/source/modes/MenuModeSkirmish.cpp
+++ b/source/modes/MenuModeSkirmish.cpp
@@ -57,7 +57,11 @@ void MenuModeSkirmish::activate()
     // TODO: Make this configurable.
     MusicPlayer::getSingleton().play("Pal_Zoltan_Illes_OpenDungeons_maintheme.ogg");
 
-    ODFrameListener::getSingleton().getClientGameMap()->setGamePaused(true);
+
+    GameMap* gameMap = ODFrameListener::getSingleton().getClientGameMap();
+    gameMap->clearAll();
+    gameMap->processDeletionQueues();
+    gameMap->setGamePaused(true);
 
     CEGUI::Window* tmpWin = Gui::getSingleton().getGuiSheet(Gui::skirmishMenu)->getChild(Gui::SKM_LIST_LEVELS);
     CEGUI::Listbox* levelSelectList = static_cast<CEGUI::Listbox*>(tmpWin);

--- a/source/modes/ODConsoleCommand.h
+++ b/source/modes/ODConsoleCommand.h
@@ -140,4 +140,18 @@ private:
     uint32_t mLevel;
 };
 
+class ODConsoleCommandAskToggleFOW : public ODConsoleCommand
+{
+public:
+    ODConsoleCommandAskToggleFOW()
+    {
+    }
+
+protected:
+    virtual void execute(GameMap* gameMap)
+    {
+        gameMap->consoleAskToggleFOW();
+    }
+};
+
 #endif // ODCONSOLECOMMAND_H

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -752,6 +752,38 @@ bool ODClient::processOneClientSocketMessage()
             break;
         }
 
+        case ServerNotification::refreshVisibleTiles:
+        {
+            uint32_t nbTiles;
+            // Tiles we gained vision
+            OD_ASSERT_TRUE(packetReceived >> nbTiles);
+            while(nbTiles > 0)
+            {
+                --nbTiles;
+                Tile* tile = gameMap->tileFromPacket(packetReceived);
+                OD_ASSERT_TRUE(tile != nullptr);
+                if(tile == nullptr)
+                    continue;
+
+                tile->setLocalPlayerHasVision(true);
+                tile->refreshMesh();
+            }
+            // Tiles we lost vision
+            OD_ASSERT_TRUE(packetReceived >> nbTiles);
+            while(nbTiles > 0)
+            {
+                --nbTiles;
+                Tile* tile = gameMap->tileFromPacket(packetReceived);
+                OD_ASSERT_TRUE(tile != nullptr);
+                if(tile == nullptr)
+                    continue;
+
+                tile->setLocalPlayerHasVision(false);
+                tile->refreshMesh();
+            }
+            break;
+        }
+
         case ServerNotification::playCreatureSound:
         {
             std::string name;

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -379,22 +379,6 @@ bool ODClient::processOneClientSocketMessage()
             break;
         }
 
-        case ServerNotification::addTile:
-        {
-            Tile* newTile = new Tile(gameMap);
-            OD_ASSERT_TRUE(packetReceived >> newTile);
-            gameMap->addTile(newTile);
-            newTile->setFullness(newTile->getFullness());
-
-            // Loop over the tile's neighbors to force them to recheck
-            // their mesh to see if they can use an optimized one
-            for (Tile* tile : newTile->getAllNeighbors())
-            {
-                tile->setFullness(tile->getFullness());
-            }
-            break;
-        }
-
         case ServerNotification::addMapLight:
         {
             MapLight *newMapLight = new MapLight(gameMap);
@@ -807,13 +791,12 @@ bool ODClient::processOneClientSocketMessage()
             while(nbTiles > 0)
             {
                 --nbTiles;
-                Tile tmpTile(gameMap);
-                OD_ASSERT_TRUE(packetReceived >> &tmpTile);
-                Tile* gameTile = gameMap->getTile(tmpTile.getX(), tmpTile.getY());
+                Tile* gameTile = gameMap->tileFromPacket(packetReceived);
                 OD_ASSERT_TRUE(gameTile != nullptr);
                 if(gameTile == nullptr)
                     continue;
-                gameTile->refreshFromTile(tmpTile);
+
+                gameTile->updateFromPacket(packetReceived);
                 tiles.push_back(gameTile);
             }
             gameMap->refreshBorderingTilesOf(tiles);

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -203,6 +203,7 @@ void ODServer::startNewTurn(double timeSinceLastFrame)
             ServerNotification::refreshPlayerSeat, player);
         std::string goals = gameMap->getGoalsStringForPlayer(player);
         Seat* seat = player->getSeat();
+        seat->computeSeatBeforeSendingToClient();
         serverNotification->mPacket << seat << goals;
         ODServer::getSingleton().queueServerNotification(serverNotification);
 

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -1071,7 +1071,8 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 serverNotification.mPacket << nbTiles;
                 for(Tile* tile : p.second)
                 {
-                    serverNotification.mPacket << tile;
+                    gameMap->tileToPacket(serverNotification.mPacket, tile);
+                    tile->exportToPacket(serverNotification.mPacket, p.first);
                 }
                 sendAsyncMsg(serverNotification);
             }
@@ -1140,7 +1141,8 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 serverNotification.mPacket << nbTiles;
                 for(Tile* tile : p.second)
                 {
-                    serverNotification.mPacket << tile;
+                    gameMap->tileToPacket(serverNotification.mPacket, tile);
+                    tile->exportToPacket(serverNotification.mPacket, p.first);
                 }
                 sendAsyncMsg(serverNotification);
             }
@@ -1208,7 +1210,8 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 serverNotification.mPacket << nbTiles;
                 for(Tile* tile : p.second)
                 {
-                    serverNotification.mPacket << tile;
+                    gameMap->tileToPacket(serverNotification.mPacket, tile);
+                    tile->exportToPacket(serverNotification.mPacket, p.first);
                 }
                 sendAsyncMsg(serverNotification);
             }
@@ -1332,7 +1335,8 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 serverNotification.mPacket << nbTiles;
                 for(Tile* tile : p.second)
                 {
-                    serverNotification.mPacket << tile;
+                    gameMap->tileToPacket(serverNotification.mPacket, tile);
+                    tile->exportToPacket(serverNotification.mPacket, p.first);
                 }
                 sendAsyncMsg(serverNotification);
             }
@@ -1399,7 +1403,8 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 serverNotification.mPacket << nbTiles;
                 for(Tile* tile : p.second)
                 {
-                    serverNotification.mPacket << tile;
+                    gameMap->tileToPacket(serverNotification.mPacket, tile);
+                    tile->exportToPacket(serverNotification.mPacket, p.first);
                 }
                 sendAsyncMsg(serverNotification);
             }
@@ -1504,13 +1509,23 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             if(!affectedTiles.empty())
             {
                 uint32_t nbTiles = affectedTiles.size();
-                ServerNotification notif(ServerNotification::refreshTiles, nullptr);
-                notif.mPacket << nbTiles;
-                for(Tile* tile : affectedTiles)
+                const std::vector<Seat*>& seats = gameMap->getSeats();
+                for(Seat* seat : seats)
                 {
-                    notif.mPacket << tile;
+                    if(seat->getPlayer() == nullptr)
+                        continue;
+                    if(!seat->getPlayer()->getIsHuman())
+                        continue;
+
+                    ServerNotification notif(ServerNotification::refreshTiles, seat->getPlayer());
+                    notif.mPacket << nbTiles;
+                    for(Tile* tile : affectedTiles)
+                    {
+                        gameMap->tileToPacket(notif.mPacket, tile);
+                        tile->exportToPacket(notif.mPacket, seat);
+                    }
+                    sendAsyncMsg(notif);
                 }
-                sendAsyncMsg(notif);
             }
             break;
         }
@@ -1637,7 +1652,8 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 serverNotification.mPacket << nbTiles;
                 for(Tile* tile : p.second)
                 {
-                    serverNotification.mPacket << tile;
+                    gameMap->tileToPacket(serverNotification.mPacket, tile);
+                    tile->exportToPacket(serverNotification.mPacket, p.first);
                 }
                 sendAsyncMsg(serverNotification);
             }

--- a/source/network/ODServer.h
+++ b/source/network/ODServer.h
@@ -71,14 +71,14 @@ class ODServer: public Ogre::Singleton<ODServer>,
     bool startServer(const std::string& levelFilename, ServerMode mode);
     void stopServer();
 
-    //! \brief Adds a server notification to the server notification queue.
+    //! \brief Adds a server notification to the server notification queue. The message will be sent to the concerned player
     void queueServerNotification(ServerNotification* n);
 
-    //! \brief Sends an asynchronous message to every client. This function should be used really carefully as it can easily
+    //! \brief Sends an asynchronous message to the concerned player. This function should be used really carefully as it can easily
     //! make the game crash by sending messages in an unexpected order (changing the state of an entity that was not created, for example).
     //! In most of the can, we will use it for messages that do not need synchronization with the game (example : chat) or
     //! for messages that need to show reactivity (after a player does something like building a room or tried to pickup a creature).
-    void sendAsyncMsgToAllClients(ServerNotification& notif);
+    void sendAsyncMsg(ServerNotification& notif);
 
     //! \brief Adds a console command to the queue.
     void queueConsoleCommand(ODConsoleCommand* cc);
@@ -98,7 +98,6 @@ private:
     ServerMode mServerMode;
     ServerState mServerState;
     GameMap *mGameMap;
-    std::string mLevelFilename;
     bool mSeatsConfigured;
 
     std::deque<ServerNotification*> mServerNotificationQueue;
@@ -130,6 +129,9 @@ private:
     bool processClientNotifications(ODSocketClient* clientSocket);
 
     void processServerCommandQueue();
+
+    //! \brief Sends the packet to the given player. If player is nullptr, the packet is sent to every connected player
+    void sendMsg(Player* player, ODPacket& packet);
 };
 
 #endif // ODSERVER_H

--- a/source/network/ODSocketServer.cpp
+++ b/source/network/ODSocketServer.cpp
@@ -155,18 +155,6 @@ ODSocketClient::ODComStatus ODSocketServer::sendMsgToClient(ODSocketClient* clie
     return client->send(packetReceived);
 }
 
-void ODSocketServer::sendMsgToAllClients(ODPacket& packetReceived)
-{
-    for (std::vector<ODSocketClient*>::iterator it = mSockClients.begin(); it != mSockClients.end(); ++it)
-    {
-        ODSocketClient* client = *it;
-        if (!client || !client->isConnected())
-            continue;
-
-        client->send(packetReceived);
-    }
-}
-
 void ODSocketServer::stopServer()
 {
     mIsConnected = false;

--- a/source/network/ODSocketServer.h
+++ b/source/network/ODSocketServer.h
@@ -67,7 +67,6 @@ class ODSocketServer
         void doTask(int timeoutMs);
         ODSocketClient::ODComStatus receiveMsgFromClient(ODSocketClient* client, ODPacket& packetReceived);
         ODSocketClient::ODComStatus sendMsgToClient(ODSocketClient* client, ODPacket& packetReceived);
-        void sendMsgToAllClients(ODPacket& packetReceived);
         std::vector<ODSocketClient*> mSockClients;
         void setClientState(ODSocketClient* client, const std::string& state);
         virtual void serverThread() = 0;

--- a/source/network/ServerNotification.cpp
+++ b/source/network/ServerNotification.cpp
@@ -106,6 +106,8 @@ std::string ServerNotification::typeString(ServerNotificationType type)
             return "playCreatureSound";
         case ServerNotificationType::refreshTiles:
             return "refreshTiles";
+        case ServerNotificationType::refreshVisibleTiles:
+            return "refreshVisibleTiles";
         case ServerNotificationType::carryEntity:
             return "carryEntity";
         case ServerNotificationType::releaseCarriedEntity:

--- a/source/network/ServerNotification.cpp
+++ b/source/network/ServerNotification.cpp
@@ -60,24 +60,10 @@ std::string ServerNotification::typeString(ServerNotificationType type)
             return "chat";
         case ServerNotificationType::chatServer:
             return "chatServer";
-        case ServerNotificationType::playerWon:
-            return "playerWon";
-        case ServerNotificationType::playerLost:
-            return "playerLost";
-        case ServerNotificationType::markTiles:
-            return "markTiles";
         case ServerNotificationType::turnStarted:
             return "turnStarted";
         case ServerNotificationType::setTurnsPerSecond:
             return "setTurnsPerSecond";
-        case ServerNotificationType::buildRoom:
-            return "buildRoom";
-        case ServerNotificationType::removeRoomTile:
-            return "removeRoomTile";
-        case ServerNotificationType::buildTrap:
-            return "buildTrap";
-        case ServerNotificationType::removeTrapTile:
-            return "removeTrapTile";
         case ServerNotificationType::animatedObjectAddDestination:
             return "animatedObjectAddDestination";
         case ServerNotificationType::animatedObjectClearDestinations:
@@ -120,6 +106,10 @@ std::string ServerNotification::typeString(ServerNotificationType type)
             return "playCreatureSound";
         case ServerNotificationType::refreshTiles:
             return "refreshTiles";
+        case ServerNotificationType::carryEntity:
+            return "carryEntity";
+        case ServerNotificationType::releaseCarriedEntity:
+            return "releaseCarriedEntity";
         case ServerNotificationType::exit:
             return "exit";
         default:

--- a/source/network/ServerNotification.h
+++ b/source/network/ServerNotification.h
@@ -29,8 +29,7 @@ class Creature;
 class MovableGameEntity;
 class Player;
 
-//! \brief A data structure used to pass messages to the serverNotificationProcessor thread.
-//TODO:  Make this class a base class and let specific messages be subclasses of this type with each having its own data structure so they don't need the unused fields
+//! \brief A data structure used to send messages to the clients
 class ServerNotification
 {
     friend class ODServer;
@@ -55,13 +54,7 @@ class ServerNotification
 
             chat,
             chatServer,
-            playerWon,
-            playerLost,
 
-            buildRoom,
-            removeRoomTile,
-            buildTrap,
-            removeTrapTile,
             turnStarted,
             setTurnsPerSecond,
 
@@ -89,9 +82,8 @@ class ServerNotification
             refreshSeatVisDebug,
 
             playSpatialSound, // Makes the client play a sound at tile coordinates.
-            playCreatureSound, // Play a sound at the creature position
+            playCreatureSound, // Play a creature sound at the given position
 
-            markTiles,
             refreshTiles,
             carryEntity,
             releaseCarriedEntity,
@@ -99,8 +91,10 @@ class ServerNotification
             exit
         };
 
-        ServerNotification(ServerNotificationType type,
-            Player* concernedPlayer);
+        /*! \brief Creates a message to be sent to concernedPlayer. If concernedPlayer is null, the message will be sent to
+         *         every connected player.
+         */
+        ServerNotification(ServerNotificationType type, Player* concernedPlayer);
         virtual ~ServerNotification()
         {}
 

--- a/source/network/ServerNotification.h
+++ b/source/network/ServerNotification.h
@@ -85,6 +85,7 @@ class ServerNotification
             playCreatureSound, // Play a creature sound at the given position
 
             refreshTiles,
+            refreshVisibleTiles,
             carryEntity,
             releaseCarriedEntity,
 

--- a/source/render/RenderManager.h
+++ b/source/render/RenderManager.h
@@ -96,11 +96,9 @@ public:
     void rrDetachEntity(GameEntity* curEntity);
     void rrAttachEntity(GameEntity* curEntity);
     void rrTemporalMarkTile(Tile* curTile);
-    void rrCreateBuilding(Building* curBuilding, Tile* curTile);
-    void rrDestroyBuilding(Building* curBuilding, Tile* curTile);
     void rrCreateRenderedMovableEntity(RenderedMovableEntity* curRenderedMovableEntity);
     void rrDestroyRenderedMovableEntity(RenderedMovableEntity* curRenderedMovableEntity);
-    void rrUpdateEntityOpacity(GameEntity* entity);
+    void rrUpdateEntityOpacity(MovableGameEntity* entity);
     void rrCreateCreature(Creature* curCreature);
     void rrDestroyCreature(Creature* curCreature);
     void rrOrientEntityToward(MovableGameEntity* gameEntity, const Ogre::Vector3& direction);
@@ -110,8 +108,8 @@ public:
     void rrCreateMapLight(MapLight* curMapLight, bool displayVisual);
     void rrDestroyMapLight(MapLight* curMapLight);
     void rrDestroyMapLightVisualIndicator(MapLight* curMapLight);
-    void rrPickUpEntity(GameEntity* curEntity, Player* localPlayer);
-    void rrDropHand(GameEntity* curEntity, Player* localPlayer);
+    void rrPickUpEntity(MovableGameEntity* curEntity, Player* localPlayer);
+    void rrDropHand(MovableGameEntity* curEntity, Player* localPlayer);
     void rrRotateHand(Player* localPlayer);
     void rrCreateCreatureVisualDebug(Creature* curCreature, Tile* curTile);
     void rrDestroyCreatureVisualDebug(Creature* curCreature, Tile* curTile);
@@ -120,8 +118,8 @@ public:
     void rrSetObjectAnimationState(MovableGameEntity* curAnimatedObject, const std::string& animation, bool loop);
     void rrMoveEntity(GameEntity* entity, const Ogre::Vector3& position);
     void rrMoveMapLightFlicker(MapLight* mapLight, const Ogre::Vector3& position);
-    void rrCarryEntity(Creature* carrier, GameEntity* carried);
-    void rrReleaseCarriedEntity(Creature* carrier, GameEntity* carried);
+    void rrCarryEntity(Creature* carrier, MovableGameEntity* carried);
+    void rrReleaseCarriedEntity(Creature* carrier, MovableGameEntity* carried);
 
 private:
     bool generateRTSSShadersForMaterial(const std::string& materialName,

--- a/source/render/RenderManager.h
+++ b/source/render/RenderManager.h
@@ -72,11 +72,6 @@ public:
 
     void rtssTest();
 
-    //! \brief Colorize an entity with the team corresponding color.
-    //! \Note: if the entity is marked for digging (wall tiles only), then a yellow color
-    //! is added to the current colorization.
-    void colourizeEntity(Ogre::Entity* ent, Seat* seat, bool markedForDigging = false);
-
     //! \brief Set the entity's opacity
     void setEntityOpacity(Ogre::Entity* ent, float opacity);
 
@@ -133,7 +128,12 @@ private:
     //! \note If the material (wall tiles only) is marked for digging, a yellow color is added
     //! to the given color.
     //! \returns The new material name according to the current colorization.
-    std::string colourizeMaterial(const std::string& materialName, Seat* seat, bool markedForDigging = false);
+    std::string colourizeMaterial(const std::string& materialName, Seat* seat, bool markedForDigging, bool playerHasVision);
+
+    //! \brief Colorize an entity with the team corresponding color.
+    //! \Note: if the entity is marked for digging (wall tiles only), then a yellow color
+    //! is added to the current colorization.
+    void colourizeEntity(Ogre::Entity* ent, Seat* seat, bool markedForDigging, bool playerHasVision);
 
     //! \brief Makes the material be transparent with the given opacity (0.0f - 1.0f)
     //! \returns The new material name according to the current opacity.

--- a/source/rooms/Room.h
+++ b/source/rooms/Room.h
@@ -67,10 +67,10 @@ public:
      */
     virtual void exportHeadersToStream(std::ostream& os);
     virtual void exportHeadersToPacket(ODPacket& os);
-    //! \brief Exports the data of the RenderedMovableEntity
-    virtual void exportToStream(std::ostream& os);
+    //! \brief Exports the data of the Room
+    virtual void exportToStream(std::ostream& os) const;
     virtual void importFromStream(std::istream& is);
-    virtual void exportToPacket(ODPacket& os);
+    virtual void exportToPacket(ODPacket& os) const;
     virtual void importFromPacket(ODPacket& is);
 
     virtual RoomType getType() const = 0;

--- a/source/rooms/RoomCrypt.h
+++ b/source/rooms/RoomCrypt.h
@@ -32,9 +32,9 @@ public:
 
     void doUpkeep();
 
-    bool hasCarryEntitySpot(GameEntity* carriedEntity);
-    Tile* askSpotForCarriedEntity(GameEntity* carriedEntity);
-    void notifyCarryingStateChanged(Creature* carrier, GameEntity* carriedEntity);
+    bool hasCarryEntitySpot(MovableGameEntity* carriedEntity);
+    Tile* askSpotForCarriedEntity(MovableGameEntity* carriedEntity);
+    void notifyCarryingStateChanged(Creature* carrier, MovableGameEntity* carriedEntity);
 protected:
     virtual RenderedMovableEntity* notifyActiveSpotCreated(ActiveSpotPlace place, Tile* tile);
     virtual void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile);

--- a/source/rooms/RoomDungeonTemple.cpp
+++ b/source/rooms/RoomDungeonTemple.cpp
@@ -99,20 +99,11 @@ void RoomDungeonTemple::produceKobold()
     }
 
     Creature* newCreature = new Creature(getGameMap(), classToSpawn);
-    newCreature->setPosition(Ogre::Vector3((Ogre::Real)mCoveredTiles[0]->x,
-                                            (Ogre::Real)mCoveredTiles[0]->y,
-                                            (Ogre::Real)0));
+    Tile* tileSpawn = mCoveredTiles[0];
     newCreature->setSeat(getSeat());
 
-    newCreature->createMesh();
     getGameMap()->addCreature(newCreature);
-
-    // Inform the clients
-    if (getGameMap()->isServerGameMap())
-    {
-        ServerNotification *serverNotification = new ServerNotification(
-           ServerNotification::addCreature, getGameMap()->getPlayerBySeat(getSeat()));
-        newCreature->exportToPacket(serverNotification->mPacket);
-        ODServer::getSingleton().queueServerNotification(serverNotification);
-    }
+    Ogre::Vector3 spawnPosition(static_cast<Ogre::Real>(tileSpawn->getX()), static_cast<Ogre::Real>(tileSpawn->getY()), static_cast<Ogre::Real>(0.0));
+    newCreature->createMesh();
+    newCreature->setPosition(spawnPosition, false);
 }

--- a/source/rooms/RoomForge.cpp
+++ b/source/rooms/RoomForge.cpp
@@ -158,7 +158,7 @@ bool RoomForge::addCreatureUsingRoom(Creature* creature)
     Tile* tileSpot = mUnusedSpots[index];
     mUnusedSpots.erase(mUnusedSpots.begin() + index);
     mCreaturesSpots[creature] = tileSpot;
-    Ogre::Vector3 creaturePosition = creature->getPosition();
+    const Ogre::Vector3& creaturePosition = creature->getPosition();
     Ogre::Real wantedX = -1;
     Ogre::Real wantedY = -1;
     getCreatureWantedPos(creature, tileSpot, wantedX, wantedY);

--- a/source/rooms/RoomForge.cpp
+++ b/source/rooms/RoomForge.cpp
@@ -276,7 +276,7 @@ void RoomForge::doUpkeep()
             {
                 Ogre::Vector3 walkDirection(ro->getPosition().x - creature->getPosition().x, ro->getPosition().y - creature->getPosition().y, 0);
                 walkDirection.normalise();
-                creature->setAnimationState("Attack1", false, &walkDirection);
+                creature->setAnimationState("Attack1", false, walkDirection);
 
                 ro->setAnimationState("Triggered", false);
                 // TODO : use efficiency from creature for this room
@@ -318,23 +318,23 @@ void RoomForge::doUpkeep()
         return;
 
     CraftedTrap* craftedTrap = new CraftedTrap(getGameMap(), getName(), mTrapType);
-    Ogre::Vector3 pos(static_cast<Ogre::Real>(tileCraftedTrap->x), static_cast<Ogre::Real>(tileCraftedTrap->y), 0.0f);
-    craftedTrap->setPosition(pos);
-    tileCraftedTrap->addCraftedTrap(craftedTrap);
     getGameMap()->addRenderedMovableEntity(craftedTrap);
+    Ogre::Vector3 spawnPosition(static_cast<Ogre::Real>(tileCraftedTrap->getX()), static_cast<Ogre::Real>(tileCraftedTrap->getY()), static_cast<Ogre::Real>(0.0));
+    craftedTrap->createMesh();
+    craftedTrap->setPosition(spawnPosition, false);
     mPoints -= pointsNeeded;
     mTrapType = Trap::TrapType::nullTrapType;
 }
 
 uint32_t RoomForge::countCraftedItemsOnRoom()
 {
-    std::vector<GameEntity*> carryable;
+    std::vector<MovableGameEntity*> carryable;
     for(Tile* t : mCoveredTiles)
     {
         t->fillWithCarryableEntities(carryable);
     }
     uint32_t nbCraftedTrap = 0;
-    for(GameEntity* entity : carryable)
+    for(MovableGameEntity* entity : carryable)
     {
         if(entity->getObjectType() != GameEntity::ObjectType::renderedMovableEntity)
             continue;
@@ -354,9 +354,9 @@ Tile* RoomForge::checkIfAvailableSpot(const std::vector<Tile*>& activeSpots)
     {
         // If the tile contains no crafted trap, we can add a new one
         bool isFilled = false;
-        std::vector<GameEntity*> entities;
+        std::vector<MovableGameEntity*> entities;
         tile->fillWithCarryableEntities(entities);
-        for(GameEntity* entity : entities)
+        for(MovableGameEntity* entity : entities)
         {
             if(entity->getObjectType() != GameEntity::ObjectType::renderedMovableEntity)
                 continue;

--- a/source/rooms/RoomHatchery.cpp
+++ b/source/rooms/RoomHatchery.cpp
@@ -81,10 +81,10 @@ void RoomHatchery::doUpkeep()
     for(Tile* chickenCoopTile : mCentralActiveSpotTiles)
     {
         ChickenEntity* chicken = new ChickenEntity(getGameMap(), getName());
-        Ogre::Vector3 pos(static_cast<Ogre::Real>(chickenCoopTile->x), static_cast<Ogre::Real>(chickenCoopTile->y), 0.0f);
-        chicken->setPosition(pos);
-        chickenCoopTile->addChickenEntity(chicken);
         getGameMap()->addRenderedMovableEntity(chicken);
+        chicken->createMesh();
+        Ogre::Vector3 spawnPosition(static_cast<Ogre::Real>(chickenCoopTile->x), static_cast<Ogre::Real>(chickenCoopTile->y), 0.0f);
+        chicken->setPosition(spawnPosition, false);
         chicken->setMoveSpeed(CHICKEN_SPEED);
         ++nbChickens;
         if(nbChickens >= mNumActiveSpots)

--- a/source/rooms/RoomPortal.cpp
+++ b/source/rooms/RoomPortal.cpp
@@ -148,33 +148,14 @@ void RoomPortal::spawnCreature()
     LogManager::getSingleton().logMessage("Spawning a creature class=" + classToSpawn->getClassName()
         + ", name=" + newCreature->getName() + ", seatId=" + Ogre::StringConverter::toString(getSeat()->getId()));
 
-    // Set the creature specific parameters.
-    //NOTE:  This needs to be modified manually when the level file creature format changes.
-    newCreature->setPosition(Ogre::Vector3((Ogre::Real)mXCenter, (Ogre::Real)mYCenter, (Ogre::Real)0.0));
     newCreature->setSeat(getSeat());
 
-    // Add the creature to the gameMap and create meshes so it is visible.
     getGameMap()->addCreature(newCreature);
+    Ogre::Vector3 spawnPosition(static_cast<Ogre::Real>(mXCenter), static_cast<Ogre::Real>(mYCenter), 0.0f);
     newCreature->createMesh();
+    newCreature->setPosition(spawnPosition, false);
 
     mSpawnCreatureCountdown = Random::Uint(15, 30);
-
-    // Inform the clients
-    if (getGameMap()->isServerGameMap())
-    {
-        try
-        {
-           ServerNotification *serverNotification = new ServerNotification(
-               ServerNotification::addCreature, newCreature->getGameMap()->getPlayerBySeat(newCreature->getSeat()));
-           newCreature->exportToPacket(serverNotification->mPacket);
-           ODServer::getSingleton().queueServerNotification(serverNotification);
-        }
-        catch (std::bad_alloc&)
-        {
-            Ogre::LogManager::getSingleton().logMessage("ERROR: bad alloc in RoomDungeonTemple::produceKobold", Ogre::LML_CRITICAL);
-            exit(1);
-        }
-    }
 }
 
 void RoomPortal::recomputeCenterPosition()

--- a/source/rooms/RoomTrainingHall.cpp
+++ b/source/rooms/RoomTrainingHall.cpp
@@ -272,7 +272,7 @@ void RoomTrainingHall::doUpkeep()
             {
                 Ogre::Vector3 walkDirection(ro->getPosition().x - creature->getPosition().x, ro->getPosition().y - creature->getPosition().y, 0);
                 walkDirection.normalise();
-                creature->setAnimationState("Attack1", false, &walkDirection);
+                creature->setAnimationState("Attack1", false, walkDirection);
 
                 ro->setAnimationState("Triggered", false);
                 creature->receiveExp(ConfigManager::getSingleton().getRoomConfigDouble("TrainHallXpPerAttack"));

--- a/source/rooms/RoomTrainingHall.cpp
+++ b/source/rooms/RoomTrainingHall.cpp
@@ -151,7 +151,7 @@ void RoomTrainingHall::refreshCreaturesDummies()
         mCreaturesDummies[creature] = tileDummy;
 
         // Set destination to the newly affected dummies if there was a change
-        Ogre::Vector3 creaturePosition = creature->getPosition();
+        const Ogre::Vector3& creaturePosition = creature->getPosition();
         Ogre::Real wantedX = -1;
         Ogre::Real wantedY = -1;
         getCreatureWantedPos(creature, tileDummy, wantedX, wantedY);
@@ -192,7 +192,7 @@ bool RoomTrainingHall::addCreatureUsingRoom(Creature* creature)
     Tile* tileDummy = mUnusedDummies[index];
     mUnusedDummies.erase(mUnusedDummies.begin() + index);
     mCreaturesDummies[creature] = tileDummy;
-    Ogre::Vector3 creaturePosition = creature->getPosition();
+    const Ogre::Vector3& creaturePosition = creature->getPosition();
     Ogre::Real wantedX = -1;
     Ogre::Real wantedY = -1;
     getCreatureWantedPos(creature, tileDummy, wantedX, wantedY);

--- a/source/rooms/RoomTreasury.h
+++ b/source/rooms/RoomTreasury.h
@@ -41,9 +41,9 @@ public:
     int withdrawGold(int gold);
     virtual void doUpkeep();
 
-    bool hasCarryEntitySpot(GameEntity* carriedEntity);
-    Tile* askSpotForCarriedEntity(GameEntity* carriedEntity);
-    void notifyCarryingStateChanged(Creature* carrier, GameEntity* carriedEntity);
+    bool hasCarryEntitySpot(MovableGameEntity* carriedEntity);
+    Tile* askSpotForCarriedEntity(MovableGameEntity* carriedEntity);
+    void notifyCarryingStateChanged(Creature* carrier, MovableGameEntity* carriedEntity);
 
 protected:
     // Because treasury do not use active spots, we don't want the default

--- a/source/sound/SoundEffectsManager.cpp
+++ b/source/sound/SoundEffectsManager.cpp
@@ -222,7 +222,7 @@ void SoundEffectsManager::initializeDefaultCreatureSounds()
     // Battle sounds
     std::vector<std::string> soundFilenames;
     Helper::fillFilesList(soundFolderPath + "Creatures/Default/Battle/", soundFilenames, ".ogg");
-    std::vector<GameSound*>& attackSounds = crSound->mSoundsPerType[CreatureSound::ATTACK];
+    std::vector<GameSound*>& attackSounds = crSound->mSoundsPerType[CreatureSound::SoundType::ATTACK];
     for (unsigned int i = 0; i < soundFilenames.size(); ++i)
     {
         GameSound* gm = getGameSound(soundFilenames[i], true);
@@ -233,7 +233,7 @@ void SoundEffectsManager::initializeDefaultCreatureSounds()
     // Digging sounds
     soundFilenames.clear();
     Helper::fillFilesList(soundFolderPath + "Creatures/Default/Digging/", soundFilenames, ".ogg");
-    std::vector<GameSound*>& diggingSounds = crSound->mSoundsPerType[CreatureSound::DIGGING];
+    std::vector<GameSound*>& diggingSounds = crSound->mSoundsPerType[CreatureSound::SoundType::DIGGING];
     for (unsigned int i = 0; i < soundFilenames.size(); ++i)
     {
         GameSound* gm = getGameSound(soundFilenames[i], true);
@@ -244,7 +244,7 @@ void SoundEffectsManager::initializeDefaultCreatureSounds()
     // Pickup sounds - PICKUP
     // 1 sound atm...
     {
-        std::vector<GameSound*>& pickupSounds = crSound->mSoundsPerType[CreatureSound::PICKUP];
+        std::vector<GameSound*>& pickupSounds = crSound->mSoundsPerType[CreatureSound::SoundType::PICKUP];
         GameSound* gm = getGameSound(soundFolderPath + "Game/click.ogg", true);
         pickupSounds.push_back(gm);
     }
@@ -252,7 +252,7 @@ void SoundEffectsManager::initializeDefaultCreatureSounds()
     // Drop sounds - DROP
     // 1 sound atm...
     {
-        std::vector<GameSound*>& dropSounds = crSound->mSoundsPerType[CreatureSound::DROP];
+        std::vector<GameSound*>& dropSounds = crSound->mSoundsPerType[CreatureSound::SoundType::DROP];
         GameSound* gm = getGameSound(soundFolderPath + "Rooms/default_build_trap.ogg", true);
         dropSounds.push_back(gm);
     }

--- a/source/sound/SoundEffectsManager.h
+++ b/source/sound/SoundEffectsManager.h
@@ -145,6 +145,9 @@ private:
     //! the GameSound* instance is correclty cleared up when quitting.
     //! \warning Returns NULL if the filename is an invalid/unreadable sound.
     GameSound* getGameSound(const std::string& filename, bool spatialSound = false);
+
+    //! \brief The list of available sound to play per type.
+    std::vector<std::pair<std::vector<GameSound*>,int>> mSoundsPerType;
 };
 
 #endif // SOUNDEFFECTSMANAGER_H_

--- a/source/traps/Trap.h
+++ b/source/traps/Trap.h
@@ -150,19 +150,19 @@ public:
     static int32_t getNeededForgePointsPerTrap(TrapType trapType);
     virtual bool isNeededCraftedTrap() const;
 
-    bool hasCarryEntitySpot(GameEntity* carriedEntity);
-    Tile* askSpotForCarriedEntity(GameEntity* carriedEntity);
-    void notifyCarryingStateChanged(Creature* carrier, GameEntity* carriedEntity);
+    bool hasCarryEntitySpot(MovableGameEntity* carriedEntity);
+    Tile* askSpotForCarriedEntity(MovableGameEntity* carriedEntity);
+    void notifyCarryingStateChanged(Creature* carrier, MovableGameEntity* carriedEntity);
 
     /*! \brief Exports the headers needed to recreate the Trap. It allows to extend Traps as much as wanted.
      * The content of the Trap will be exported by exportToPacket.
      */
     virtual void exportHeadersToStream(std::ostream& os);
     virtual void exportHeadersToPacket(ODPacket& os);
-    //! \brief Exports the data of the RenderedMovableEntity
-    virtual void exportToStream(std::ostream& os);
+    //! \brief Exports the data of the Trap
+    virtual void exportToStream(std::ostream& os) const;
     virtual void importFromStream(std::istream& is);
-    virtual void exportToPacket(ODPacket& os);
+    virtual void exportToPacket(ODPacket& os) const;
     virtual void importFromPacket(ODPacket& is);
 
     static std::string getFormat();

--- a/source/traps/TrapBoulder.cpp
+++ b/source/traps/TrapBoulder.cpp
@@ -77,10 +77,10 @@ bool TrapBoulder::shoot(Tile* tile)
     direction.normalise();
     MissileBoulder* missile = new MissileBoulder(getGameMap(), getSeat(), getName(), "Boulder",
         direction, Random::Double(mMinDamage, mMaxDamage));
-    missile->setPosition(position);
     getGameMap()->addRenderedMovableEntity(missile);
-    missile->setMoveSpeed(ConfigManager::getSingleton().getTrapConfigDouble("BoulderSpeed"));
     missile->createMesh();
+    missile->setPosition(position, false);
+    missile->setMoveSpeed(ConfigManager::getSingleton().getTrapConfigDouble("BoulderSpeed"));
     // We don't want the missile to stay idle for 1 turn. Because we are in a doUpkeep context,
     // we can safely call the missile doUpkeep as we know the engine will not call it the turn
     // it has been added

--- a/source/traps/TrapCannon.cpp
+++ b/source/traps/TrapCannon.cpp
@@ -62,10 +62,10 @@ bool TrapCannon::shoot(Tile* tile)
     direction.normalise();
     MissileOneHit* missile = new MissileOneHit(getGameMap(), getSeat(), getName(), "Cannonball",
         direction, Random::Double(mMinDamage, mMaxDamage), 0.0, false);
-    missile->setPosition(position);
     getGameMap()->addRenderedMovableEntity(missile);
-    missile->setMoveSpeed(ConfigManager::getSingleton().getTrapConfigDouble("CannonSpeed"));
     missile->createMesh();
+    missile->setPosition(position, false);
+    missile->setMoveSpeed(ConfigManager::getSingleton().getTrapConfigDouble("CannonSpeed"));
     // We don't want the missile to stay idle for 1 turn. Because we are in a doUpkeep context,
     // we can safely call the missile doUpkeep as we know the engine will not call it the turn
     // it has been added

--- a/source/traps/TrapSpike.cpp
+++ b/source/traps/TrapSpike.cpp
@@ -48,15 +48,13 @@ bool TrapSpike::shoot(Tile* tile)
     spike->setAnimationState("Triggered", false);
 
     // We damage every creature standing on the trap
-    for(std::vector<GameEntity*>::iterator it = enemyCreatures.begin(); it != enemyCreatures.end(); ++it)
+    for(GameEntity* target : enemyCreatures)
     {
-        GameEntity* target = *it;
         target->takeDamage(this, Random::Double(mMinDamage, mMaxDamage), 0.0, target->getCoveredTiles()[0]);
     }
     std::vector<GameEntity*> alliedCreatures = getGameMap()->getVisibleCreatures(visibleTiles, getSeat(), false);
-    for(std::vector<GameEntity*>::iterator it = alliedCreatures.begin(); it != alliedCreatures.end(); ++it)
+    for(GameEntity* target : alliedCreatures)
     {
-        GameEntity* target = *it;
         target->takeDamage(this, Random::Double(mMinDamage, mMaxDamage), 0.0, target->getCoveredTiles()[0]);
     }
     return true;


### PR DESCRIPTION
Merry christmas everybody ^^

As a christmas gift, here is the PR implementing FOW.
This PR also contains a lot of small fixes / improvements.

Known bugs:
- When an ennemy claims your last visible tile, you loose vision but the tile is still displayed with your color (I will create an issue for that because this commit was big enough) #395 
- Creature vision is not well handled (that's really visible now that it is used for FOW - I will create an issue) #396 
- The not visible tiles are displayed like the visible ones so it's not obvious which tiles you have vision on or not

This needs to be tested well.
Please note that on the 2v2 skirmish test map, I've added a dead creature and an ennemy kobold to see what happens when you loose vision on a kobold carrying a dead corpse.

@Bertram25 Sorry for the big PR to review

@oyvindln Don't hesitate to have a look if you can

@akien-mga As I said, this PR changes the architecture of most of the game so it can introduce regressions nearly everywhere. Please don't hesitate to test it as much as you can ^^

Enjoy ^^
