### PR TITLE
Fixed memory leak and some warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,16 +349,16 @@ find_package(OGRE REQUIRED)
 find_package(CEGUI REQUIRED)
 find_package(SFML 2 REQUIRED COMPONENTS Audio System Network)
 
-if ((OGRE_VERSION_MAJOR LESS 1) AND (OGRE_VERSION_MINOR LESS 9))
-    message(SEND_ERROR "OGRE version >= 1.9.0 required")
+if((OGRE_VERSION_MAJOR LESS 1) AND (OGRE_VERSION_MINOR LESS 9))
+    message(FATAL_ERROR "OGRE version >= 1.9.0 required")
 endif()
 
-if ((CEGUI_VERSION_MINOR LESS 8) OR (CEGUI_VERSION_MAJOR LESS 1))
-    message(SEND_ERROR "CEGUI version >= 0.8.0 required")
+if("${CEGUI_VERSION}" VERSION_LESS "0.8.0")
+    message(FATAL_ERROR "CEGUI version >= 0.8.0 required")
 endif()
 
 if (SFML_VERSION_MAJOR LESS 2)
-    message(SEND_ERROR "SFML version >= 2.0 required")
+    message(FATAL_ERROR "SFML version >= 2.0 required")
 else()
     message(STATUS "SFML include directory: ${SFML_INCLUDE_DIR}; SFML audio library: ${SFML_AUDIO_LIBRARY_DEBUG} ${SFML_AUDIO_LIBRARY_RELEASE}")
 endif()
@@ -473,8 +473,8 @@ target_link_libraries(
     ${OGRE_RTShaderSystem_LIBRARIES}
     ${OPENAL_LIBRARY}
     ${OIS_LIBRARIES}
-    ${CEGUI_LIBRARIES_RELEASE}
-    ${CEGUI_LIBRARIES_DEBUG}
+    ${CEGUI_LIBRARIES}
+    ${CEGUI_OgreRenderer_LIBRARIES}
 )
 
 # Set linker options in MSVC
@@ -496,16 +496,7 @@ endif()
 # Link sfml
 # No need to make a difference when release/debug is found because even
 # if only one is found, the other is set to the same value
-target_link_libraries(
-    ${PROJECT_BINARY_NAME}
-
-    optimized ${SFML_AUDIO_LIBRARY_RELEASE}
-    optimized ${SFML_SYSTEM_LIBRARY_RELEASE}
-    optimized ${SFML_NETWORK_LIBRARY_RELEASE}
-    debug ${SFML_AUDIO_LIBRARY_DEBUG}
-    debug ${SFML_SYSTEM_LIBRARY_DEBUG}
-    debug ${SFML_NETWORK_LIBRARY_DEBUG}
-)
+target_link_libraries(${PROJECT_BINARY_NAME} ${SFML_LIBRARIES})
 
 ##################################
 #### Unit testing ################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,8 @@ endif()
 #### ExplicitCompilerFlags #######
 ##################################
 
+# TODO: Use add_compiler_options instead of setting CMAKE_CXX_FLAGS
+
 # CMAKE_CXX_FLAGS are meant to be defined using these two public strings
 # This makes it possible to have them explicitly displayed in CMake GUI
 # CMAKE_CXX_FLAGS can still be used to override our default defintions
@@ -112,6 +114,13 @@ else()
     if(OD_ENABLE_WARNINGS)
         # Help getting compilation warnings
         set(OD_OPT_FLAGS "${OD_OPT_FLAGS} -Wall")
+        #for later https://stackoverflow.com/questions/5088460/flags-to-enable-thorough-and-verbose-g-warnings/9862800#9862800:
+        #set(OD_OPT_FLAGS "${OD_OPT_FLAGS} -pedantic -Wextra -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization ")
+        #set(OD_OPT_FLAGS "${OD_OPT_FLAGS} -Wformat=2 -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-include-dirs -Wnoexcept")
+        #set(OD_OPT_FLAGS "${OD_OPT_FLAGS} -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wsign-conversion -Wsign-promo")
+        #set(OD_OPT_FLAGS "${OD_OPT_FLAGS} -Wstrict-null-sentinel -Wstrict-overflow=5 -Wswitch-default -Wundef -Wno-unused")
+        #set(OD_OPT_FLAGS "${OD_OPT_FLAGS} -Winline -Winvalid-pch -Wswitch-enum -Wzero-as-null-pointer-constant -Wuseless-cast")
+        #set(OD_OPT_FLAGS "${OD_OPT_FLAGS} -Weffc++")
     endif()
     if(MINGW)
         if(NOT OD_CXX11_FLAGS)
@@ -397,25 +406,22 @@ include_directories(
     #OpenDungeons includes
     ${CMAKE_SOURCE_DIR}/source
 
-    #General external includes
-    ${DEPENDENCIES_DIR}
-
     #Angelscript includes
-    ${ANGELSCRIPT_DIR}/angelscript/include
-    ${ANGELSCRIPT_SRC_DIR}
+    SYSTEM ${ANGELSCRIPT_DIR}/angelscript/include
+    SYSTEM ${ANGELSCRIPT_SRC_DIR}
 
     #AngelScript Addons, in-comment only the ones we actually use
-    ${ANGELSCRIPT_ADDON_DIR}/scriptarray
-    ${ANGELSCRIPT_ADDON_DIR}/scriptbuilder
-    ${ANGELSCRIPT_ADDON_DIR}/scripthelper
-    ${ANGELSCRIPT_ADDON_DIR}/scriptstdstring
+    SYSTEM ${ANGELSCRIPT_ADDON_DIR}/scriptarray
+    SYSTEM ${ANGELSCRIPT_ADDON_DIR}/scriptbuilder
+    SYSTEM ${ANGELSCRIPT_ADDON_DIR}/scripthelper
+    SYSTEM ${ANGELSCRIPT_ADDON_DIR}/scriptstdstring
 
     #external packages includes
-    ${CEGUI_INCLUDE_DIR}
-    ${SFML_INCLUDE_DIR}
-    ${OGRE_INCLUDE_DIRS}
-    ${OPENAL_INCLUDE_DIR}
-    ${OIS_INCLUDE_DIRS}
+    SYSTEM ${CEGUI_INCLUDE_DIR}
+    SYSTEM ${SFML_INCLUDE_DIR}
+    SYSTEM ${OGRE_INCLUDE_DIRS}
+    SYSTEM ${OPENAL_INCLUDE_DIR}
+    SYSTEM ${OIS_INCLUDE_DIRS}
 )
 
 if(WIN32)
@@ -423,11 +429,11 @@ if(WIN32)
         #TODO: Why are we linking boost here? It's linked again later.
         # Boost
         link_libraries(${Boost_LIBRARIES})
-        include_directories(${Boost_INCLUDE_DIRS})
+        include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
     endif()
 
     if(MSVC)
-        include_directories(${OD_BOOST_INCLUDE_DIRS})
+        include_directories(SYSTEM ${OD_BOOST_INCLUDE_DIRS})
         link_directories(${OD_BOOST_LIB_DIRS})
     endif()
 endif()
@@ -438,6 +444,11 @@ endif()
 
 # Create the angelscript library file
 add_library(${AS_LIBRARY_NAME} ${AS_SOURCEFILES})
+
+# Treat warnings as errors for main build, but not angelscript, since it would fail.
+if(NOT MSVC)
+    add_compile_options("-Werror")
+endif()
 
 # Create the binary file (WIN32 makes sure there is no console window on windows.)
 add_executable(${PROJECT_BINARY_NAME} WIN32 ${OD_SOURCEFILES})
