### PR TITLE
Added support to handle Temple/Portal in the editor + deharcoded workers.

### DIFF
--- a/config/factions.cfg
+++ b/config/factions.cfg
@@ -7,6 +7,9 @@
 [Faction]
     Name	Keeper
     [SpawnPool]
+    # Worker
+    Kobold
+    # Fighters
     CaveHornet
     Wyvern
     Dragon
@@ -26,6 +29,9 @@
 [Faction]
     Name	Hero
     [SpawnPool]
+    # Worker
+    DwarfWorker
+    # Fighters
     Gnome
     Knight
     BigKnight

--- a/config/factions.cfg
+++ b/config/factions.cfg
@@ -6,10 +6,8 @@
 [Factions]
 [Faction]
     Name	Keeper
+    WorkerClass	Kobold
     [SpawnPool]
-    # Worker
-    Kobold
-    # Fighters
     CaveHornet
     Wyvern
     Dragon
@@ -28,10 +26,8 @@
 [/Faction]
 [Faction]
     Name	Hero
+    WorkerClass	DwarfWorker
     [SpawnPool]
-    # Worker
-    DwarfWorker
-    # Fighters
     Gnome
     Knight
     BigKnight

--- a/gui/OpenDungeonsMenuRooms.layout
+++ b/gui/OpenDungeonsMenuRooms.layout
@@ -55,13 +55,13 @@
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/ImageButton" name="TempleButton" >
-            <Property name="Area" value="{{0,849},{0,25},{0,909},{0,85}}" />
+            <Property name="Area" value="{{0,749},{0,25},{0,809},{0,85}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/TempleButton" />
             <Property name="TooltipText" value="Build a Temple (3x3)" />
             <Property name="InheritsAlpha" value="False" />
         </Window>
         <Window type="OD/ImageButton" name="PortalButton" >
-            <Property name="Area" value="{{0,909},{0,25},{0,969},{0,85}}" />
+            <Property name="Area" value="{{0,809},{0,25},{0,869},{0,85}}" />
             <Property name="NormalImage" value="OpenDungeonsIcons/PortalButton" />
             <Property name="TooltipText" value="Build a Portal (3x3)" />
             <Property name="InheritsAlpha" value="False" />

--- a/source/camera/CameraManager.cpp
+++ b/source/camera/CameraManager.cpp
@@ -42,7 +42,7 @@ const Ogre::Real MOVE_SPEED = 2.0;
 const Ogre::Real MOVE_SPEED_ACCELERATION = 2.0 * MOVE_SPEED;
 
 //! The camera moving speed factor on Z axis.
-const Ogre::Real ZOOM_SPEED = 5.0;
+const Ogre::Real ZOOM_SPEED = 4.0;
 
 //! Camera speed when clicking on the minimap or pushing the home key.
 const Ogre::Real FLIGHT_SPEED = 70.0;

--- a/source/entities/Tile.cpp
+++ b/source/entities/Tile.cpp
@@ -762,6 +762,7 @@ void Tile::loadFromLine(const std::string& line, Tile *t)
     t->setName(tileName.str());
     t->mX = xLocation;
     t->mY = yLocation;
+    t->mPosition = Ogre::Vector3(static_cast<Ogre::Real>(t->mX), static_cast<Ogre::Real>(t->mY), 0.0f);
 
     Tile::TileType tileType = static_cast<Tile::TileType>(Helper::toInt(elems[2]));
     t->setType(tileType);

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -336,12 +336,16 @@ void Seat::initSpawnPool()
     }
 }
 