@@ -463,7 +474,7 @@ target_link_libraries(
     ${OPENAL_LIBRARY}
     ${OIS_LIBRARIES}
     ${CEGUI_LIBRARIES_RELEASE}
-    #${CEGUI_LIBRARIES_DEBUG}
+    ${CEGUI_LIBRARIES_DEBUG}
 )
 
 # Set linker options in MSVC

--- a/cmake/modules/FindCEGUI.cmake
+++ b/cmake/modules/FindCEGUI.cmake
@@ -1,130 +1,636 @@
-# - Try to find CEGUI
-# Once done, this will define
+################################################################################
+# FindCEGUI
 #
-#  CEGUI_FOUND - system has CEGUI
-#  CEGUI_INCLUDE_DIRS - the CEGUI include directories 
-#  CEGUI_LIBRARIES_RELEASE - link these to use CEGUI release
-#  CEGUI_LIBRARIES_DEBUG - link these to use CEGUI debug
+# Locate CEGUI LIBRARIES
+#
+# This module defines
+#    CEGUI_FOUND, if false, do not try to link to CEGUI
+#    CEGUI_INCLUDE_DIR, where to find headers.
+#    CEGUI_LIBRARIES, the LIBRARIES to link against
+#    CEGUI_BINARY_REL - location of the main CEGUI binary (win32 non-static only, release)
+#    CEGUI_BINARY_DBG - location of the main CEGUI binaries (win32 non-static only, debug)
+#
+#
+#         Modules :
+#    CEGUI_${COMPONENT}_FOUND - ${COMPONENT} is available
+#    CEGUI_${COMPONENT}_INCLUDE_DIRS - additional include directories for ${COMPONENT}
+#    CEGUI_${COMPONENT}_LIBRARIES - link these to use ${COMPONENT}
+#    CEGUI_${COMPONENT}_BINARY_REL - location of the component binary (win32 non-static only, release)
+#    CEGUI_${COMPONENT}_BINARY_DBG - location of the component binary (win32 non-static only, debug)
+#
+# VERSION 0.7.X:
+#        WindowsRenderer:
+#                Falagard
+#        Renderer:
+#                Direct3D9Renderer Direct3D10Renderer Direct3D11Renderer IrrlichtRenderer NullRenderer OgreRenderer OpenGLRenderer
+#        ImageCodec:
+#                CoronaImageCodec DevILImageCodec FreeImageImageCodec SILLYImageCodec STBImageCodec TGAImageCodec
+#        Parser:
+#                ExpatParser LibxmlParser RapidXMLParser TinyXMLParser XercesParser)
+#        Script:
+#                LuaScriptModule toluapp
 
-find_package(PkgConfig)
-#pkg_check_modules(PC_CEGUI CEGUI)
-#pkg_check_modules(PC_CEGUIOGRE CEGUI-OGRE)
+# VERSION 0.8.X:
+#        WindowsRenderer:
+#                CoreWindowRendererSet
+#        Renderer:
+#                Direct3D9Renderer Direct3D10Renderer Direct3D11Renderer IrrlichtRenderer NullRenderer OgreRenderer OpenGLRenderer OpenGL3Renderer OpenGLESRenderer
+#        ImageCodec:
+#                CoronaImageCodec DevILImageCodec FreeImageImageCodec SILLYImageCodec STBImageCodec TGAImageCodec PVRImageCodec
+#        Parser:
+#                ExpatParser LibXMLParser RapidXMLParser TinyXMLParser XercesParser)
+#        Script:
+#                LuaScriptModule
+#
+# author: Guillaume Smaha
+#
+# People have asked us to include a FindCEGUI that is high quality that they will
+# be able to copy and use to find CEGUI, so we have finally done that.
+#
+# If you have improvements for this scripts, please consider sending them upstream.
+# See https://bitbucket.org/cegui/cegui
+################################################################################
 
-message(STATUS "looking for headers")
-#TODO - check for ogre renderer
-#Look for headers
-find_path(CEGUI_INCLUDE_DIR CEGUI/CEGUI.h
-    HINTS $ENV{CEGUIDIR}
-    ${PC_CEGUI_INCLUDEDIR}
-    PATH_SUFFIXES cegui-0 include/cegui-0 include cegui/include
-    PATHS
-    ~/Library/Frameworks
-    /Library/Frameworks
-    /usr/local/include/
-    /usr/include/
-    /sw # Fink
-    /opt/local # DarwinPorts
-    /opt/csw # Blastwave
-    /opt
+
+################################################################################
+# Get the value of a preprocessor entry
+################################################################################
+macro(get_preprocessor_entry CONTENTS KEYWORD VARIABLE)
+    string(REGEX MATCH
+        "# *define +${KEYWORD} +((\"([^\n]*)\")|([^ \n]*))"
+        PREPROC_TEMP_VAR
+        ${${CONTENTS}}
     )
-    
-#Look for libs
-find_library(CEGUI_LIBRARY_REL
-  CEGUIBase-0 CEGUIBase
-  HINTS
-  $ENV{CEGUIDIR}
-  ${PC_CEGUI_LIBDIR}
-  PATH_SUFFIXES lib64 lib
-  PATHS
-  /sw
-  /opt/local
-  /opt/csw
-  /opt
-  /usr
-  /usr/local
+    if (CMAKE_MATCH_3)
+        set(${VARIABLE} ${CMAKE_MATCH_3})
+    else ()
+        set(${VARIABLE} ${CMAKE_MATCH_4})
+    endif ()
+endmacro()
+
+################################################################################
+# Check if exist a preprocessor entry
+################################################################################
+macro(has_preprocessor_entry CONTENTS KEYWORD VARIABLE)
+    string(REGEX MATCH
+        "\n *# *define +(${KEYWORD})"
+        PREPROC_TEMP_VAR
+        ${${CONTENTS}}
+    )
+    if (CMAKE_MATCH_1)
+        set(${VARIABLE} TRUE)
+    else ()
+        set(${VARIABLE} FALSE)
+    endif ()
+endmacro()
+
+################################################################################
+# Replace the value of a preprocessor entry
+################################################################################
+macro(replace_preprocessor_entry VARIABLE KEYWORD NEW_VALUE)
+    string(REGEX REPLACE
+        "(// *)?# *define +${KEYWORD} +[^ \n]*"
+        "#define ${KEYWORD} ${NEW_VALUE}"
+        ${VARIABLE}_TEMP
+        ${${VARIABLE}}
+    )
+    set(${VARIABLE} ${${VARIABLE}_TEMP})
+endmacro()
+
+################################################################################
+# Define the value of preprocessor entry
+################################################################################
+macro(set_preprocessor_entry VARIABLE KEYWORD ENABLE)
+    if (${ENABLE})
+        set(TMP_REPLACE_STR "#define ${KEYWORD}")
+    else ()
+        set(TMP_REPLACE_STR "// #define ${KEYWORD}")
+    endif ()
+    string(REGEX REPLACE
+        "(// *)?# *define +${KEYWORD} *\n"
+        ${TMP_REPLACE_STR}
+        ${VARIABLE}_TEMP
+        ${${VARIABLE}}
+    )
+    set(${VARIABLE} ${${VARIABLE}_TEMP})
+endmacro()
+
+################################################################################
+# Begin processing of package
+################################################################################
+macro(findpkg_begin PREFIX)
+    if (NOT ${PREFIX}_FIND_QUIETLY)
+        message(STATUS "Looking for ${PREFIX}...")
+    endif ()
+endmacro(findpkg_begin)
+
+################################################################################
+# Display a status message unless FIND_QUIETLY is set
+################################################################################
+macro(pkg_message PREFIX)
+    if (NOT ${PREFIX}_FIND_QUIETLY)
+        message(STATUS ${ARGN})
+    endif ()
+endmacro(pkg_message)
+
+################################################################################
+# Get environment variable, define it as ENV_$var and make sure backslashes are converted to forward slashes
+################################################################################
+macro(getenv_path VAR)
+     set(ENV_${VAR} $ENV{${VAR}})
+     # replace won't work if var is blank
+     if (ENV_${VAR})
+         string( REGEX REPLACE "\\\\" "/" ENV_${VAR} ${ENV_${VAR}} )
+     endif ()
+endmacro(getenv_path)
+
+################################################################################
+# Construct search paths for includes and libraries from a PREFIX_PATH
+################################################################################
+macro(create_search_paths PREFIX)
+    foreach(dir ${${PREFIX}_PREFIX_PATH})
+        set(${PREFIX}_INC_SEARCH_PATH ${${PREFIX}_INC_SEARCH_PATH}
+            ${dir}/include ${dir}/Include ${dir}/include/${PREFIX} ${dir}/Headers)
+        set(${PREFIX}_INC_SEARCH_PATH ${${PREFIX}_INC_SEARCH_PATH}
+            ${dir}/${PREFIX}/include ${dir}/${PREFIX}/Include ${dir}/${PREFIX}/include/${PREFIX} ${dir}/${PREFIX}/Headers)
+        set(${PREFIX}_LIB_SEARCH_PATH ${${PREFIX}_LIB_SEARCH_PATH}
+            ${dir}/lib ${dir}/Lib ${dir}/lib/${PREFIX} ${dir}/Libs)
+        set(${PREFIX}_BIN_SEARCH_PATH ${${PREFIX}_BIN_SEARCH_PATH}
+            ${dir}/bin)
+    endforeach(dir)
+    if(ANDROID)
+        set(${PREFIX}_LIB_SEARCH_PATH ${${PREFIX}_LIB_SEARCH_PATH} ${OGRE_DEPENDENCIES_DIR}/lib/${ANDROID_ABI})
+    endif()
+    set(${PREFIX}_FRAMEWORK_SEARCH_PATH ${${PREFIX}_PREFIX_PATH})
+endmacro(create_search_paths)
+
+################################################################################
+# clear cache variables if a certain variable changed
+################################################################################
+macro(clear_if_changed TESTVAR)
+    # test against internal check variable
+    # HACK: Apparently, adding a variable to the cache cleans up the list
+    # a bit. We need to also remove any empty strings from the list, but
+    # at the same time ensure that we are actually dealing with a list.
+    list(APPEND ${TESTVAR} "")
+    list(REMOVE_ITEM ${TESTVAR} "")
+    if (NOT "${${TESTVAR}}" STREQUAL "${${TESTVAR}_INT_CHECK}")
+        message(STATUS "${TESTVAR} changed.")
+        foreach(var ${ARGN})
+            set(${var} "NOTFOUND" CACHE STRING "${var}-docstring" FORCE)
+        endforeach(var)
+    endif ()
+    set(${TESTVAR}_INT_CHECK ${${TESTVAR}} CACHE INTERNAL "${TESTVAR}-docstring" FORCE)
+endmacro(clear_if_changed)
+
+################################################################################
+# Try to get some hints from pkg-config, if available
+################################################################################
+macro(use_pkgconfig PREFIX PKGNAME)
+    find_package(PkgConfig)
+    if (PKG_CONFIG_FOUND)
+        pkg_check_modules(${PREFIX} ${PKGNAME} QUIET)
+    endif ()
+endmacro (use_pkgconfig)
+
+################################################################################
+# Couple a set of release AND debug libraries (or frameworks)
+################################################################################
+macro(make_library_set PREFIX)
+
+    if (${PREFIX}_FWK)
+        set(${PREFIX} ${${PREFIX}_FWK})
+    elseif (${PREFIX}_REL AND ${PREFIX}_DBG)
+        set(${PREFIX} optimized ${${PREFIX}_REL} debug ${${PREFIX}_DBG})
+    elseif (${PREFIX}_REL)
+        set(${PREFIX} ${${PREFIX}_REL})
+    elseif (${PREFIX}_DBG)
+        set(${PREFIX} ${${PREFIX}_DBG})
+    endif ()
+endmacro(make_library_set)
+
+################################################################################
+# Generate debug names from given release names
+################################################################################
+macro(get_debug_names PREFIX)
+    foreach(i ${${PREFIX}})
+        set(${PREFIX}_DBG ${${PREFIX}_DBG} ${i}d ${i}D ${i}_d ${i}_D ${i}_debug ${i})
+    endforeach(i)
+endmacro(get_debug_names)
+
+################################################################################
+# Add the parent dir from DIR to VAR
+################################################################################
+macro(add_parent_dir VAR DIR)
+    get_filename_component(${DIR}_TEMP "${${DIR}}/.." ABSOLUTE)
+    set(${VAR} ${${VAR}} ${${DIR}_TEMP})
+endmacro(add_parent_dir)
+
+################################################################################
+# Do the final processing for the package find.
+################################################################################
+macro(findpkg_finish PREFIX)
+    # skip if already processed during this run
+    if (NOT ${PREFIX}_FOUND)
+        if (${PREFIX}_INCLUDE_DIR AND ${PREFIX}_LIBRARY)
+            set(${PREFIX}_FOUND TRUE)
+            set(${PREFIX}_INCLUDE_DIRS ${${PREFIX}_INCLUDE_DIR})
+            set(${PREFIX}_LIBRARIES ${${PREFIX}_LIBRARY})
+            if (NOT ${PREFIX}_FIND_QUIETLY)
+                message(STATUS "Found ${PREFIX}: ${${PREFIX}_LIBRARIES}")
+            endif ()
+        else ()
+            if (NOT ${PREFIX}_FIND_QUIETLY)
+                message(STATUS "Could not locate ${PREFIX}")
+            endif ()
+            if (${PREFIX}_FIND_REQUIRED)
+                message(FATAL_ERROR "Required library ${PREFIX} not found! Install the library (including dev packages) and try again. If the library is already installed, set the missing variables manually in cmake.")
+            endif ()
+        endif ()
+
+        mark_as_advanced(${PREFIX}_FOUND ${PREFIX}_LIBRARIES ${PREFIX}_INCLUDE_DIRS ${PREFIX}_INCLUDE_DIR ${PREFIX}_LIBRARY ${PREFIX}_LIBRARY_REL ${PREFIX}_LIBRARY_DBG ${PREFIX}_LIBRARY_FWK)
+    endif ()
+endmacro(findpkg_finish)
+
+
+#########################################################
+# Find cegui modules
+#########################################################
+macro(cegui_find_modules PLUGIN_COMPONENT)
+
+    foreach (comp ${CEGUI_${PLUGIN_COMPONENT}_MODULES})
+
+        set(LIBNAME ${comp})
+        set(HEADER ${CEGUI_${PLUGIN_COMPONENT}_MODULES_${comp}_HEADER})
+        set(PKGCONFIG ${CEGUI_${PLUGIN_COMPONENT}_MODULES_${comp}_PKGCONFIG})
+        set(CHECKNOPREFIX ${CEGUI_${PLUGIN_COMPONENT}_MODULES_${comp}_CHECKNOPREFIX})
+
+        if (NOT "${HEADER}" STREQUAL "")
+
+            findpkg_begin(CEGUI_${comp})
+
+            if(PKGCONFIG)
+                use_pkgconfig(CEGUI_${comp}_PKGC "CEGUI-${PKGCONFIG}")
+                if(NOT CEGUI_${comp}_PKGC_INCLUDE_DIRS AND CEGUI_LIB_SUFFIX)
+                    use_pkgconfig(CEGUI_${comp}_PKGC "CEGUI${CEGUI_LIB_SUFFIX}-${PKGCONFIG}")
+                endif()
+            endif()
+
+            list(LENGTH HEADER len)
+            math(EXPR lenmax "${len} - 1")
+
+            foreach(val RANGE ${lenmax})
+                list(GET HEADER ${val} pathHeader)
+
+                if(CEGUI_${comp}_INCLUDE_DIR)
+                    set(CEGUI_${comp}_INCLUDE_DIR_TMP ${CEGUI_${comp}_INCLUDE_DIR})
+                    unset(CEGUI_${comp}_INCLUDE_DIR CACHE)
+                endif()
+
+                get_filename_component(head "${pathHeader}" NAME)
+                get_filename_component(dir "${pathHeader}" DIRECTORY)
+                if (NOT "${dir}" STREQUAL "")
+                    set(dir "${dir}/")
+                endif ()
+
+                find_path(CEGUI_${comp}_INCLUDE_DIR NAMES ${head} HINTS ${CEGUI_INCLUDE_DIRS} ${CEGUI_${comp}_PKGC_INCLUDE_DIRS} PATH_SUFFIXES ${dir} CEGUI/${dir})
+
+                if(CEGUI_${comp}_INCLUDE_DIR_TMP)
+                    set(CEGUI_${comp}_INCLUDE_DIR ${CEGUI_${comp}_INCLUDE_DIR} ${CEGUI_${comp}_INCLUDE_DIR_TMP})
+                    unset(CEGUI_${comp}_INCLUDE_DIR_TMP CACHE)
+                endif()
+
+            endforeach()
+            list(REMOVE_DUPLICATES CEGUI_${comp}_INCLUDE_DIR)
+
+            set(CEGUI_SUBLIB_DIR "cegui-${CEGUI_VERSION_MAJOR}.${CEGUI_VERSION_MINOR}")
+
+
+            set(CEGUI_${comp}_LIBRARY_NAMES "CEGUI${comp}")
+            get_debug_names(CEGUI_${comp}_LIBRARY_NAMES)
+
+            set(CEGUI_${comp}_LIBRARY_NAMES_SUFFIX "CEGUI${comp}${CEGUI_LIB_SUFFIX}")
+            get_debug_names(CEGUI_${comp}_LIBRARY_NAMES_SUFFIX)
+
+            find_library(CEGUI_${comp}_LIBRARY_REL NAMES ${CEGUI_${comp}_LIBRARY_NAMES} ${CEGUI_${comp}_LIBRARY_NAMES_SUFFIX} HINTS ${CEGUI_LIBRARY_DIR_REL} ${CEGUI_LIBRARY_DIR_REL}/${CEGUI_SUBLIB_DIR} ${CEGUI_${comp}_PKGC_LIBRARY_DIRS} PATH_SUFFIXES "" "Release" "RelWithDebInfo" "MinSizeRel")
+            find_library(CEGUI_${comp}_LIBRARY_DBG NAMES ${CEGUI_${comp}_LIBRARY_NAMES_DBG} ${CEGUI_${comp}_LIBRARY_NAMES_SUFFIX_DBG} HINTS ${CEGUI_LIBRARY_DIR_DBG} ${CEGUI_LIBRARY_DIR_DBG}/${CEGUI_SUBLIB_DIR} ${CEGUI_${comp}_PKGC_LIBRARY_DIRS} PATH_SUFFIXES "" "Debug")
+
+            if(CHECKNOPREFIX AND (NOT CEGUI_${comp}_LIBRARY_REL OR NOT CEGUI_${comp}_LIBRARY_DBG))
+                set(CEGUI_${comp}_LIBRARY_NAMES "${comp}")
+                get_debug_names(CEGUI_${comp}_LIBRARY_NAMES)
+
+                set(CEGUI_${comp}_LIBRARY_NAMES_SUFFIX "${comp}${CEGUI_LIB_SUFFIX}")
+                get_debug_names(CEGUI_${comp}_LIBRARY_NAMES_SUFFIX)
+
+                find_library(CEGUI_${comp}_LIBRARY_REL NAMES ${CEGUI_${comp}_LIBRARY_NAMES} ${CEGUI_${comp}_LIBRARY_NAMES_SUFFIX} HINTS ${CEGUI_LIBRARY_DIR_REL} ${CEGUI_LIBRARY_DIR_REL}/${CEGUI_SUBLIB_DIR} ${CEGUI_${comp}_PKGC_LIBRARY_DIRS} PATH_SUFFIXES "" "Release" "RelWithDebInfo" "MinSizeRel")
+                find_library(CEGUI_${comp}_LIBRARY_DBG NAMES ${CEGUI_${comp}_LIBRARY_NAMES_DBG} ${CEGUI_${comp}_LIBRARY_NAMES_SUFFIX_DBG} HINTS ${CEGUI_LIBRARY_DIR_DBG} ${CEGUI_LIBRARY_DIR_DBG}/${CEGUI_SUBLIB_DIR} ${CEGUI_${comp}_PKGC_LIBRARY_DIRS} PATH_SUFFIXES "" "Debug")
+            endif()
+
+            make_library_set(CEGUI_${comp}_LIBRARY)
+
+            if (NOT CEGUI_STATIC)
+                if (WIN32)
+                    find_file(CEGUI_${comp}_BINARY_REL NAMES "CEGUI${comp}.dll" "CEGUI${comp}${CEGUI_LIB_SUFFIX}.dll" HINTS ${CEGUI_BIN_SEARCH_PATH} ${CEGUI_${comp}_PKGC_LIBRARY_DIRS} PATH_SUFFIXES "" "Release" "RelWithDebInfo" "MinSizeRel")
+                    find_file(CEGUI_${comp}_BINARY_DBG NAMES "CEGUI${comp}_d.dll" "CEGUI${comp}${CEGUI_LIB_SUFFIX}_d.dll" HINTS ${CEGUI_BIN_SEARCH_PATH} ${CEGUI_${comp}_PKGC_LIBRARY_DIRS} PATH_SUFFIXES "" "Debug")
+
+                     if(CHECKNOPREFIX AND (NOT CEGUI_${comp}_LIBRARY_REL OR NOT CEGUI_${comp}_LIBRARY_DBG))
+                         find_file(CEGUI_${comp}_BINARY_REL NAMES "${comp}${CEGUI_LIB_SUFFIX}.dll" HINTS ${CEGUI_BIN_SEARCH_PATH} PATH_SUFFIXES "" "Release" "RelWithDebInfo" "MinSizeRel")
+                         find_file(CEGUI_${comp}_BINARY_DBG NAMES "${comp}${CEGUI_LIB_SUFFIX}_d.dll" HINTS ${CEGUI_BIN_SEARCH_PATH} PATH_SUFFIXES "" "Debug")
+                    endif()
+                endif()
+
+                get_filename_component(CEGUI_${comp}_BINARY_DIR_REL "${CEGUI_${comp}_BINARY_REL}" PATH)
+                get_filename_component(CEGUI_${comp}_BINARY_DIR_DBG "${CEGUI_${comp}_BINARY_DBG}" PATH)
+                mark_as_advanced(CEGUI_${comp}_BINARY_REL CEGUI_${comp}_BINARY_DBG CEGUI_${comp}_BINARY_DIR_REL CEGUI_${comp}_BINARY_DIR_DBG)
+            endif()
+
+            findpkg_finish(CEGUI_${comp})
+
+        endif ()
+
+    endforeach (comp)
+
+endmacro(cegui_find_modules)
+
+
+#########################################################
+# register a module
+#########################################################
+macro(cegui_register_module TYPE LIBNAME HEADER PKGCONFIG)
+        set(CEGUI_MODULES ${CEGUI_MODULES} ${LIBNAME})
+        set(CEGUI_${TYPE}_MODULES ${CEGUI_${TYPE}_MODULES} ${LIBNAME})
+        set(CEGUI_${TYPE}_MODULES_${LIBNAME}_HEADER ${HEADER})
+        if(NOT "${PKGCONFIG}" STREQUAL "")
+            set(CEGUI_${TYPE}_MODULES_${LIBNAME}_PKGCONFIG ${PKGCONFIG})
+        endif()
+endmacro()
+
+
+#########################################################
+# Main
+#########################################################
+
+
+set(CEGUI_VERSION_MAJOR_DEFAULT "0")
+
+# Register var to check change on base
+set(CEGUI_RESET_VARS CEGUI_CONFIG_INCLUDE_DIR CEGUI_INCLUDE_DIR CEGUI_LIBRARY_REL CEGUI_LIBRARY_DBG)
+set(CEGUI_PREFIX_WATCH ${CEGUI_PREFIX_PATH})
+clear_if_changed(CEGUI_PREFIX_WATCH ${CEGUI_RESET_VARS})
+
+findpkg_begin(CEGUI)
+
+# Get path, convert backslashes as ${ENV_${var}}
+getenv_path(CEGUI_HOME)
+getenv_path(CEGUI_DIR)
+getenv_path(CEGUI_ROOT)
+getenv_path(PROGRAMFILES)
+
+# Determine whether to search for a dynamic or static build
+if (CEGUI_STATIC)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES_OLD "${CMAKE_FIND_LIBRARY_SUFFIXES}")
+    if (WIN32)
+        set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib;.dll")
+    else()
+        set(CMAKE_FIND_LIBRARY_SUFFIXES ".a;.so")
+    endif()
+endif ()
+
+# construct search paths from environmental hints and
+# OS specific guesses
+if (WIN32)
+    set(CEGUI_PREFIX_GUESSES
+        ${ENV_PROGRAMFILES}/cegui
+        ${ENV_PROGRAMFILES}/CEGUI
+        C:/CEGUI-SDK
+        C:/lib/cegui
+        [HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session\ Manager\\Environment;CEGUI_HOME]
+        [HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session\ Manager\\Environment;CEGUI_DIR]
+        [HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session\ Manager\\Environment;CEGUI_ROOT]
+    )
+elseif (UNIX)
+    set(CEGUI_PREFIX_GUESSES
+        /opt/cegui
+        /opt/CEGUI
+        /usr
+        /usr/local
+        $ENV{HOME}/cegui
+        $ENV{HOME}/CEGUI
+    )
+    if (APPLE)
+        set(CEGUI_PREFIX_GUESSES
+            ${CMAKE_CURRENT_SOURCE_DIR}/lib/macosx
+            ${CEGUI_PREFIX_GUESSES}
+        )
+    endif ()
+endif ()
+
+set(CEGUI_PREFIX_PATH
+        $ENV{CEGUI_HOME} $ENV{CEGUI_DIR} $ENV{CEGUI_ROOT}
+        ${CEGUI_PREFIX_GUESSES}
 )
 
-find_library(CEGUI_LIBRARY_DBG
-  CEGUIBase-0_d CEGUIBase_d
-  HINTS
-  $ENV{CEGUIDIR}
-  ${PC_CEGUI_LIBDIR}
-  PATH_SUFFIXES lib64 lib
-  PATHS
-  /sw
-  /opt/local
-  /opt/csw
-  /opt
-  /usr
-  /usr/local
-)
-
-find_library(CEGUI_OGRE_LIBRARY_REL
-  CEGUIOgreRenderer-0 CEGUIOgreRenderer
-  HINTS
-  $ENV{CEGUIDIR}
-  ${PC_CEGUI_LIBDIR}
-  PATH_SUFFIXES lib64 lib
-  PATHS
-  /sw
-  /opt/local
-  /opt/csw
-  /opt
-  /usr
-  /usr/local
-)
-
-find_library(CEGUI_OGRE_LIBRARY_DBG
-  CEGUIOgreRenderer-0_d CEGUIOgreRenderer_d
-  HINTS
-  $ENV{CEGUIDIR}
-  ${PC_CEGUI_LIBDIR}
-  PATH_SUFFIXES lib64 lib
-  PATHS
-  /sw
-  /opt/local
-  /opt/csw
-  /opt
-  /usr
-  /usr/local
-)
-
-# if only one debug/release variant is found, set the other to be equal to the found one
-if(CEGUI_LIBRARY_REL AND CEGUI_LIBRARY_DBG)
-set(CEGUI_LIBRARY_RELEASE ${CEGUI_LIBRARY_REL})
-set(CEGUI_LIBRARY_DEBUG ${CEGUI_LIBRARY_DBG})
-endif()
-if(CEGUI_LIBRARY_REL AND NOT CEGUI_LIBRARY_DBG)
-set(CEGUI_LIBRARY_RELEASE ${CEGUI_LIBRARY_REL})
-set(CEGUI_LIBRARY_DEBUG ${CEGUI_LIBRARY_REL})
-endif()
-if(CEGUI_LIBRARY_DBG AND NOT CEGUI_LIBRARY_REL)
-set(CEGUI_LIBRARY_RELEASE ${CEGUI_LIBRARY_DBG})
-set(CEGUI_LIBRARY_DEBUG ${CEGUI_LIBRARY_DBG})
-endif()
-
-if(CEGUI_OGRE_LIBRARY_REL AND CEGUI_OGRE_LIBRARY_DBG)
-set(CEGUI_OGRE_LIBRARY_RELEASE ${CEGUI_OGRE_LIBRARY_REL})
-set(CEGUI_OGRE_LIBRARY_DEBUG ${CEGUI_OGRE_LIBRARY_DBG})
-endif()
-if(CEGUI_OGRE_LIBRARY_REL AND NOT CEGUI_OGRE_LIBRARY_DBG)
-set(CEGUI_OGRE_LIBRARY_RELEASE ${CEGUI_OGRE_LIBRARY_REL})
-set(CEGUI_OGRE_LIBRARY_DEBUG ${CEGUI_OGRE_LIBRARY_REL})
-endif()
-if(CEGUI_OGRE_LIBRARY_DBG AND NOT CEGUI_OGRE_LIBRARY_REL)
-set(CEGUI_OGRE_LIBRARY_RELEASE ${CEGUI_OGRE_LIBRARY_DBG})
-set(CEGUI_OGRE_LIBRARY_DEBUG ${CEGUI_OGRE_LIBRARY_DBG})
-endif()
+# Construct search paths for includes and libraries
+create_search_paths(CEGUI)
 
 
-set(CEGUI_LIBRARIES_RELEASE optimized ${CEGUI_LIBRARY_RELEASE}
-   optimized ${CEGUI_OGRE_LIBRARY_RELEASE})
-set(CEGUI_LIBRARIES_DEBUG debug ${CEGUI_LIBRARY_DEBUG}
-   debug ${CEGUI_OGRE_LIBRARY_DEBUG})
+
+# try to locate CEGUI via pkg-config
+use_pkgconfig(CEGUI_PKGC "CEGUI${CEGUI_LIB_SUFFIX};CEGUI${CEGUI_LIB_SUFFIX}-${CEGUI_VERSION_MAJOR_DEFAULT}")
+
+# locate CEGUI include files
+find_path(CEGUI_CONFIG_INCLUDE_DIR_PREFIX NAMES CEGUIConfig.h HINTS ${CEGUI_INC_SEARCH_PATH} ${CEGUI_FRAMEWORK_INCLUDES} ${CEGUI_PKGC_INCLUDE_DIRS} PATH_SUFFIXES CEGUI cegui cegui-${CEGUI_VERSION_MAJOR_DEFAULT} cegui-${CEGUI_VERSION_MAJOR_DEFAULT}/CEGUI)
+find_path(CEGUI_CONFIG_INCLUDE_DIR NAMES CEGUIConfig.h Config.h HINTS ${CEGUI_INC_SEARCH_PATH} ${CEGUI_FRAMEWORK_INCLUDES} ${CEGUI_PKGC_INCLUDE_DIRS} PATH_SUFFIXES CEGUI cegui cegui-${CEGUI_VERSION_MAJOR_DEFAULT} cegui-${CEGUI_VERSION_MAJOR_DEFAULT}/CEGUI)
+find_path(CEGUI_INCLUDE_DIR NAMES CEGUI.h HINTS ${CEGUI_INC_SEARCH_PATH} ${CEGUI_FRAMEWORK_INCLUDES} ${CEGUI_PKGC_INCLUDE_DIRS} PATH_SUFFIXES CEGUI cegui cegui-${CEGUI_VERSION_MAJOR_DEFAULT} cegui-${CEGUI_VERSION_MAJOR_DEFAULT}/CEGUI)
+
+set(CEGUI_INCOMPATIBLE FALSE)
+if (CEGUI_INCLUDE_DIR)
+    # determine CEGUI version
+    if(CEGUI_CONFIG_INCLUDE_DIR_PREFIX)
+        file(READ ${CEGUI_INCLUDE_DIR}/CEGUIVersion.h CEGUI_TEMP_VERSION_CONTENT)
+    else()
+        file(READ ${CEGUI_INCLUDE_DIR}/Version.h CEGUI_TEMP_VERSION_CONTENT)
+    endif()
+
+    if (NOT "${CEGUI_TEMP_VERSION_CONTENT}" STREQUAL "")
+        get_preprocessor_entry(CEGUI_TEMP_VERSION_CONTENT CEGUI_VERSION_MAJOR CEGUI_VERSION_MAJOR)
+        get_preprocessor_entry(CEGUI_TEMP_VERSION_CONTENT CEGUI_VERSION_MINOR CEGUI_VERSION_MINOR)
+        get_preprocessor_entry(CEGUI_TEMP_VERSION_CONTENT CEGUI_VERSION_PATCH CEGUI_VERSION_PATCH)
+        get_preprocessor_entry(CEGUI_TEMP_VERSION_CONTENT CEGUI_VERSION_NAME CEGUI_VERSION_NAME)
+        set(CEGUI_VERSION "${CEGUI_VERSION_MAJOR}.${CEGUI_VERSION_MINOR}.${CEGUI_VERSION_PATCH}")
+        pkg_message(CEGUI "Found CEGUI ${CEGUI_VERSION_NAME} (${CEGUI_VERSION})")
+    else()
+        message(SEND_ERROR "Can't found CEGUI version !")
+        set(CEGUI_INCOMPATIBLE FALSE)
+    endif()
+
+else ()
+    set(CEGUI_INCOMPATIBLE FALSE)
+endif ()
+
+
+if ("${CEGUI_VERSION}" VERSION_GREATER "0.8.0")
+    set(CEGUI_LIB_SUFFIX "-${CEGUI_VERSION_MAJOR}")
+endif ()
+
+
+set(CEGUI_LIBRARY_NAMES "CEGUIBase${CEGUI_LIB_SUFFIX}")
+get_debug_names(CEGUI_LIBRARY_NAMES)
+find_library(CEGUI_LIBRARY_REL NAMES ${CEGUI_LIBRARY_NAMES} HINTS ${CEGUI_LIB_SEARCH_PATH} ${CEGUI_PKGC_LIBRARY_DIRS} ${CEGUI_FRAMEWORK_SEARCH_PATH} PATH_SUFFIXES "" "release" "relwithdebinfo" "minsizerel")
+find_library(CEGUI_LIBRARY_DBG NAMES ${CEGUI_LIBRARY_NAMES_DBG} HINTS ${CEGUI_LIB_SEARCH_PATH} ${CEGUI_PKGC_LIBRARY_DIRS} ${CEGUI_FRAMEWORK_SEARCH_PATH} PATH_SUFFIXES "" "debug")
+make_library_set(CEGUI_LIBRARY)
+
+
+if (CEGUI_INCOMPATIBLE)
+    set(CEGUI_LIBRARY "NOTFOUND")
+endif ()
+
+set(CEGUI_INCLUDE_DIR ${CEGUI_CONFIG_INCLUDE_DIR} ${CEGUI_INCLUDE_DIR})
+list(REMOVE_DUPLICATES CEGUI_INCLUDE_DIR)
+findpkg_finish(CEGUI)
+
+# Starting CEGUI 0.8, the headers are in the CEGUI subdirectory, and we must include
+# its parent rather than directly the subdirectory. Otherwise we'll get compiler errors.
+if ("${CEGUI_VERSION}" VERSION_GREATER "0.8.0")
+    add_parent_dir(CEGUI_INCLUDE_DIRS_TEMP CEGUI_INCLUDE_DIR)
+    # we basically overwrite CEGUI_INCLUDE_DIR so that it contains only the parent directory.
+    set(CEGUI_INCLUDE_DIR ${CEGUI_INCLUDE_DIRS_TEMP})
+endif()
 
 set(CEGUI_INCLUDE_DIRS ${CEGUI_INCLUDE_DIR})
 
-include(FindPackageHandleStandardArgs)
-#Set vars
-find_package_handle_standard_args(CEGUI DEFAULT_MSG
-                                  CEGUI_LIBRARY_RELEASE CEGUI_OGRE_LIBRARY_RELEASE CEGUI_INCLUDE_DIR)
+mark_as_advanced(CEGUI_CONFIG_INCLUDE_DIR)
+
+if (NOT CEGUI_FOUND)
+    return()
+endif ()
+
+
+get_filename_component(CEGUI_LIBRARY_DIR_REL "${CEGUI_LIBRARY_REL}" PATH)
+get_filename_component(CEGUI_LIBRARY_DIR_DBG "${CEGUI_LIBRARY_DBG}" PATH)
+set(CEGUI_LIBRARY_DIRS ${CEGUI_LIBRARY_DIR_REL} ${CEGUI_LIBRARY_DIR_DBG})
+
+
+# find binaries
+if (NOT CEGUI_STATIC)
+        if (WIN32)
+                find_file(CEGUI_BINARY_REL NAMES "CEGUIBase${CEGUI_LIB_SUFFIX}.dll" "CEGUIBase.dll" HINTS ${CEGUI_BIN_SEARCH_PATH} PATH_SUFFIXES "" "Release" "RelWithDebInfo" "MinSizeRel")
+                find_file(CEGUI_BINARY_DBG NAMES "CEGUIBase${CEGUI_LIB_SUFFIX}_d.dll" "CEGUIBase_d.dll" HINTS ${CEGUI_BIN_SEARCH_PATH} PATH_SUFFIXES "" "Debug")
+        endif()
+
+        get_filename_component(CEGUI_BINARY_DIR_REL "${CEGUI_BINARY_REL}" PATH)
+        get_filename_component(CEGUI_BINARY_DIR_DBG "${CEGUI_BINARY_DBG}" PATH)
+        mark_as_advanced(CEGUI_BINARY_REL CEGUI_BINARY_DBG CEGUI_BINARY_DIR_REL CEGUI_BINARY_DIR_DBG)
+endif()
+
+if ("${CEGUI_VERSION}" VERSION_GREATER "0.8.0")
+    # Base
+    cegui_register_module(BASE CommonDialogs CommonDialogs/Module.h "")
+
+    # WindowsRenderer
+    cegui_register_module(WINDOWSRENDERER CoreWindowRendererSet WindowRendererSets/Core/Module.h "")
+
+    # Renderer
+    cegui_register_module(RENDERER Direct3D9Renderer RendererModules/Direct3D9/Renderer.h "")
+    cegui_register_module(RENDERER Direct3D10Renderer RendererModules/Direct3D10/Renderer.h "")
+    cegui_register_module(RENDERER Direct3D11Renderer RendererModules/Direct3D11/Renderer.h "")
+    cegui_register_module(RENDERER DirectFBRenderer RendererModules/DirectFB/Renderer.h "")
+    cegui_register_module(RENDERER IrrlichtRenderer RendererModules/Irrlicht/Renderer.h "IRRLICHT")
+    cegui_register_module(RENDERER NullRenderer RendererModules/Null/Renderer.h "NULL")
+    cegui_register_module(RENDERER OgreRenderer RendererModules/Ogre/Renderer.h "OGRE")
+    cegui_register_module(RENDERER OpenGLRenderer RendererModules/OpenGL/GLRenderer.h "OPENGL")
+    cegui_register_module(RENDERER OpenGL3Renderer RendererModules/OpenGL/GL3Renderer.h "OPENGL3")
+    cegui_register_module(RENDERER OpenGLESRenderer RendererModules/OpenGLES/Renderer.h "")
+
+    # ImageCodec
+    cegui_register_module(IMAGECODEC CoronaImageCodec ImageCodecModules/Corona/ImageCodec.h "")
+    cegui_register_module(IMAGECODEC DevILImageCodec ImageCodecModules/DevIL/ImageCodec.h "")
+    cegui_register_module(IMAGECODEC FreeImageImageCodec ImageCodecModules/FreeImage/ImageCodec.h "")
+    cegui_register_module(IMAGECODEC SILLYImageCodec ImageCodecModules/SILLY/ImageCodec.h "")
+    cegui_register_module(IMAGECODEC STBImageCodec ImageCodecModules/STB/ImageCodec.h "")
+    cegui_register_module(IMAGECODEC TGAImageCodec ImageCodecModules/TGA/ImageCodec.h "")
+    cegui_register_module(IMAGECODEC PVRImageCodec ImageCodecModules/PVR/ImageCodec.h "")
+
+    # Parser
+    cegui_register_module(PARSER ExpatParser XMLParserModules/Expat/XMLParser.h "")
+    cegui_register_module(PARSER LibXMLParser XMLParserModules/Libxml2/XMLParser.h "")
+    cegui_register_module(PARSER RapidXMLParser XMLParserModules/RapidXML/XMLParser.h "")
+    cegui_register_module(PARSER TinyXMLParser XMLParserModules/TinyXML/XMLParser.h "")
+    cegui_register_module(PARSER XercesParser XMLParserModules/Xerces/XMLParser.h "")
+
+    # Script
+    cegui_register_module(SCRIPT LuaScriptModule ScriptModules/Lua/ScriptModule.h "LUA")
+
+else ()
+
+    # WindowsRenderer
+    cegui_register_module(WINDOWSRENDERER FalagardWRBase "WindowRendererSets/Falagard/FalModule.h;falagard/CEGUIFalNamedArea.h" "")
+
+    # Renderer
+    cegui_register_module(RENDERER Direct3D9Renderer RendererModules/Direct3D9/CEGUIDirect3D9Renderer.h "")
+    cegui_register_module(RENDERER Direct3D10Renderer RendererModules/Direct3D10/CEGUIDirect3D10Renderer.h "")
+    cegui_register_module(RENDERER Direct3D11Renderer RendererModules/Direct3D11/CEGUIDirect3D11Renderer.h "")
+    cegui_register_module(RENDERER DirectFBRenderer RendererModules/DirectFB/CEGUIDirectFBRenderer.h "")
+    cegui_register_module(RENDERER IrrlichtRenderer RendererModules/Irrlicht/CEGUIIrrlichtRenderer.h "")
+    cegui_register_module(RENDERER NullRenderer RendererModules/Null/CEGUINullRenderer.h "NULL")
+    cegui_register_module(RENDERER OgreRenderer RendererModules/Ogre/CEGUIOgreRenderer.h "OGRE")
+    cegui_register_module(RENDERER OpenGLRenderer RendererModules/OpenGL/CEGUIOpenGLRenderer.h "OPENGL")
+
+    # ImageCodec
+    cegui_register_module(IMAGECODEC CoronaImageCodec ImageCodecModules/CoronaImageCodec/CEGUICoronaImageCodec.h "")
+    cegui_register_module(IMAGECODEC DevILImageCodec ImageCodecModules/DevILImageCodec/CEGUIDevILImageCodec.h "")
+    cegui_register_module(IMAGECODEC FreeImageImageCodec ImageCodecModules/FreeImageImageCodec/CEGUIFreeImageImageCodec.h "")
+    cegui_register_module(IMAGECODEC SILLYImageCodec ImageCodecModules/SILLYImageCodec/CEGUISILLYImageCodec.h "")
+    cegui_register_module(IMAGECODEC STBImageCodec ImageCodecModules/STBImageCodec/CEGUISTBImageCodec.h "")
+    cegui_register_module(IMAGECODEC TGAImageCodec ImageCodecModules/TGAImageCodec/CEGUITGAImageCodec.h "")
+
+    # Parser
+    cegui_register_module(PARSER ExpatParser XMLParserModules/ExpatParser/CEGUIExpatParser.h "")
+    cegui_register_module(PARSER LibxmlParser XMLParserModules/LibxmlParser/CEGUILibxmlParser.h "")
+    cegui_register_module(PARSER RapidXMLParser XMLParserModules/RapidXMLParser/CEGUIRapidXMLParser.h "")
+    cegui_register_module(PARSER TinyXMLParser XMLParserModules/TinyXMLParser/CEGUITinyXMLParser.h "")
+    cegui_register_module(PARSER XercesParser XMLParserModules/XercesParser/CEGUIXercesParser.h "")
+
+    # Script
+    cegui_register_module(SCRIPT LuaScriptModule ScriptingModules/LuaScriptModule/CEGUILua.h "")
+
+    if(WIN32)
+        cegui_register_module(SCRIPT tolua++ ScriptingModules/LuaScriptModule/support/tolua++/tolua++.h "")
+        set(CEGUI_SCRIPT_MODULES_tolua++_CHECKNOPREFIX TRUE)
+    else()
+        cegui_register_module(SCRIPT toluapp ScriptingModules/LuaScriptModule/support/tolua++/tolua++.h "")
+    endif()
+
+endif ()
+
+
+# Register var to check change on modules
+set(CEGUI_RESET_MODULES_VARS "")
+foreach (comp ${CEGUI_MODULES})
+    set(CEGUI_RESET_MODULES_VARS ${CEGUI_RESET_MODULES_VARS}
+        CEGUI_${comp}_INCLUDE_DIR CEGUI_${comp}_LIBRARY_FWK
+        CEGUI_${comp}_LIBRARY_DBG CEGUI_${comp}_LIBRARY_REL
+    )
+endforeach (comp)
+set(CEGUI_PREFIX_MODULES_WATCH ${CEGUI_PREFIX_MODULES_PATH})
+clear_if_changed(CEGUI_PREFIX_WATCH ${CEGUI_RESET_MODULES_VARS})
+
+
+# Find modules
+cegui_find_modules(BASE)
+cegui_find_modules(WINDOWSRENDERER)
+cegui_find_modules(RENDERER)
+cegui_find_modules(IMAGECODEC)
+cegui_find_modules(PARSER)
+cegui_find_modules(SCRIPT)
+
+
+# Find modules
+if (CEGUI_STATIC)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES "${CMAKE_FIND_LIBRARY_SUFFIXES_OLD}")
+endif()
+
+
+#Check change on modules
+clear_if_changed(CEGUI_PREFIX_WATCH)
+clear_if_changed(CEGUI_PREFIX_MODULES_WATCH)