-const CreatureDefinition* Seat::getNextCreatureClassToSpawn()
+const CreatureDefinition* Seat::getNextFighterClassToSpawn()
 {
     std::vector<std::pair<const CreatureDefinition*, int32_t> > defSpawnable;
     int32_t nbPointsTotal = 0;
     for(std::pair<const CreatureDefinition*, bool>& def : mSpawnPool)
     {
+        // Only check for fighter creatures.
+        if (!def.first || def.first->isWorker())
+            continue;
+
         const std::vector<const SpawnCondition*>& conditions = ConfigManager::getSingleton().getCreatureSpawnConditions(def.first);
         int32_t nbPointsConditions = 0;
         for(const SpawnCondition* condition : conditions)
@@ -386,6 +390,20 @@ const CreatureDefinition* Seat::getNextCreatureClassToSpawn()
 
     // It is not normal to come here
     OD_ASSERT_TRUE_MSG(false, "seatId=" + Ogre::StringConverter::toString(getId()));
+    return nullptr;
+}
+
+const CreatureDefinition* Seat::getWorkerClassToSpawn()
+{
+    for(std::pair<const CreatureDefinition*, bool>& def : mSpawnPool)
+    {
+        if (def.first == nullptr)
+            continue;
+
+        if (def.first->isWorker())
+            return def.first;
+    }
+
     return nullptr;
 }
 

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -341,6 +341,7 @@ void Seat::initSpawnPool()
     // Get the default worker class
     std::string defaultWorkerClass = config.getFactionWorkerClass(mFaction);
     mDefaultWorkerClass = mGameMap->getClassDescription(defaultWorkerClass);
+    OD_ASSERT_TRUE_MSG(mDefaultWorkerClass != nullptr, "No valid default worker class for faction: " + mFaction);
 }
 
 const CreatureDefinition* Seat::getNextFighterClassToSpawn()

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -49,6 +49,8 @@ Seat::Seat(GameMap* gameMap) :
     mStartingY(0),
     mGoldMined(0),
     mNumCreaturesControlled(0),
+    mStartingGold(0),
+    mDefaultWorkerClass(nullptr),
     mNumClaimedTiles(0),
     mHasGoalsChanged(true),
     mGold(0),
@@ -323,7 +325,8 @@ void Seat::addAlliedSeat(Seat* seat)
 
 void Seat::initSpawnPool()
 {
-    const std::vector<std::string>& pool = ConfigManager::getSingleton().getFactionSpawnPool(mFaction);
+    ConfigManager& config = ConfigManager::getSingleton();
+    const std::vector<std::string>& pool = config.getFactionSpawnPool(mFaction);
     OD_ASSERT_TRUE_MSG(!pool.empty(), "Empty spawn pool for faction=" + mFaction);
     for(const std::string& defName : pool)
     {
@@ -334,6 +337,10 @@ void Seat::initSpawnPool()
 
         mSpawnPool.push_back(std::pair<const CreatureDefinition*, bool>(def, false));
     }
+
+    // Get the default worker class
+    std::string defaultWorkerClass = config.getFactionWorkerClass(mFaction);
+    mDefaultWorkerClass = mGameMap->getClassDescription(defaultWorkerClass);
 }
 
 const CreatureDefinition* Seat::getNextFighterClassToSpawn()
@@ -390,20 +397,6 @@ const CreatureDefinition* Seat::getNextFighterClassToSpawn()
 
     // It is not normal to come here
     OD_ASSERT_TRUE_MSG(false, "seatId=" + Ogre::StringConverter::toString(getId()));
-    return nullptr;
-}
-
-const CreatureDefinition* Seat::getWorkerClassToSpawn()
-{
-    for(std::pair<const CreatureDefinition*, bool>& def : mSpawnPool)
-    {
-        if (def.first == nullptr)
-            continue;
-
-        if (def.first->isWorker())
-            return def.first;
-    }
-
     return nullptr;
 }
 

--- a/source/game/Seat.h
+++ b/source/game/Seat.h
@@ -171,7 +171,7 @@ public:
     const CreatureDefinition* getNextFighterClassToSpawn();
 
     //! \brief Returns the first (default) worker class definition.
-    const CreatureDefinition* getWorkerClassToSpawn()
+    inline const CreatureDefinition* getWorkerClassToSpawn()
     {
         return mDefaultWorkerClass;
     }
@@ -289,7 +289,7 @@ private:
     //! if the spawning conditions are not empty and are met, we will set it to true and force spawning of the related creature
     std::vector<std::pair<const CreatureDefinition*, bool> > mSpawnPool;
 
-    //! \broef The default workers spawned in temples.
+    //! \brief The default workers spawned in temples.
     const CreatureDefinition* mDefaultWorkerClass;
 
     //! \brief List of all the tiles in the gamemap (used for human players seats only). The first vector stores the X position.

--- a/source/game/Seat.h
+++ b/source/game/Seat.h
@@ -171,7 +171,10 @@ public:
     const CreatureDefinition* getNextFighterClassToSpawn();
 
     //! \brief Returns the first (default) worker class definition.
-    const CreatureDefinition* getWorkerClassToSpawn();
+    const CreatureDefinition* getWorkerClassToSpawn()
+    {
+        return mDefaultWorkerClass;
+    }
 
     //! \brief Returns true if the given seat is allied. False otherwise
     bool isAlliedSeat(Seat *seat);