--- a/source/camera/HermiteCatmullSpline.cpp
+++ b/source/camera/HermiteCatmullSpline.cpp
@@ -138,7 +138,7 @@ bool HermiteCatmullSpline::addNode(double node)
     if(mReserved < mNn)
     {
         mPp[mReserved] = node;
-        mTt[mReserved] = (double)mReserved / 2;
+        mTt[mReserved] = static_cast<double>(mReserved) / 2;
         ++mReserved;
 
         if(mReserved == mNn)

--- a/source/modes/Console_executePromptCommand.cpp
+++ b/source/modes/Console_executePromptCommand.cpp
@@ -427,10 +427,7 @@ bool Console::executePromptCommand(const std::string& command, std::string argum
     {
         if (ODClient::getSingleton().isConnected())
         {
-            ClientNotification *clientNotification = new ClientNotification(
-                ClientNotification::chat);
-            clientNotification->mPacket << arguments;
-            ODClient::getSingleton().queueClientNotification(clientNotification);
+            ODClient::getSingleton().queueClientNotification(ClientNotification::chat, arguments);
         }
     }
 

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -879,6 +879,7 @@ void ODClient::processClientNotifications()
                 sendToServer(event->mPacket);
                 break;
         }
+        delete event;
     }
 }
 

--- a/source/network/ODClient.h
+++ b/source/network/ODClient.h
@@ -61,6 +61,13 @@ class ODClient: public Ogre::Singleton<ODClient>,
     //! \brief Adds a client notification to the client notification queue.
     void queueClientNotification(ClientNotification* n);
 
+    /*! \brief Adds a client notification to the client notification queue.
+     *  \param type The type of the notification
+     *  \param args The arguments that are to be piped into the notification.
+     */
+    template<typename ...Args>
+    void queueClientNotification(ClientNotification::ClientNotificationType type, const Args&... args);
+
     void disconnect();
 
     //! \brief Adds a client notification to the client notification queue.
@@ -79,5 +86,12 @@ class ODClient: public Ogre::Singleton<ODClient>,
     std::deque<ClientNotification*> mClientNotificationQueue;
 
 };
+
+template<typename ...Args>
+void ODClient::queueClientNotification(ClientNotification::ClientNotificationType type, const Args&... args)
+{
+    mClientNotificationQueue.emplace_back(new ClientNotification(type));
+    ODPacket::putInPacket(mClientNotificationQueue.back()->mPacket, args...);
+}
 
 #endif // ODCLIENT_H

--- a/source/network/ODPacket.h
+++ b/source/network/ODPacket.h
@@ -135,6 +135,21 @@ class ODPacket
          */
         int32_t readPacket(std::ifstream& is);
 
+        /*! \brief Template function to put arguments in a packet, used for in-place construction.
+         */
+        template<typename FirstArg, typename ...Args>
+        static void putInPacket(ODPacket& packet, const FirstArg& arg, const Args&... args)
+        {
+            packet << arg;
+            putInPacket(packet, args...);
+        }
+
+        template<typename Arg>
+        static void putInPacket(ODPacket& packet, const Arg& arg)
+        {
+            packet << arg;
+        }
+
     private:
         sf::Packet mPacket;
 