@@ -285,6 +288,9 @@ private:
     //! are managed by the configuration manager and should NOT be deleted. The boolean will be set to false at beginning
     //! if the spawning conditions are not empty and are met, we will set it to true and force spawning of the related creature
     std::vector<std::pair<const CreatureDefinition*, bool> > mSpawnPool;
+
+    //! \broef The default workers spawned in temples.
+    const CreatureDefinition* mDefaultWorkerClass;
 
     //! \brief List of all the tiles in the gamemap (used for human players seats only). The first vector stores the X position.
     //! The second vector stores the Y position. The first bool from the pair is set to true if the seat had vision on the concerned

--- a/source/game/Seat.h
+++ b/source/game/Seat.h
@@ -167,7 +167,11 @@ public:
 
     void setMapSize(int x, int y);
 
-    const CreatureDefinition* getNextCreatureClassToSpawn();
+    //! \brief Returns the next fighter creature class to spawn.
+    const CreatureDefinition* getNextFighterClassToSpawn();
+
+    //! \brief Returns the first (default) worker class definition.
+    const CreatureDefinition* getWorkerClassToSpawn();
 
     //! \brief Returns true if the given seat is allied. False otherwise
     bool isAlliedSeat(Seat *seat);

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -40,6 +40,8 @@
 #include "game/Player.h"
 #include "game/Seat.h"
 
+#include "modes/ModeManager.h"
+
 #include "network/ODServer.h"
 #include "network/ServerNotification.h"
 
@@ -156,6 +158,14 @@ GameMap::~GameMap()
 {
     clearAll();
     processDeletionQueues();
+}
+
+bool GameMap::isInEditorMode() const
+{
+    if (isServerGameMap())
+        return (ODServer::getSingleton().getServerMode() == ODServer::ServerMode::ModeEditor);
+
+    return (ODFrameListener::getSingleton().getModeManager()->getCurrentModeTypeExceptConsole() == ModeManager::EDITOR);
 }
 
 bool GameMap::loadLevel(const std::string& levelFilepath)

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -1675,7 +1675,7 @@ Player* GameMap::getPlayerBySeat(Seat* seat)
     return nullptr;
 }
 
-std::vector<GameEntity*> GameMap::getVisibleForce(const std::vector<Tile*>& visibleTiles, Seat* seat, bool invert)
+std::vector<GameEntity*> GameMap::getVisibleForce(const std::vector<Tile*>& visibleTiles, Seat* seat, bool enemyForce)
 {
     std::vector<GameEntity*> returnList;
 
@@ -1686,15 +1686,15 @@ std::vector<GameEntity*> GameMap::getVisibleForce(const std::vector<Tile*>& visi
         if(tile == nullptr)
             continue;
 
-        tile->fillWithAttackableCreatures(returnList, seat, invert);
-        tile->fillWithAttackableRoom(returnList, seat, invert);
-        tile->fillWithAttackableTrap(returnList, seat, invert);
+        tile->fillWithAttackableCreatures(returnList, seat, enemyForce);
+        tile->fillWithAttackableRoom(returnList, seat, enemyForce);
+        tile->fillWithAttackableTrap(returnList, seat, enemyForce);
     }
 
     return returnList;
 }
 
-std::vector<GameEntity*> GameMap::getVisibleCreatures(const std::vector<Tile*>& visibleTiles, Seat* seat, bool invert)
+std::vector<GameEntity*> GameMap::getVisibleCreatures(const std::vector<Tile*>& visibleTiles, Seat* seat, bool enemyCreatures)
 {
     std::vector<GameEntity*> returnList;
 
@@ -1705,7 +1705,7 @@ std::vector<GameEntity*> GameMap::getVisibleCreatures(const std::vector<Tile*>& 
         if(tile == nullptr)
             continue;
 
-        tile->fillWithAttackableCreatures(returnList, seat, invert);
+        tile->fillWithAttackableCreatures(returnList, seat, enemyCreatures);
     }
 
     return returnList;

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -474,7 +474,7 @@ void GameMap::queueEntityForDeletion(GameEntity *ge)
     mEntitiesToDelete.push_back(ge);
 }
 
-const CreatureDefinition* GameMap::getClassDescription(const std::string& className)
+const CreatureDefinition* GameMap::getClassDescription(const string &className)
 {
     for (std::pair<const CreatureDefinition*,CreatureDefinition*>& def : mClassDescriptions)
     {
@@ -1131,7 +1131,7 @@ unsigned long int GameMap::doMiscUpkeep()
         if (koboldsNeededPerSeat[seat] > 0)
         {
             --koboldsNeededPerSeat[seat];
-            dungeonTemple->produceKobold();
+            dungeonTemple->produceWorker();
         }
     }
 

--- a/source/gamemap/GameMap.h
+++ b/source/gamemap/GameMap.h
@@ -67,6 +67,13 @@ public:
     const std::string serverStr()
     { return std::string( mIsServerGameMap ? "SERVER - " : "CLIENT - "); }
 
+    //! \brief Tells whether the game map is currently used for the map editor mode
+    //! or for a standard game session.
+    //! \note This function has got the noticeable role to keep the separation between the client
+    //! and the server game maps clean, by not calling client related code when acting
+    //! as a server game and vice versa.
+    bool isInEditorMode() const;
+
     //! \brief Load a level file (Part of the resource paths)
     //! \returns whether the file loaded correctly
     bool loadLevel(const std::string& levelFilepath);
@@ -401,12 +408,12 @@ public:
         mTurnNumber = turnNumber;
     }
 
-    bool isServerGameMap()
+    bool isServerGameMap() const
     {
         return mIsServerGameMap;
     }
 
-    bool getGamePaused()
+    bool getGamePaused() const
     {
         return mIsPaused;
     }

--- a/source/gamemap/GameMap.h
+++ b/source/gamemap/GameMap.h
@@ -340,11 +340,13 @@ public:
     //! \note Returns a path for the given creature to the given destination.
     std::list<Tile*> path(const Creature* creature, Tile* destination, bool throughDiggableTiles = false);
 
-    //! \brief Loops over the visibleTiles and returns any creature/room/trap in those tiles allied with the given seat (or if invert is true, is not allied)
-    std::vector<GameEntity*> getVisibleForce(const std::vector<Tile*>& visibleTiles, Seat* seat, bool invert);
+    //! \brief Loops over the visibleTiles and returns any creature/room/trap in those tiles allied with the given seat
+    //! (or if enemyForce is true, is not allied)
+    std::vector<GameEntity*> getVisibleForce(const std::vector<Tile*>& visibleTiles, Seat* seat, bool enemyForce);
 
-    //! \brief Loops over the visibleTiles and returns any creature in those tiles allied with the given seat (or if invert is true, is not allied)
-    std::vector<GameEntity*> getVisibleCreatures(const std::vector<Tile*>& visibleTiles, Seat* seat, bool invert);
+    //! \brief Loops over the visibleTiles and returns any creature in those tiles allied with the given seat.
+    //! (or if enemyCreatures is true, is not allied)
+    std::vector<GameEntity*> getVisibleCreatures(const std::vector<Tile*>& visibleTiles, Seat* seat, bool enemyCreatures);
 
     //! \brief Loops over the visibleTiles and returns any carryable entity in those tiles
     std::vector<MovableGameEntity*> getVisibleCarryableEntities(const std::vector<Tile*>& visibleTiles);

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -620,8 +620,11 @@ bool ODClient::processOneClientSocketMessage()
             OD_ASSERT_TRUE(packetReceived >> name);
             RenderedMovableEntity* tempRenderedMovableEntity = gameMap->getRenderedMovableEntity(name);
             OD_ASSERT_TRUE_MSG(tempRenderedMovableEntity != nullptr, "name=" + name);
-            gameMap->removeRenderedMovableEntity(tempRenderedMovableEntity);
-            tempRenderedMovableEntity->deleteYourself();
+            if (tempRenderedMovableEntity != nullptr)
+            {
+                gameMap->removeRenderedMovableEntity(tempRenderedMovableEntity);
+                tempRenderedMovableEntity->deleteYourself();
+            }
             break;
         }
 

--- a/source/render/Gui.cpp
+++ b/source/render/Gui.cpp
@@ -297,6 +297,14 @@ void Gui::assignEventHandlers()
             CEGUI::PushButton::EventClicked,
             CEGUI::Event::Subscriber(&cryptButtonPressed));
 
+    mSheets[editorModeGui]->getChild(BUTTON_TEMPLE)->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&templeButtonPressed));
+
+    mSheets[editorModeGui]->getChild(BUTTON_PORTAL)->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&portalButtonPressed));
+
     mSheets[editorModeGui]->getChild(BUTTON_TRAP_CANNON)->subscribeEvent(
             CEGUI::PushButton::EventClicked,
             CEGUI::Event::Subscriber(&cannonButtonPressed));