--- a/source/utils/Random.cpp
+++ b/source/utils/Random.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <ctime>
 
 unsigned long myRandomSeed;
 const unsigned long MAX = 32768;
@@ -68,7 +69,7 @@ namespace Random
 
 void initialize()
 {
-    myRandomSeed = static_cast<unsigned long>(time(0));
+    myRandomSeed = static_cast<unsigned long>(std::time(0));
 }
 
 double Double(double min, double max)

--- a/source/utils/Random.cpp
+++ b/source/utils/Random.cpp
@@ -21,73 +21,43 @@
  */
 
 #include "utils/Random.h"
-
 #include "utils/Helper.h"
 
-#ifdef __MINGW32__
-#ifndef mode_t
-#include <sys/types.h>
-#endif //mode_t
-#endif //mingw32
 #include <algorithm>
 #include <cmath>
-#include <ctime>
 
 unsigned long myRandomSeed;
 const unsigned long MAX = 32768;
 
-unsigned long randgen()
+static unsigned long randgen()
 {
     myRandomSeed = myRandomSeed * 1103515245 + 12345;
-    unsigned long returnVal = (unsigned int) (myRandomSeed / 65536) % MAX;
+    //TODO: What is the purpose of the cast?
+    unsigned long returnVal = static_cast<unsigned int>(myRandomSeed / 65536) % MAX;
 
     return returnVal;
 }
 
 //! \brief uniformly distributed number [0;1)