@@ -544,6 +552,26 @@ bool Gui::cryptButtonPressed(const CEGUI::EventArgs& e)
 {
     GameMap* gameMap = ODFrameListener::getSingleton().getClientGameMap();
     gameMap->getLocalPlayer()->setNewRoomType(Room::crypt);
+    gameMap->getLocalPlayer()->setNewTrapType(Trap::nullTrapType);
+    gameMap->getLocalPlayer()->setCurrentAction(Player::SelectedAction::buildRoom);
+    SoundEffectsManager::getSingleton().playInterfaceSound(SoundEffectsManager::BUTTONCLICK);
+    return true;
+}
+
+bool Gui::templeButtonPressed(const CEGUI::EventArgs& e)
+{
+    GameMap* gameMap = ODFrameListener::getSingleton().getClientGameMap();
+    gameMap->getLocalPlayer()->setNewRoomType(Room::dungeonTemple);
+    gameMap->getLocalPlayer()->setNewTrapType(Trap::nullTrapType);
+    gameMap->getLocalPlayer()->setCurrentAction(Player::SelectedAction::buildRoom);
+    SoundEffectsManager::getSingleton().playInterfaceSound(SoundEffectsManager::BUTTONCLICK);
+    return true;
+}
+
+bool Gui::portalButtonPressed(const CEGUI::EventArgs& e)
+{
+    GameMap* gameMap = ODFrameListener::getSingleton().getClientGameMap();
+    gameMap->getLocalPlayer()->setNewRoomType(Room::portal);
     gameMap->getLocalPlayer()->setNewTrapType(Trap::nullTrapType);
     gameMap->getLocalPlayer()->setCurrentAction(Player::SelectedAction::buildRoom);
     SoundEffectsManager::getSingleton().playInterfaceSound(SoundEffectsManager::BUTTONCLICK);

--- a/source/render/Gui.h
+++ b/source/render/Gui.h
@@ -236,6 +236,7 @@ private:
 
     // Button handlers game UI
     static bool miniMapclicked          (const CEGUI::EventArgs& e);
+
     static bool dormitoryButtonPressed  (const CEGUI::EventArgs& e);
     static bool treasuryButtonPressed   (const CEGUI::EventArgs& e);
     static bool destroyRoomButtonPressed(const CEGUI::EventArgs& e);
@@ -244,12 +245,17 @@ private:
     static bool libraryButtonPressed    (const CEGUI::EventArgs& e);
     static bool hatcheryButtonPressed   (const CEGUI::EventArgs& e);
     static bool cryptButtonPressed      (const CEGUI::EventArgs& e);
+    static bool templeButtonPressed     (const CEGUI::EventArgs& e);
+    static bool portalButtonPressed     (const CEGUI::EventArgs& e);
+
     static bool cannonButtonPressed     (const CEGUI::EventArgs& e);
     static bool spikeTrapButtonPressed  (const CEGUI::EventArgs& e);
     static bool boulderTrapButtonPressed(const CEGUI::EventArgs& e);
     static bool destroyTrapButtonPressed(const CEGUI::EventArgs& e);
+
     static bool workerCreatureButtonPressed     (const CEGUI::EventArgs& e);
     static bool fighterCreatureButtonPressed    (const CEGUI::EventArgs& e);
+
     static bool confirmExitYesButtonPressed     (const CEGUI::EventArgs& e);
     static bool confirmExitNoButtonPressed      (const CEGUI::EventArgs& e);
 

--- a/source/rooms/Room.h
+++ b/source/rooms/Room.h
@@ -94,7 +94,7 @@ public:
     virtual bool hasOpenCreatureSpot(Creature* c) { return false; }
 
     //! \brief Updates the active spot lists.
-    void updateActiveSpots();
+    virtual void updateActiveSpots();
 
     inline unsigned int getNumActiveSpots() const
     { return mNumActiveSpots; }

--- a/source/rooms/RoomDungeonTemple.cpp
+++ b/source/rooms/RoomDungeonTemple.cpp
@@ -42,7 +42,7 @@ void RoomDungeonTemple::updateActiveSpots()
 {
     // Room::updateActiveSpots(); <<-- Disabled on purpose.
     // We don't update the active spots the same way as only the central tile is needed.
-    if (ODFrameListener::getSingleton().getModeManager()->getCurrentModeTypeExceptConsole() == ModeManager::ModeType::EDITOR)
+    if (getGameMap()->isInEditorMode())
         updateTemplePosition();
 }
 

--- a/source/rooms/RoomDungeonTemple.cpp
+++ b/source/rooms/RoomDungeonTemple.cpp
@@ -28,6 +28,7 @@
 #include "render/ODFrameListener.h"
 #include "modes/ModeManager.h"
 #include "utils/LogManager.h"
+#include "utils/ConfigManager.h"
 
 RoomDungeonTemple::RoomDungeonTemple(GameMap* gameMap) :
     Room(gameMap),
@@ -41,7 +42,7 @@ void RoomDungeonTemple::updateActiveSpots()
 {
     // Room::updateActiveSpots(); <<-- Disabled on purpose.
     // We don't update the active spots the same way as only the central tile is needed.
-    if (ODFrameListener::getSingleton().getModeManager()->getCurrentModeType() == ModeManager::ModeType::EDITOR)
+    if (ODFrameListener::getSingleton().getModeManager()->getCurrentModeTypeExceptConsole() == ModeManager::ModeType::EDITOR)
         updateTemplePosition();
 }
 
@@ -75,7 +76,7 @@ void RoomDungeonTemple::destroyMeshLocal()
     mTempleObject = nullptr;
 }
 
-void RoomDungeonTemple::produceKobold()
+void RoomDungeonTemple::produceWorker()
 {
     // If the room has been destroyed, or has not yet been assigned any tiles, then we
     // cannot determine where to place the new creature and we should just give up.
@@ -94,18 +95,18 @@ void RoomDungeonTemple::produceKobold()
 
     mWaitTurns = 30;
 
-    // Create a new creature and copy over the class-based creature parameters.
-    const CreatureDefinition *classToSpawn = getGameMap()->getClassDescription("Kobold");
-    Creature* newCreature = new Creature(getGameMap(), classToSpawn);
+    // Creates a creature from the first worker class found for the given faction.
+    const CreatureDefinition* classToSpawn = getSeat()->getWorkerClassToSpawn();
+
     if (classToSpawn == nullptr)
     {
-        LogManager::getSingleton().logMessage("Error: No worker creature definition, class=" + classToSpawn->getClassName()
-            + ", name=" + newCreature->getName() + ", seatId=" + Ogre::StringConverter::toString(getSeat()->getId()));
-
-        delete newCreature;
+        LogManager::getSingleton().logMessage("Error: No worker creature definition, class=nullptr, seatId="
+            + Ogre::StringConverter::toString(getSeat()->getId()));
         return;
     }
 
+    // Create a new creature and copy over the class-based creature parameters.
+    Creature* newCreature = new Creature(getGameMap(), classToSpawn);
     LogManager::getSingleton().logMessage("Spawning a creature class=" + classToSpawn->getClassName()
         + ", name=" + newCreature->getName() + ", seatId=" + Ogre::StringConverter::toString(getSeat()->getId()));
 

--- a/source/rooms/RoomDungeonTemple.h
+++ b/source/rooms/RoomDungeonTemple.h
@@ -31,6 +31,8 @@ public:
     //! \brief Get back a reference to the temple mesh after calling Room::absorbRoom()
     void absorbRoom(Room* room);
 
+    bool removeCoveredTile(Tile *t);
+
     /*! \brief Counts down a timer until it reaches 0,
     *  then it spawns a kobold of the color of this dungeon temple
     *  at the center of the dungeon temple, and resets the timer.
@@ -47,6 +49,9 @@ private:
 
     //! \brief The reference of the temple object
     RenderedMovableEntity* mTempleObject;
+
+    //! \brief Updates the temple mesh position.
+    void updateTemplePosition();
 };
 
 #endif // ROOMDUNGEONTEMPLE_H

--- a/source/rooms/RoomDungeonTemple.h
+++ b/source/rooms/RoomDungeonTemple.h
@@ -32,10 +32,10 @@ public:
     void updateActiveSpots();
 
     /*! \brief Counts down a timer until it reaches 0,
-     * then it spawns a kobold of the color of this dungeon temple
+     * then it spawns a worker of the color of this dungeon temple
      * at the center of the dungeon temple, and resets the timer.
      */
-    void produceKobold();
+    void produceWorker();
 
 protected:
     virtual void createMeshLocal();

--- a/source/rooms/RoomDungeonTemple.h
+++ b/source/rooms/RoomDungeonTemple.h
@@ -28,21 +28,25 @@ public:
     virtual RoomType getType() const
     { return RoomType::dungeonTemple; }
 
-    //! \brief Get back a reference to the temple mesh after calling Room::absorbRoom()
-    void absorbRoom(Room* room);
-
-    bool removeCoveredTile(Tile *t);
+    //! \brief Updates the temple position when in editor mode.
+    void updateActiveSpots();
 
     /*! \brief Counts down a timer until it reaches 0,
-    *  then it spawns a kobold of the color of this dungeon temple
-    *  at the center of the dungeon temple, and resets the timer.
-    */
+     * then it spawns a kobold of the color of this dungeon temple
+     * at the center of the dungeon temple, and resets the timer.
+     */
     void produceKobold();
 
 protected:
     virtual void createMeshLocal();
     virtual void destroyMeshLocal();
-    void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile);
+
+    void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile)
+    {
+        // This Room keeps its building object until it is destroyed (they will be released when
+        // the room is destroyed)
+    }
+
 private:
     //! \brief The number of turns to wait before producing a worker
     int mWaitTurns;