-double uniform()
+static double uniform()
 {
     return randgen() * 1.0 / static_cast<double>(MAX);
 }
 
-//! \brief uniformly distributed number [0;hi)
-double uniform(double hi)
-{
-    return uniform() * hi;
-}
-
 //! \brief uniformly distributed number [lo;hi)
-double uniform(double lo, double hi)
+static double uniform(double lo, double hi)
 {
     return uniform() * (hi - lo) + lo;
 }
 
-//! \brief random bit
-int randint()
-{
-    return uniform() > 0.5 ? 1 : 0;
-}
-
-//! \brief random integer [0;hi]
-int randint(int hi)
-{
-    return static_cast<signed>(uniform() * (hi + 1));
-}
-
 //! \brief random integer [lo;hi]
-int randint(int lo, int hi)
+static int randint(int lo, int hi)
 {
-    return static_cast<signed>(uniform() * (hi - lo + 1) + lo);
-}
-
-//! \brief random unsigned integer [0;hi]
-unsigned int randuint(unsigned int hi)
-{
-    return static_cast<unsigned int>(uniform() * (hi + 1));
+    return static_cast<int>(uniform() * (hi - lo + 1) + lo);
 }
 
 //! \brief random unsigned integer [lo;hi]
-unsigned int randuint(unsigned int lo, unsigned int hi)
+static unsigned int randuint(unsigned int lo, unsigned int hi)
 {
     return static_cast<unsigned int>(uniform() * (hi - lo + 1) + lo);
 }