--- a/source/rooms/RoomPortal.cpp
+++ b/source/rooms/RoomPortal.cpp
@@ -48,7 +48,7 @@ void RoomPortal::updateActiveSpots()
 {
     // Room::updateActiveSpots(); <<-- Disabled on purpose.
     // We don't update the active spots the same way as only the central tile is needed.
-    if (ODFrameListener::getSingleton().getModeManager()->getCurrentModeTypeExceptConsole() == ModeManager::ModeType::EDITOR)
+    if (getGameMap()->isInEditorMode())
         updatePortalPosition();
 }
 

--- a/source/rooms/RoomPortal.cpp
+++ b/source/rooms/RoomPortal.cpp
@@ -48,7 +48,7 @@ void RoomPortal::updateActiveSpots()
 {
     // Room::updateActiveSpots(); <<-- Disabled on purpose.
     // We don't update the active spots the same way as only the central tile is needed.
-    if (ODFrameListener::getSingleton().getModeManager()->getCurrentModeType() == ModeManager::ModeType::EDITOR)
+    if (ODFrameListener::getSingleton().getModeManager()->getCurrentModeTypeExceptConsole() == ModeManager::ModeType::EDITOR)
         updatePortalPosition();
 }
 
@@ -117,7 +117,7 @@ void RoomPortal::spawnCreature()
 
     // We check if a creature can spawn
     Seat* seat = getSeat();
-    const CreatureDefinition* classToSpawn = seat->getNextCreatureClassToSpawn();
+    const CreatureDefinition* classToSpawn = seat->getNextFighterClassToSpawn();
     if (classToSpawn == nullptr)
         return;
 

--- a/source/rooms/RoomPortal.h
+++ b/source/rooms/RoomPortal.h
@@ -32,8 +32,6 @@ public:
     virtual RoomType getType() const
     { return RoomType::portal; }
 
-    // Functions overriding virtual functions in the Room base class.
-    void addCoveredTile(Tile* t, double nHP);
     bool removeCoveredTile(Tile* t);
 
     //! \brief Get back a reference to the portal mesh after calling Room::absorbRoom()
@@ -58,15 +56,12 @@ protected:
     void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile);
 
 private:
-    //! \brief Finds the X,Y coordinates of the center of the tiles that make up the portal.
-    void recomputeCenterPosition();
-
     int mSpawnCreatureCountdown;
 
-    double mXCenter;
-    double mYCenter;
-
     RenderedMovableEntity* mPortalObject;
+
+    //! \brief Updates the portal mesh position.
+    void updatePortalPosition();
 };
 
 #endif // ROOMPORTAL_H

--- a/source/rooms/RoomPortal.h
+++ b/source/rooms/RoomPortal.h
@@ -32,11 +32,6 @@ public:
     virtual RoomType getType() const
     { return RoomType::portal; }
 
-    bool removeCoveredTile(Tile* t);
-
-    //! \brief Get back a reference to the portal mesh after calling Room::absorbRoom()
-    void absorbRoom(Room* room);
-
     //! \brief In addition to the standard upkeep, check to see if a new creature should be spawned.
     void doUpkeep();
 
@@ -49,13 +44,21 @@ public:
         return false;
     }
 
+    //! \brief Updates the portal position when in editor mode.
+    void updateActiveSpots();
+
 protected:
     void createMeshLocal();
     void destroyMeshLocal();
 
-    void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile);
+    void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile)
+    {
+        // This Room keeps its building object until it is destroyed (it will be released when
+        // the room is destroyed)
+    }
 
 private:
+    //! \brief Stores the number of turns before spawning the next creature.
     int mSpawnCreatureCountdown;
 
     RenderedMovableEntity* mPortalObject;