@@ -133,7 +103,7 @@ unsigned int Uint(unsigned int min, unsigned int max)
 
 double gaussianRandomDouble()
 {
-    return sqrt(-2.0 * log(Double(0.0, 1.0))) * cos(2.0 * PI * Double(0.0, 1.0));
+    return std::sqrt(-2.0 * log(Double(0.0, 1.0))) * cos(2.0 * PI * Double(0.0, 1.0));
 }
 
 } // namespace Random

--- a/source/utils/ResourceManager.cpp
+++ b/source/utils/ResourceManager.cpp
@@ -49,7 +49,7 @@
 #include <OgreRenderTarget.h>
 
 template<> ResourceManager* Ogre::Singleton<ResourceManager>::msSingleton = 0;
-#if defined(OD_DEBUG)
+#if OGRE_PLATFORM == OGRE_PLATFORM_WIN32 && defined(OD_DEBUG)
 //On windows, if the application is compiled in debug mode, use the plugins with debug prefix.
 const std::string ResourceManager::PLUGINSCFG = "plugins_d.cfg";
 #else


### PR DESCRIPTION
Fixed a memory leak.
Started adding more compiler warnings ("-Wall" leaves out many, see https://stackoverflow.com/questions/5088460/flags-to-enable-thorough-and-verbose-g-warnings/9862800#9862800 ) and added SYSTEM to include directories to avoid having warnings trigger in header files. This also allow us to use "-Werror". 
New warning are disabled for now, as many of them will trigger, my though is that we can incrementally add them and fix the occuring warnins.