--- a/source/utils/ConfigManager.cpp
+++ b/source/utils/ConfigManager.cpp
@@ -636,6 +636,7 @@ bool ConfigManager::loadFactions(const std::string& fileName)
         }
 
         std::string factionName;
+        std::string workerClass;
         while(defFile.good())
         {
             if(!(defFile >> nextParam))
@@ -652,19 +653,30 @@ bool ConfigManager::loadFactions(const std::string& fileName)
                 defFile >> factionName;
                 continue;
             }
-
-            if (nextParam != "[SpawnPool]")
-            {
-                OD_ASSERT_TRUE_MSG(false, "Invalid faction. Line was " + nextParam);
-                return false;
-            }
-
             if(factionName.empty())
             {
                 OD_ASSERT_TRUE_MSG(false, "Empty or missing faction name is not allowed");
                 return false;
             }
             mFactions.push_back(factionName);
+
+            if (nextParam == "WorkerClass")
+            {
+                defFile >> workerClass;
+                continue;
+            }
+            if(workerClass.empty())
+            {
+                OD_ASSERT_TRUE_MSG(false, "Empty or missing WorkerClass name is not allowed");
+                return false;
+            }
+            mFactionDefaultWorkerClass[factionName] = workerClass;
+
+            if (nextParam != "[SpawnPool]")
+            {
+                OD_ASSERT_TRUE_MSG(false, "Invalid faction. Line was " + nextParam);
+                return false;
+            }
 
             while(defFile.good())
             {
@@ -1002,6 +1014,14 @@ const std::vector<std::string>& ConfigManager::getFactionSpawnPool(const std::st
         return EMPTY_SPAWNPOOL;
 
     return mFactionSpawnPool.at(faction);
+}
+
+const std::string& ConfigManager::getFactionWorkerClass(const std::string& faction) const
+{
+    if(mFactionDefaultWorkerClass.count(faction) == 0)
+        return EMPTY_STRING;
+
+    return mFactionDefaultWorkerClass.at(faction);
 }
 
 CreatureMoodLevel ConfigManager::getCreatureMoodLevel(int32_t moodModifiersPoints) const

--- a/source/utils/ConfigManager.h
+++ b/source/utils/ConfigManager.h
@@ -73,7 +73,11 @@ public:
 
     const std::vector<const SpawnCondition*>& getCreatureSpawnConditions(const CreatureDefinition* def) const;
 
+    //! \brief Get the fighter creature definition spawnable in portals according to the given faction.
     const std::vector<std::string>& getFactionSpawnPool(const std::string& faction) const;
+
+    //! \brief Get the worker creature definition spawnable in portals according to the given faction.
+    const std::string& getFactionWorkerClass(const std::string& faction) const;
 
     inline const std::vector<std::string>& getFactions() const
     { return mFactions; }
@@ -130,6 +134,10 @@ private:
     std::map<const CreatureDefinition*, std::vector<const SpawnCondition*> > mCreatureSpawnConditions;
     std::map<const std::string, std::vector<const CreatureMood*> > mCreatureMoodModifiers;
     std::map<const std::string, std::vector<std::string> > mFactionSpawnPool;
+
+    //! \brief Stores the faction default worker creature definition.
+    std::map<const std::string, std::string> mFactionDefaultWorkerClass;
+
     std::vector<std::string> mFactions;
     std::map<const std::string, std::string> mRoomsConfig;
     std::map<const std::string, std::string> mTrapsConfig;

--- a/source/utils/ConfigManager.h
+++ b/source/utils/ConfigManager.h
@@ -76,7 +76,7 @@ public:
     //! \brief Get the fighter creature definition spawnable in portals according to the given faction.
     const std::vector<std::string>& getFactionSpawnPool(const std::string& faction) const;
 
-    //! \brief Get the worker creature definition spawnable in portals according to the given faction.
+    //! \brief Get the default worker creature definition spawnable according to the given faction.
     const std::string& getFactionWorkerClass(const std::string& faction) const;
 
     inline const std::vector<std::string>& getFactions() const


### PR DESCRIPTION
Part of #192

I also added support to handle moving the portal and temple only within the editor.
But this still triggers an assert failure when removing tiles including the one
with the mesh.
E.g.:
ERROR: Assert failed file opendungeons/source/network/ODClient.cpp line 622 info : name=RenderedMovableEntity_Portal2_50

I've made a few tests but so far I really can't tell what's triggering it.
Any advice? ;)

Otherwise, it' working fine.
