### PR TITLE
Implemented creatures mood

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,13 @@ set(OD_SOURCEFILES
     ${SRC}/camera/CameraManager.cpp
     ${SRC}/camera/HermiteCatmullSpline.cpp
 
+    ${SRC}/creaturemood/CreatureMood.cpp
+    ${SRC}/creaturemood/CreatureMoodAwakness.cpp
+    ${SRC}/creaturemood/CreatureMoodCreature.cpp
+    ${SRC}/creaturemood/CreatureMoodFee.cpp
+    ${SRC}/creaturemood/CreatureMoodHunger.cpp
+    ${SRC}/creaturemood/CreatureMoodHpLoss.cpp
+
     ${SRC}/entities/Building.cpp
     ${SRC}/entities/BuildingObject.cpp
     ${SRC}/entities/ChickenEntity.cpp

--- a/config/creatures.cfg
+++ b/config/creatures.cfg
@@ -4,7 +4,7 @@
 # The creatures initial stats are parsed within the [Stats] [/Stats] tag couple.
 # The creatures XP table is parsed within the [XP] [/XP] tag couple.
 # It represents the amount of Experience points needed to reach the next level.
-# Later, the [SpawnConditions], [MoodModifiers], and [Skills] tags will have to added when supported.
+# Later, the [Skills] tag will have to be added when supported.
 #
 # Supported stats:
 # Name        (Must be unique without spaces) The creature definition name.
@@ -44,6 +44,7 @@
 # AttackWarmupTime    The time the creature will wait before triggering an attack, in seconds.
 # FeeBase             Fee that the creature will claim at level 1
 # FeePerLevel         Fee that the creature will claim for each level
+# CreatureMoodName    Name of the creature mood modifier that should be used to compute the creature mood
 # RoomAffinity        Defines which rooms the creature will want and be able to use. There can be several rooms. They should be ordered from highest to lowest likeness. Each is defined by:
 #                     RoomName(string) likeness(uint) efficiency(double)
 #                     The likeness defines if a creature will go to this kind of room (if available). If likeness = 0 the creature won't go to this given room by itself
@@ -240,6 +241,7 @@
     AttackWarmupTime	1.6
     FeeBase	300
     FeePerLevel	125
+    CreatureMoodName	MoodTier2
     [RoomAffinity]
     TrainingHall	100	1.0
     Forge	80	1.0
@@ -294,6 +296,7 @@
     AttackWarmupTime	2.5
     FeeBase	800
     FeePerLevel	250
+    CreatureMoodName	MoodTier3
     [/Stats]
     [RoomAffinity]
     TrainingHall	100	1.0
@@ -347,6 +350,7 @@
     AttackWarmupTime	1.8
     FeeBase	300
     FeePerLevel	125
+    CreatureMoodName	MoodTier2
     [/Stats]
     [RoomAffinity]
     TrainingHall	100	1.0
@@ -401,6 +405,7 @@
     AttackWarmupTime	2.0
     FeeBase	400
     FeePerLevel	150
+    CreatureMoodName	MoodTier2
     [/Stats]
     [RoomAffinity]
     TrainingHall	100	1.0
@@ -455,6 +460,7 @@
     AttackWarmupTime	1.1
     FeeBase	80
     FeePerLevel	60
+    CreatureMoodName	MoodTier1
     [/Stats]
     [RoomAffinity]
     Forge	200	2.0
@@ -509,6 +515,7 @@
     AttackWarmupTime	2.5
     FeeBase	1500
     FeePerLevel	350
+    CreatureMoodName	MoodTier4
     [/Stats]
     [RoomAffinity]
     TrainingHall	100	1.0
@@ -562,6 +569,7 @@
     AttackWarmupTime	1.1
     FeeBase	100
     FeePerLevel	80
+    CreatureMoodName	MoodSpider
     [/Stats]
     [RoomAffinity]
     TrainingHall	100	1.0
@@ -615,6 +623,7 @@
     AttackWarmupTime	1
     FeeBase	60
     FeePerLevel	40
+    CreatureMoodName	MoodTier1
     [/Stats]
     [RoomAffinity]
     TrainingHall	100	1.0
@@ -668,6 +677,7 @@
     AttackWarmupTime	0.7
     FeeBase	40
     FeePerLevel	25
+    CreatureMoodName	MoodTier1
     [/Stats]
     [RoomAffinity]
     TrainingHall	100	1.0
@@ -721,6 +731,7 @@
     AttackWarmupTime	2.5
     FeeBase	550
     FeePerLevel	200
+    CreatureMoodName	MoodTier1
     [/Stats]
     [RoomAffinity]
     TrainingHall	100	1.0
@@ -774,6 +785,7 @@
     AttackWarmupTime	1.5
     FeeBase	100
     FeePerLevel	80
+    CreatureMoodName	MoodTier2
     [/Stats]
     [RoomAffinity]
     TrainingHall	100	1.0
@@ -828,6 +840,7 @@
     AttackWarmupTime	0.8
     FeeBase	40
     FeePerLevel	20
+    CreatureMoodName	MoodCaveHornet
     [/Stats]
     [RoomAffinity]
     TrainingHall	100	1.0
@@ -881,6 +894,7 @@
     AttackWarmupTime	2.0
     FeeBase	300
     FeePerLevel	60
+    CreatureMoodName	MoodTier3
     [/Stats]
     [RoomAffinity]
     TrainingHall	100	1.0
@@ -935,6 +949,7 @@
     AttackWarmupTime	1.1
     FeeBase	50
     FeePerLevel	30
+    CreatureMoodName	MoodTier1
     [/Stats]
     [RoomAffinity]
     Library	200	0
@@ -991,6 +1006,7 @@
     AttackWarmupTime	1.1
     FeeBase	40
     FeePerLevel	25
+    CreatureMoodName	MoodTier1
     [/Stats]
     [RoomAffinity]
     TrainingHall	100	1.0
@@ -1045,6 +1061,7 @@
     AttackWarmupTime	1.5
     FeeBase	320
     FeePerLevel	130
+    CreatureMoodName	MoodTier2
     [/Stats]
     [RoomAffinity]
     TrainingHall	100	1.0
@@ -1099,6 +1116,7 @@
     AttackWarmupTime	1.2
     FeeBase	100
     FeePerLevel	20
+    CreatureMoodName	MoodTier1
     [/Stats]
     [RoomAffinity]
     Forge	200	2.0
@@ -1153,6 +1171,7 @@
     AttackWarmupTime	1.5
     FeeBase	100
     FeePerLevel	80
+    CreatureMoodName	MoodTier1
     [/Stats]
     [RoomAffinity]
     Forge	200	1.5
@@ -1209,6 +1228,7 @@
     WeaponSpawnR	RustySword
     FeeBase	400
     FeePerLevel	150
+    CreatureMoodName	MoodTier3
     [/Stats]
     [RoomAffinity]
     TrainingHall	100	1.0
@@ -1263,6 +1283,7 @@
     AttackWarmupTime	2.0
     FeeBase	280
     FeePerLevel	120
+    CreatureMoodName	MoodTier2
     [/Stats]
     [RoomAffinity]
     TrainingHall	100	1.0
@@ -1316,6 +1337,7 @@
     AttackWarmupTime	2
     FeeBase	150
     FeePerLevel	90
+    CreatureMoodName	MoodTier1
     [/Stats]
     [RoomAffinity]
     TrainingHall	100	1.0
@@ -1371,6 +1393,7 @@
     FeePerLevel	400
     WeaponSpawnL	RustyShield
     WeaponSpawnR	RustySword
+    CreatureMoodName	MoodTier4
     [/Stats]
     [RoomAffinity]
     TrainingHall	100	1.0
@@ -1424,6 +1447,7 @@
     AttackWarmupTime	1.8
     FeeBase	300
     FeePerLevel	125
+    CreatureMoodName	MoodTier2
     [/Stats]
     [RoomAffinity]
     TrainingHall	100	1.0

--- a/config/creaturesmood.cfg
+++ b/config/creaturesmood.cfg
@@ -1,0 +1,122 @@
+# CreaturesMood      Mood modifiers are defined per class. They define how the creatures moods will evolve regarding how they are
+#                    and what is around them. Mood modifier can be > 0 (will make the creature happy) or < 0 (will make the creature angry)
+#                    If a creature has mood < 0, it will engage 
+# BaseMood           Represents the mood points a creature will have before applying modifiers
+#
+# The modifiers can be :
+# - Creature <CreatureClass> <Mood modifier>
+#    => The mood modifier will apply per each creature class within visible tiles
+# - HpLoss <Mood modifier>
+#    => The mood modifier will apply per maxHp - currentHp 
+# - Hunger <StartingLevel> <Mood modifier>
+#    => When the creature has eaten, the hunger is 0. The mood modifier will apply per hunger point over StartingLevel
+# - Awakness <StartingLevel> <Mood modifier>
+#    => When the creature has slept, the hunger is 100. The mood modifier will apply per hunger point under StartingLevel
+# - Fee <Mood modifier>
+#    => The mood modifier will apply per 100 gold > 1 pay day (if the creature fee is 150, it will apply for gold owed > 150)
+
+[CreaturesMood]
+BaseMood	1000
+MoodHappy	1200
+MoodUpset	0
+MoodAngry	-1000
+MoodFurious	-2000
+
+[CreatureMood]
+    CreatureMoodName	MoodTier1
+    [MoodModifier]
+    Hunger	80	-20
+    [/MoodModifier]
+    [MoodModifier]
+    Awakness	20	-20
+    [/MoodModifier]
+    [MoodModifier]
+    Fee	-80
+    [/MoodModifier]
+    [MoodModifier]
+    HpLoss	-2
+    [/MoodModifier]
+[/CreatureMood]
+[CreatureMood]
+    CreatureMoodName	MoodTier2
+    [MoodModifier]
+    Hunger	80	-40
+    [/MoodModifier]
+    [MoodModifier]
+    Awakness	20	-40
+    [/MoodModifier]
+    [MoodModifier]
+    Fee	-100
+    [/MoodModifier]
+    [MoodModifier]
+    HpLoss	-4
+    [/MoodModifier]
+[/CreatureMood]
+[CreatureMood]
+    CreatureMoodName	MoodTier3
+    [MoodModifier]
+    Hunger	80	-60
+    [/MoodModifier]
+    [MoodModifier]
+    Awakness	20	-60
+    [/MoodModifier]
+    [MoodModifier]
+    Fee	-100
+    [/MoodModifier]
+    [MoodModifier]
+    HpLoss	-4
+    [/MoodModifier]
+[/CreatureMood]
+[CreatureMood]
+    CreatureMoodName	MoodTier4
+    [MoodModifier]
+    Hunger	80	-60
+    [/MoodModifier]
+    [MoodModifier]
+    Awakness	20	-60
+    [/MoodModifier]
+    [MoodModifier]
+    Fee	-120
+    [/MoodModifier]
+    [MoodModifier]
+    HpLoss	-6
+    [/MoodModifier]
+[/CreatureMood]
+[CreatureMood]
+    CreatureMoodName	MoodSpider
+    [MoodModifier]
+    Creature	CaveHornet	-500
+    [/MoodModifier]
+    [MoodModifier]
+    Hunger	80	-20
+    [/MoodModifier]
+    [MoodModifier]
+    Awakness	20	-20
+    [/MoodModifier]
+    [MoodModifier]
+    Fee	-80
+    [/MoodModifier]
+    [MoodModifier]
+    HpLoss	-2
+    [/MoodModifier]
+[/CreatureMood]
+[CreatureMood]
+    CreatureMoodName	MoodCaveHornet
+    [MoodModifier]
+    Creature	Spider	-500
+    [/MoodModifier]
+    [MoodModifier]
+    Hunger	80	-20
+    [/MoodModifier]
+    [MoodModifier]
+    Awakness	20	-20
+    [/MoodModifier]
+    [MoodModifier]
+    Fee	-80
+    [/MoodModifier]
+    [MoodModifier]
+    HpLoss	-2
+    [/MoodModifier]
+[/CreatureMood]
+
+[/CreaturesMood]

--- a/config/global.cfg
+++ b/config/global.cfg
@@ -76,6 +76,10 @@
     Type	Traps
     Filename	traps.cfg
 [/ConfigFile]
+[ConfigFile]
+    Type	CreaturesMood
+    Filename	creaturesmood.cfg
+[/ConfigFile]
 [/ConfigFiles]
 [GameConfig]
     NetworkPort	31222
@@ -83,4 +87,5 @@
     MaxCreaturesPerSeat	15
     SlapDamagePercent	15
     TimePayDay	180
+    NbTurnsFuriousMax	120
 [/GameConfig]

--- a/levels/skirmish/GreedOrMight.level
+++ b/levels/skirmish/GreedOrMight.level
@@ -12,7 +12,6 @@ FightMusic	The_Dark_Amulet.ogg
 1	1	Choice	Keeper	37	15	1	1000
 2	2	Choice	Keeper	59	47	2	1000
 3	3	Choice	Keeper	14	45	3	1000
-4	4	Inactive	Keeper	37	37	4	0
 [/Seats]
 
 [Goals]
@@ -2330,15 +2329,15 @@ MineNGold	50
 [Creatures]
 # SeatId	ClassName	Name	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	PosX	PosY	PosZ	LeftWeapon	RightWeapon
 [Creature]
-4	BossDragon	BossDragon1	4	0	max	100	0	0	62	14	0	none	none
+0	BossDragon	BossDragon1	4	0	max	100	0	0	62	14	0	none	none
 [/Creature]
 [Creature]
-4	BossDragon	BossDragon2	3	0	max	100	0	0	40	68	0	none	none
+0	BossDragon	BossDragon2	3	0	max	100	0	0	40	68	0	none	none
 [/Creature]
 [Creature]
-4	BossDragon	BossDragon3	3	0	max	100	0	0	33	65	0	none	none
+0	BossDragon	BossDragon3	3	0	max	100	0	0	33	65	0	none	none
 [/Creature]
 [Creature]
-4	BossDragon	BossDragon4	4	0	max	100	0	0	9	14	0	none	none
+0	BossDragon	BossDragon4	4	0	max	100	0	0	9	14	0	none	none
 [/Creature]
 [/Creatures]

--- a/levels/skirmish/Stonekeep siege.level
+++ b/levels/skirmish/Stonekeep siege.level
@@ -13,7 +13,6 @@ FightMusic	The_Dark_Amulet.ogg
 2	2	AI	Keeper	7	55	2	1000
 3	3	AI	Keeper	91	55	3	1000
 4	4	AI	Keeper	47	94	4	1000
-5	5	Inactive	Keeper	47	94	5	1000
 [/Seats]
 
 [Goals]
@@ -3949,59 +3948,59 @@ ProtectDungeonTemple	NULL
 [Traps]
 # typeTrap	seatId	numTiles		Subsequent Lines: tileX	tileY	isActivated(0/1)		Subsequent Lines: optional specific data
 [Trap]
-1	5	1
+1	0	1
 48	37	1
 [/Trap]
 [Trap]
-1	5	1
+1	0	1
 50	37	1
 [/Trap]
 [Trap]
-1	5	1
+1	0	1
 17	16	1
 [/Trap]
 [Trap]
-1	5	1
+1	0	1
 17	20	1
 [/Trap]
 [Trap]
-1	5	1
+1	0	1
 46	47	1
 [/Trap]
 [Trap]
-1	5	1
+1	0	1
 48	47	1
 [/Trap]
 [Trap]
-1	5	1
+1	0	1
 50	47	1
 [/Trap]
 [Trap]
-1	5	1
+1	0	1
 52	47	1
 [/Trap]
 [Trap]
-1	5	1
+1	0	1
 43	66	1
 [/Trap]
 [Trap]
-1	5	1
+1	0	1
 46	66	1
 [/Trap]
 [Trap]
-1	5	1
+1	0	1
 48	66	1
 [/Trap]
 [Trap]
-1	5	1
+1	0	1
 50	66	1
 [/Trap]
 [Trap]
-1	5	1
+1	0	1
 52	66	1
 [/Trap]
 [Trap]
-1	5	1
+1	0	1
 55	66	1
 [/Trap]
 [/Traps]
@@ -4045,100 +4044,100 @@ ProtectDungeonTemple	NULL
 4	Kobold	Kobold97	1	0	max	100	0	0	47	94	0	none	none
 [/Creature]
 [Creature]
-5	Dwarf3	Dwarf99	1	0	max	100	0	0	9	15	0	Roundshield	Longsword
+0	Dwarf3	Dwarf99	1	0	max	100	0	0	9	15	0	Roundshield	Longsword
 [/Creature]
 [Creature]
-5	Dwarf3	Dwarf98	1	0	max	100	0	0	9	16	0	Roundshield	Longsword
+0	Dwarf3	Dwarf98	1	0	max	100	0	0	9	16	0	Roundshield	Longsword
 [/Creature]
 [Creature]
-5	Dwarf3	Dwarf97	1	0	max	100	0	0	9	17	0	Roundshield	Longsword
+0	Dwarf3	Dwarf97	1	0	max	100	0	0	9	17	0	Roundshield	Longsword
 [/Creature]
 [Creature]
-5	Dwarf3	Dwarf96	1	0	max	100	0	0	9	18	0	Roundshield	Longsword
+0	Dwarf3	Dwarf96	1	0	max	100	0	0	9	18	0	Roundshield	Longsword
 [/Creature]
 [Creature]
-5	Dwarf3	Dwarf95	1	0	max	100	0	0	9	19	0	Roundshield	Longsword
+0	Dwarf3	Dwarf95	1	0	max	100	0	0	9	19	0	Roundshield	Longsword
 [/Creature]
 [Creature]
-5	Dwarf3	Dwarf94	1	0	max	100	0	0	9	20	0	Roundshield	Longsword
+0	Dwarf3	Dwarf94	1	0	max	100	0	0	9	20	0	Roundshield	Longsword
 [/Creature]
 [Creature]
-5	Dwarf3	Dwarf93	1	0	max	100	0	0	9	21	0	Roundshield	Longsword
+0	Dwarf3	Dwarf93	1	0	max	100	0	0	9	21	0	Roundshield	Longsword
 [/Creature]
 [Creature]
-5	Knight	Knight90	1	0	max	100	0	0	46	42	0	Roundshield	Longsword
+0	Knight	Knight90	1	0	max	100	0	0	46	42	0	Roundshield	Longsword
 [/Creature]
 [Creature]
-5	Knight	Knight91	1	0	max	100	0	0	47	42	0	Roundshield	Longsword
+0	Knight	Knight91	1	0	max	100	0	0	47	42	0	Roundshield	Longsword
 [/Creature]
 [Creature]
-5	Knight	Knight92	1	0	max	100	0	0	48	42	0	Roundshield	Sabre
+0	Knight	Knight92	1	0	max	100	0	0	48	42	0	Roundshield	Sabre
 [/Creature]
 [Creature]
-5	Knight	Knight93	1	0	max	100	0	0	49	42	0	Roundshield	Sabre
+0	Knight	Knight93	1	0	max	100	0	0	49	42	0	Roundshield	Sabre
 [/Creature]
 [Creature]
-5	Knight	Knight94	1	0	max	100	0	0	50	42	0	Roundshield	Sabre
+0	Knight	Knight94	1	0	max	100	0	0	50	42	0	Roundshield	Sabre
 [/Creature]
 [Creature]
-5	Knight	Knight95	1	0	max	100	0	0	51	42	0	Roundshield	Longsword
+0	Knight	Knight95	1	0	max	100	0	0	51	42	0	Roundshield	Longsword
 [/Creature]
 [Creature]
-5	Knight	Knight96	1	0	max	100	0	0	52	42	0	Longsword	Longsword
+0	Knight	Knight96	1	0	max	100	0	0	52	42	0	Longsword	Longsword
 [/Creature]
 [Creature]
-5	Knight	Knight97	1	0	max	100	0	0	49	41	0	Longsword	Longsword
+0	Knight	Knight97	1	0	max	100	0	0	49	41	0	Longsword	Longsword
 [/Creature]
 [Creature]
-5	Dragon	Dragon90	1	0	max	100	0	0	86	20	0	none	none
+0	Dragon	Dragon90	1	0	max	100	0	0	86	20	0	none	none
 [/Creature]
 [Creature]
-5	Dragon	Dragon91	1	0	max	100	0	0	92	20	0	none	none
+0	Dragon	Dragon91	1	0	max	100	0	0	92	20	0	none	none
 [/Creature]
 [Creature]
-5	Dragon	Dragon92	1	0	max	100	0	0	89	25	0	none	none
+0	Dragon	Dragon92	1	0	max	100	0	0	89	25	0	none	none
 [/Creature]
 [Creature]
-5	Dragon	Dragon93	1	0	max	100	0	0	96	18	0	none	none
+0	Dragon	Dragon93	1	0	max	100	0	0	96	18	0	none	none
 [/Creature]
 [Creature]
-5	Tentacle2	Tentacle90	1	0	max	100	0	0	73	23	0	none	none
+0	Tentacle2	Tentacle90	1	0	max	100	0	0	73	23	0	none	none
 [/Creature]
 [Creature]
-5	Tentacle2	Tentacle91	1	0	max	100	0	0	73	23	0	none	none
+0	Tentacle2	Tentacle91	1	0	max	100	0	0	73	23	0	none	none
 [/Creature]
 [Creature]
-5	Tentacle2	Tentacle92	1	0	max	100	0	0	73	23	0	none	none
+0	Tentacle2	Tentacle92	1	0	max	100	0	0	73	23	0	none	none
 [/Creature]
 [Creature]
-5	Tentacle2	Tentacle93	1	0	max	100	0	0	73	23	0	none	none
+0	Tentacle2	Tentacle93	1	0	max	100	0	0	73	23	0	none	none
 [/Creature]
 [Creature]
-5	Tentacle2	Tentacle94	1	0	max	100	0	0	75	12	0	none	none
+0	Tentacle2	Tentacle94	1	0	max	100	0	0	75	12	0	none	none
 [/Creature]
 [Creature]
-5	Tentacle2	Tentacle95	1	0	max	100	0	0	75	12	0	none	none
+0	Tentacle2	Tentacle95	1	0	max	100	0	0	75	12	0	none	none
 [/Creature]
 [Creature]
-5	Tentacle2	Tentacle96	1	0	max	100	0	0	75	12	0	none	none
+0	Tentacle2	Tentacle96	1	0	max	100	0	0	75	12	0	none	none
 [/Creature]
 [Creature]
-5	Tentacle2	Tentacle97	1	0	max	100	0	0	75	12	0	none	none
+0	Tentacle2	Tentacle97	1	0	max	100	0	0	75	12	0	none	none
 [/Creature]
 [Creature]
-5	Tentacle2	Tentacle98	1	0	max	100	0	0	72	5	0	none	none
+0	Tentacle2	Tentacle98	1	0	max	100	0	0	72	5	0	none	none
 [/Creature]
 [Creature]
-5	Tentacle2	Tentacle99	1	0	max	100	0	0	72	5	0	none	none
+0	Tentacle2	Tentacle99	1	0	max	100	0	0	72	5	0	none	none
 [/Creature]
 [Creature]
-5	Tentacle2	Tentacle100	1	0	max	100	0	0	69	37	0	none	none
+0	Tentacle2	Tentacle100	1	0	max	100	0	0	69	37	0	none	none
 [/Creature]
 [Creature]
-5	Tentacle2	Tentacle101	1	0	max	100	0	0	69	37	0	none	none
+0	Tentacle2	Tentacle101	1	0	max	100	0	0	69	37	0	none	none
 [/Creature]
 [Creature]
-5	Tentacle2	Tentacle102	1	0	max	100	0	0	69	37	0	none	none
+0	Tentacle2	Tentacle102	1	0	max	100	0	0	69	37	0	none	none
 [/Creature]
 [Creature]
 4	PitDemon	PitDemon90	1	0	max	100	0	0	48	57	0	none	none

--- a/levels/skirmish/TestSingleplayerSmall.level
+++ b/levels/skirmish/TestSingleplayerSmall.level
@@ -13,7 +13,6 @@ FightMusic	The_Dark_Amulet.ogg
 2	1/2	AI	Hero	10	40	2	1000
 3	3	Choice	Choice	40	10	3	1000
 4	3	Choice	Choice	40	40	4	1000
-5	4	Inactive	Keeper	0	0	5	0
 [/Seats]
 
 [Goals]
@@ -974,9 +973,13 @@ ProtectDungeonTemple	NULL
     AttackRange	1
     AtkRange/Level	0
     AttackWarmupTime	1.5
+    FeeBase	0
+    FeePerLevel	0
     WeaponSpawnL	none
     WeaponSpawnL	none
     [/Stats]
+    [RoomAffinity]
+    [/RoomAffinity]
     [XP]
     # 2-10
     6	12	20	29	39	50	62	76	90
@@ -1020,13 +1023,13 @@ ProtectDungeonTemple	NULL
 2	Adventurer	Adventurer3	1	0	10	100	0	0	7	40	0	none	none
 [/Creature]
 [Creature]
-5	BigDragon	Dragon1	1	0	max	100	0	0	43	10	0	none	none
+0	BigDragon	Dragon1	1	0	max	100	0	0	43	10	0	none	none
 [/Creature]
 [Creature]
-5	BigDragon	Dragon2	1	0	max	100	0	0	40	10	0	none	none
+0	BigDragon	Dragon2	1	0	max	100	0	0	40	10	0	none	none
 [/Creature]
 [Creature]
-5	BigDragon	Dragon3	1	0	max	100	0	0	40	12	0	none	none
+0	BigDragon	Dragon3	1	0	max	100	0	0	40	12	0	none	none
 [/Creature]
 [Creature]
 3	Tentacle1	Tentacle11	1	0	max	100	0	0	5	15	0	none	none
@@ -1048,5 +1051,8 @@ ProtectDungeonTemple	NULL
 [/Creature]
 [Creature]
 3	Orc	Orc3	1	0	0	100	0	0	3	20	0	none	none
+[/Creature]
+[Creature]
+0	Wyvern	Wyvern1	1	0	max	100	0	0	15	18	0	none	none
 [/Creature]
 [/Creatures]

--- a/levels/skirmish/TestSingleplayerSmallEmpty.level
+++ b/levels/skirmish/TestSingleplayerSmallEmpty.level
@@ -10,7 +10,6 @@ FightMusic	The_Dark_Amulet.ogg
 [Seats]
 # seatId	teamId	player	faction	startingX	startingY	color	startingGold
 1	1	Choice	Keeper	10	10	1	1000
-2	2	Inactive	Keeper	10	10	2	1000
 [/Seats]
 
 [Goals]
@@ -2601,6 +2600,6 @@ ProtectDungeonTemple	NULL
 1	ConstructWorker	ConstructWorker1	1	0	max	100	0	0	7	7	0	none	none
 [/Creature]
 [Creature]
-2	Scarab	Scarab1	1	0	max	100	0	0	37	42	0	none	none
+0	Scarab	Scarab1	1	0	max	100	0	0	37	42	0	none	none
 [/Creature]
 [/Creatures]

--- a/levels/skirmish/The Bridge.level
+++ b/levels/skirmish/The Bridge.level
@@ -11,7 +11,6 @@ FightMusic	The_Dark_Amulet.ogg
 # seatId	teamId	player	faction	startingX	startingY	color	startingGold
 1	1	Choice	Choice	50	79	1	1000
 2	2	Choice	Choice	50	21	2	1000
-3	3	Inactive	Keeper	0	0	3	0
 [/Seats]
 
 [Goals]
@@ -4404,57 +4403,57 @@ ProtectDungeonTemple	NULL
 [Creatures]
 # SeatId	ClassName	Name	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	PosX	PosY	PosZ	LeftWeapon	RightWeapon
 [Creature]
-3	Spider	Spider1	2	0	max	100	0	0	17	67	0	none	none
+0	Spider	Spider1	2	0	max	100	0	0	17	67	0	none	none
 [/Creature]
 [Creature]
-3	Spider	Spider2	2	0	max	100	0	0	16	67	0	none	none
+0	Spider	Spider2	2	0	max	100	0	0	16	67	0	none	none
 [/Creature]
 [Creature]
-3	Spider	Spider3	2	0	max	100	0	0	15	67	0	none	none
+0	Spider	Spider3	2	0	max	100	0	0	15	67	0	none	none
 [/Creature]
 [Creature]
-3	Spider	Spider4	2	0	max	100	0	0	16	68	0	none	none
+0	Spider	Spider4	2	0	max	100	0	0	16	68	0	none	none
 [/Creature]
 [Creature]
-3	Spider	Spider5	2	0	max	100	0	0	16	66	0	none	none
+0	Spider	Spider5	2	0	max	100	0	0	16	66	0	none	none
 [/Creature]
 [Creature]
-3	Spider	Spider6	2	0	max	100	0	0	83	33	0	none	none
+0	Spider	Spider6	2	0	max	100	0	0	83	33	0	none	none
 [/Creature]
 [Creature]
-3	Spider	Spider7	2	0	max	100	0	0	84	33	0	none	none
+0	Spider	Spider7	2	0	max	100	0	0	84	33	0	none	none
 [/Creature]
 [Creature]
-3	Spider	Spider8	2	0	max	100	0	0	82	33	0	none	none
+0	Spider	Spider8	2	0	max	100	0	0	82	33	0	none	none
 [/Creature]
 [Creature]
-3	Spider	Spider9	2	0	max	100	0	0	83	34	0	none	none
+0	Spider	Spider9	2	0	max	100	0	0	83	34	0	none	none
 [/Creature]
 [Creature]
-3	Spider	Spider10	2	0	max	100	0	0	83	32	0	none	none
+0	Spider	Spider10	2	0	max	100	0	0	83	32	0	none	none
 [/Creature]
 [Creature]
-3	Spider	Spider11	3	0	max	100	0	0	50	41	0	none	none
+0	Spider	Spider11	3	0	max	100	0	0	50	41	0	none	none
 [/Creature]
 [Creature]
-3	Spider	Spider12	3	0	max	100	0	0	51	43	0	none	none
+0	Spider	Spider12	3	0	max	100	0	0	51	43	0	none	none
 [/Creature]
 [Creature]
-3	Spider	Spider13	3	0	max	100	0	0	50	45	0	none	none
+0	Spider	Spider13	3	0	max	100	0	0	50	45	0	none	none
 [/Creature]
 [Creature]
-3	Spider	Spider14	3	0	max	100	0	0	51	47	0	none	none
+0	Spider	Spider14	3	0	max	100	0	0	51	47	0	none	none
 [/Creature]
 [Creature]
-3	Spider	Spider15	3	0	max	100	0	0	50	53	0	none	none
+0	Spider	Spider15	3	0	max	100	0	0	50	53	0	none	none
 [/Creature]
 [Creature]
-3	Spider	Spider16	3	0	max	100	0	0	51	55	0	none	none
+0	Spider	Spider16	3	0	max	100	0	0	51	55	0	none	none
 [/Creature]
 [Creature]
-3	Spider	Spider17	3	0	max	100	0	0	50	57	0	none	none
+0	Spider	Spider17	3	0	max	100	0	0	50	57	0	none	none
 [/Creature]
 [Creature]
-3	Spider	Spider18	3	0	max	100	0	0	51	59	0	none	none
+0	Spider	Spider18	3	0	max	100	0	0	51	59	0	none	none
 [/Creature]
 [/Creatures]

--- a/source/creaturemood/CreatureMood.cpp
+++ b/source/creaturemood/CreatureMood.cpp
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (C) 2011-2015  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "creaturemood/CreatureMood.h"
+
+#include "creaturemood/CreatureMoodAwakness.h"
+#include "creaturemood/CreatureMoodCreature.h"
+#include "creaturemood/CreatureMoodFee.h"
+#include "creaturemood/CreatureMoodHpLoss.h"
+#include "creaturemood/CreatureMoodHunger.h"
+
+#include "utils/ConfigManager.h"
+#include "utils/Helper.h"
+#include "utils/LogManager.h"
+
+CreatureMood* CreatureMood::load(std::istream& defFile)
+{
+    std::string nextParam;
+    CreatureMood* def = nullptr;
+    while (defFile.good())
+    {
+        if(!(defFile >> nextParam))
+            break;
+
+        if (nextParam == "[/MoodModifiers]" || nextParam == "[/MoodModifier]")
+            return def;
+
+        if(def != nullptr)
+        {
+            // The previous line was a valid def so we should have had an ending tag
+            OD_ASSERT_TRUE_MSG(false, "nextParam=" + nextParam);
+            return def;
+        }
+
+        if (nextParam == "Awakness")
+        {
+            if(!(defFile >> nextParam))
+                break;
+            int32_t startAwakness = Helper::toInt(nextParam);
+            if(!(defFile >> nextParam))
+                break;
+            int32_t moodModifier = Helper::toInt(nextParam);
+
+            def = new CreatureMoodAwakness(startAwakness, moodModifier);
+        }
+
+        if (nextParam == "Creature")
+        {
+            std::string creatureClass;
+            if(!(defFile >> creatureClass))
+                break;
+            if(!(defFile >> nextParam))
+                break;
+            int32_t moodModifier = Helper::toInt(nextParam);
+
+            def = new CreatureMoodCreature(creatureClass, moodModifier);
+        }
+
+        if (nextParam == "Fee")
+        {
+            if(!(defFile >> nextParam))
+                break;
+            int32_t moodModifier = Helper::toInt(nextParam);
+
+            def = new CreatureMoodFee(moodModifier);
+        }
+
+        if (nextParam == "HpLoss")
+        {
+            if(!(defFile >> nextParam))
+                break;
+            int32_t moodModifier = Helper::toInt(nextParam);
+
+            def = new CreatureMoodHpLoss(moodModifier);
+        }
+
+        if (nextParam == "Hunger")
+        {
+            if(!(defFile >> nextParam))
+                break;
+            int32_t startHunger = Helper::toInt(nextParam);
+            if(!(defFile >> nextParam))
+                break;
+            int32_t moodModifier = Helper::toInt(nextParam);
+
+            def = new CreatureMoodHunger(startHunger, moodModifier);
+        }
+    }
+    OD_ASSERT_TRUE(false);
+    return nullptr;
+}

--- a/source/creaturemood/CreatureMood.cpp
+++ b/source/creaturemood/CreatureMood.cpp
@@ -27,6 +27,26 @@
 #include "utils/Helper.h"
 #include "utils/LogManager.h"
 
+std::string CreatureMood::toString(CreatureMoodLevel moodLevel)
+{
+    switch(moodLevel)
+    {
+        case CreatureMoodLevel::Happy:
+            return "Happy";
+        case CreatureMoodLevel::Neutral:
+            return "Neutral";
+        case CreatureMoodLevel::Upset:
+            return "Upset";
+        case CreatureMoodLevel::Angry:
+            return "Angry";
+        case CreatureMoodLevel::Furious:
+            return "Furious";
+        default:
+            OD_ASSERT_TRUE_MSG(false, "moodLevel=" + Helper::toString(static_cast<int>(moodLevel)));
+            return "";
+    }
+}
+
 CreatureMood* CreatureMood::load(std::istream& defFile)
 {
     std::string nextParam;

--- a/source/creaturemood/CreatureMood.h
+++ b/source/creaturemood/CreatureMood.h
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (C) 2011-2015  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CREATUREMOOD_H
+#define CREATUREMOOD_H
+
+#include <cstdint>
+#include <istream>
+#include <vector>
+
+class Creature;
+class GameMap;
+
+class CreatureMood
+{
+public:
+    enum CreatureMoodType
+    {
+        unknown,
+        awakness,
+        creature,
+        fee,
+        hploss,
+        hunger
+    };
+
+    // Constructors
+    CreatureMood()
+    {}
+
+    virtual ~CreatureMood()
+    {}
+
+    virtual CreatureMoodType getCreatureMoodType() const
+    { return CreatureMoodType::unknown; }
+
+    //! \brief Computes the creature mood for this modifier
+    virtual int32_t computeMood(const Creature* creature) const = 0;
+
+    //! \brief This function should return a copy of the current class
+    virtual CreatureMood* clone() const = 0;
+
+    //! \brief This function will be called after loading the level
+    virtual void init(GameMap* gameMap)
+    {}
+
+    static CreatureMood* load(std::istream& defFile);
+};
+
+#endif // CREATUREMOOD_H

--- a/source/creaturemood/CreatureMood.h
+++ b/source/creaturemood/CreatureMood.h
@@ -25,19 +25,28 @@
 class Creature;
 class GameMap;
 
+enum class CreatureMoodType
+{
+    unknown,
+    awakness,
+    creature,
+    fee,
+    hploss,
+    hunger
+};
+
+enum class CreatureMoodLevel
+{
+    Happy,
+    Neutral,
+    Upset,
+    Angry,
+    Furious
+};
+
 class CreatureMood
 {
 public:
-    enum CreatureMoodType
-    {
-        unknown,
-        awakness,
-        creature,
-        fee,
-        hploss,
-        hunger
-    };
-
     // Constructors
     CreatureMood()
     {}
@@ -57,6 +66,8 @@ public:
     //! \brief This function will be called after loading the level
     virtual void init(GameMap* gameMap)
     {}
+
+    static std::string toString(CreatureMoodLevel moodLevel);
 
     static CreatureMood* load(std::istream& defFile);
 };

--- a/source/creaturemood/CreatureMoodAwakness.cpp
+++ b/source/creaturemood/CreatureMoodAwakness.cpp
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (C) 2011-2015  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "creaturemood/CreatureMoodAwakness.h"
+
+#include "entities/Creature.h"
+
+int32_t CreatureMoodAwakness::computeMood(const Creature* creature) const
+{
+    int32_t awakness = static_cast<int32_t>(creature->getAwakeness());
+    if(awakness > mStartAwakness)
+        return 0;
+
+    return (mStartAwakness - awakness) * mMoodModifier;
+}

--- a/source/creaturemood/CreatureMoodAwakness.h
+++ b/source/creaturemood/CreatureMoodAwakness.h
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (C) 2011-2015  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CREATUREMOODAWAKNESS_H
+#define CREATUREMOODAWAKNESS_H
+
+#include "creaturemood/CreatureMood.h"
+
+class CreatureMoodAwakness : public CreatureMood
+{
+public:
+    CreatureMoodAwakness(int32_t startAwakness, int32_t moodModifier) :
+        mStartAwakness(startAwakness),
+        mMoodModifier(moodModifier)
+    {}
+
+    virtual ~CreatureMoodAwakness() {}
+
+    virtual CreatureMoodType getCreatureMoodType() const
+    { return CreatureMoodType::awakness; }
+
+    virtual int32_t computeMood(const Creature* creature) const;
+
+    inline CreatureMood* clone() const
+    {  return new CreatureMoodAwakness(mStartAwakness, mMoodModifier); }
+
+private:
+    int32_t mStartAwakness;
+    int32_t mMoodModifier;
+};
+
+#endif // CREATUREMOODAWAKNESS_H

--- a/source/creaturemood/CreatureMoodCreature.cpp
+++ b/source/creaturemood/CreatureMoodCreature.cpp
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (C) 2011-2015  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "creaturemood/CreatureMoodCreature.h"
+
+#include "entities/Creature.h"
+#include "entities/GameEntity.h"
+
+#include "gamemap/GameMap.h"
+
+#include "utils/LogManager.h"
+
+int32_t CreatureMoodCreature::computeMood(const Creature* creature) const
+{
+    std::vector<GameEntity*> alliedCreatures = creature->getGameMap()->getVisibleCreatures(creature->getVisibleTiles(),
+        creature->getSeat(), false);
+    int nbCreatures = 0;
+    for(GameEntity* entity : alliedCreatures)
+    {
+        if(entity->getObjectType() != GameEntity::ObjectType::creature)
+            continue;
+
+        Creature* alliedCreature = static_cast<Creature*>(entity);
+        if(alliedCreature->getDefinition() != mCreatureDefinition)
+            continue;
+
+        ++nbCreatures;
+    }
+    return nbCreatures * mMoodModifier;
+}
+
+void CreatureMoodCreature::init(GameMap* gameMap)
+{
+    mCreatureDefinition = gameMap->getClassDescription(mCreatureClass);
+    OD_ASSERT_TRUE_MSG(mCreatureDefinition != nullptr, "Unknown creature class=" + mCreatureClass);
+}

--- a/source/creaturemood/CreatureMoodCreature.h
+++ b/source/creaturemood/CreatureMoodCreature.h
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (C) 2011-2015  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CREATUREMOODCREATURE_H
+#define CREATUREMOODCREATURE_H
+
+#include "creaturemood/CreatureMood.h"
+
+class CreatureDefinition;
+
+class CreatureMoodCreature : public CreatureMood
+{
+public:
+    CreatureMoodCreature(const std::string& creatureClass, int32_t moodModifier) :
+        mCreatureDefinition(nullptr),
+        mCreatureClass(creatureClass),
+        mMoodModifier(moodModifier)
+    {}
+
+    virtual ~CreatureMoodCreature() {}
+
+    virtual CreatureMoodType getCreatureMoodType() const
+    { return CreatureMoodType::creature; }
+
+    virtual int32_t computeMood(const Creature* creature) const;
+    virtual void init(GameMap* gameMap);
+
+    inline CreatureMood* clone() const
+    {  return new CreatureMoodCreature(mCreatureClass, mMoodModifier); }
+
+    inline const CreatureDefinition* getCreatureDefinition() const
+    { return mCreatureDefinition; }
+
+private:
+    const CreatureDefinition* mCreatureDefinition;
+    std::string mCreatureClass;
+    int32_t mMoodModifier;
+};
+
+#endif // CREATUREMOODCREATURE_H

--- a/source/creaturemood/CreatureMoodFee.cpp
+++ b/source/creaturemood/CreatureMoodFee.cpp
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2011-2015  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "creaturemood/CreatureMoodFee.h"
+
+#include "entities/Creature.h"
+
+#include "utils/Helper.h"
+
+int32_t CreatureMoodFee::computeMood(const Creature* creature) const
+{
+    int32_t owedGold = creature->getGoldFee() - creature->getDefinition()->getFee(creature->getLevel());
+    if(owedGold < 100)
+        return 0;
+
+    owedGold = Helper::round(static_cast<double>(owedGold) * 0.01);
+    return owedGold * mMoodModifier;
+}

--- a/source/creaturemood/CreatureMoodFee.h
+++ b/source/creaturemood/CreatureMoodFee.h
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (C) 2011-2015  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CREATUREMOODFEE_H
+#define CREATUREMOODFEE_H
+
+#include "creaturemood/CreatureMood.h"
+
+class CreatureMoodFee : public CreatureMood
+{
+public:
+    CreatureMoodFee(int32_t moodModifier) :
+        mMoodModifier(moodModifier)
+    {}
+
+    virtual ~CreatureMoodFee() {}
+
+    virtual CreatureMoodType getCreatureMoodType() const
+    { return CreatureMoodType::fee; }
+
+    virtual int32_t computeMood(const Creature* creature) const;
+
+    inline CreatureMood* clone() const
+    {  return new CreatureMoodFee(mMoodModifier); }
+
+private:
+    int32_t mMoodModifier;
+};
+
+#endif // CREATUREMOODFEE_H

--- a/source/creaturemood/CreatureMoodHpLoss.cpp
+++ b/source/creaturemood/CreatureMoodHpLoss.cpp
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2011-2015  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "creaturemood/CreatureMoodHpLoss.h"
+
+#include "entities/Creature.h"
+
+#include "utils/Helper.h"
+
+int32_t CreatureMoodHpLoss::computeMood(const Creature* creature) const
+{
+    int32_t hpLost = creature->getMaxHp() - creature->getHP();
+    if(hpLost <= 0)
+        return 0;
+
+    hpLost = Helper::round(static_cast<float>(hpLost));
+    return hpLost * mMoodModifier;
+}

--- a/source/creaturemood/CreatureMoodHpLoss.h
+++ b/source/creaturemood/CreatureMoodHpLoss.h
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (C) 2011-2015  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CREATUREMOODHPLOSS_H
+#define CREATUREMOODHPLOSS_H
+
+#include "creaturemood/CreatureMood.h"
+
+class CreatureMoodHpLoss : public CreatureMood
+{
+public:
+    CreatureMoodHpLoss(int32_t moodModifier) :
+        mMoodModifier(moodModifier)
+    {}
+
+    virtual ~CreatureMoodHpLoss() {}
+
+    virtual CreatureMoodType getCreatureMoodType() const
+    { return CreatureMoodType::hploss; }
+
+    virtual int32_t computeMood(const Creature* creature) const;
+
+    inline CreatureMood* clone() const
+    {  return new CreatureMoodHpLoss(mMoodModifier); }
+
+private:
+    int32_t mMoodModifier;
+};
+
+#endif // CREATUREMOODHPLOSS_H

--- a/source/creaturemood/CreatureMoodHunger.cpp
+++ b/source/creaturemood/CreatureMoodHunger.cpp
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (C) 2011-2015  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "creaturemood/CreatureMoodHunger.h"
+
+#include "entities/Creature.h"
+
+int32_t CreatureMoodHunger::computeMood(const Creature* creature) const
+{
+    int32_t hunger = static_cast<int32_t>(creature->getHunger());
+    if(hunger < mStartHunger)
+        return 0;
+
+    return (hunger - mStartHunger) * mMoodModifier;
+}

--- a/source/creaturemood/CreatureMoodHunger.h
+++ b/source/creaturemood/CreatureMoodHunger.h
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (C) 2011-2015  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CREATUREMOODHUNGER_H
+#define CREATUREMOODHUNGER_H
+
+#include "creaturemood/CreatureMood.h"
+
+class CreatureMoodHunger : public CreatureMood
+{
+public:
+    CreatureMoodHunger(int32_t startHunger, int32_t moodModifier) :
+        mStartHunger(startHunger),
+        mMoodModifier(moodModifier)
+    {}
+
+    virtual ~CreatureMoodHunger() {}
+
+    virtual CreatureMoodType getCreatureMoodType() const
+    { return CreatureMoodType::hunger; }
+
+    virtual int32_t computeMood(const Creature* creature) const;
+
+    inline CreatureMood* clone() const
+    {  return new CreatureMoodHunger(mStartHunger, mMoodModifier); }
+
+private:
+    int32_t mStartHunger;
+    int32_t mMoodModifier;
+};
+
+#endif // CREATUREMOODHUNGER_H

--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -109,7 +109,7 @@ Creature::Creature(GameMap* gameMap, const CreatureDefinition* definition) :
     mCarriedEntity           (nullptr),
     mCarriedEntityDestType   (GameEntity::ObjectType::unknown),
     mMoodCooldownTurns       (0),
-    mMoodValue               (ConfigManager::CreatureMoodLevel::Neutral),
+    mMoodValue               (CreatureMoodLevel::Neutral),
     mMoodPoints              (0),
     mFirstTurnFurious        (-1)
 
@@ -183,7 +183,7 @@ Creature::Creature(GameMap* gameMap) :
     mCarriedEntity           (nullptr),
     mCarriedEntityDestType   (GameEntity::ObjectType::unknown),
     mMoodCooldownTurns       (0),
-    mMoodValue               (ConfigManager::CreatureMoodLevel::Neutral),
+    mMoodValue               (CreatureMoodLevel::Neutral),
     mMoodPoints              (0),
     mFirstTurnFurious        (-1)
 {
@@ -824,8 +824,8 @@ void Creature::decidePrioritaryAction()
         // Unhappy creatures might flee instead of engaging enemies
         switch(mMoodValue)
         {
-            case ConfigManager::CreatureMoodLevel::Angry:
-            case ConfigManager::CreatureMoodLevel::Furious:
+            case CreatureMoodLevel::Angry:
+            case CreatureMoodLevel::Furious:
             {
                 if(Random::Int(0,100) > 80)
                 {
@@ -863,9 +863,9 @@ void Creature::decidePrioritaryAction()
     // Unhappy creatures might engage allied natural enemies
     switch(mMoodValue)
     {
-        case ConfigManager::CreatureMoodLevel::Upset:
-        case ConfigManager::CreatureMoodLevel::Angry:
-        case ConfigManager::CreatureMoodLevel::Furious:
+        case CreatureMoodLevel::Upset:
+        case CreatureMoodLevel::Angry:
+        case CreatureMoodLevel::Furious:
         {
             // We are fighting an allied enemy. We don't consider leaving yet
             if(isActionInList(CreatureAction::fightNaturalEnemy))
@@ -883,7 +883,7 @@ void Creature::decidePrioritaryAction()
             }
 
             // If we are furious, we consider leaving the dungeon
-            if((mMoodValue != ConfigManager::CreatureMoodLevel::Furious) ||
+            if((mMoodValue != CreatureMoodLevel::Furious) ||
                (isActionInList(CreatureAction::leaveDungeon)))
             {
                 return;
@@ -1914,7 +1914,7 @@ bool Creature::handleJobAction(const CreatureAction& actionItem)
     // If we are unhappy, we stop working
     switch(mMoodValue)
     {
-        case ConfigManager::CreatureMoodLevel::Upset:
+        case CreatureMoodLevel::Upset:
         {
             // 20% chances of not working
             if(Random::Int(0, 100) < 20)
@@ -1925,8 +1925,8 @@ bool Creature::handleJobAction(const CreatureAction& actionItem)
             }
             break;
         }
-        case ConfigManager::CreatureMoodLevel::Angry:
-        case ConfigManager::CreatureMoodLevel::Furious:
+        case CreatureMoodLevel::Angry:
+        case CreatureMoodLevel::Furious:
         {
             // We don't work
             popAction();
@@ -3239,7 +3239,7 @@ std::string Creature::getStatsText()
     tempSS << "Seat id: " << getSeat()->getId() << std::endl;
     tempSS << "Team id: " << getSeat()->getTeamId() << std::endl;
     tempSS << "Position: " << Ogre::StringConverter::toString(getPosition()) << std::endl;
-    tempSS << "Mood: " << ConfigManager::toString(mMoodValue) << std::endl;
+    tempSS << "Mood: " << CreatureMood::toString(mMoodValue) << std::endl;
     tempSS << "MoodPoints: " << Helper::toString(mMoodPoints) << std::endl;
     return tempSS.str();
 }
@@ -3910,9 +3910,9 @@ void Creature::computeMood()
 {
     mMoodPoints = getGameMap()->computeCreatureMoodModifiers(this);
 
-    ConfigManager::CreatureMoodLevel newMoodValue = ConfigManager::getSingleton().getCreatureMoodLevel(mMoodPoints);
-    if((newMoodValue > ConfigManager::CreatureMoodLevel::Neutral) &&
-       (mMoodValue <= ConfigManager::CreatureMoodLevel::Neutral))
+    CreatureMoodLevel newMoodValue = ConfigManager::getSingleton().getCreatureMoodLevel(mMoodPoints);
+    if((newMoodValue > CreatureMoodLevel::Neutral) &&
+       (mMoodValue <= CreatureMoodLevel::Neutral))
     {
         // We became unhappy
         if((getSeat()->getPlayer() != nullptr) &&
@@ -3925,14 +3925,14 @@ void Creature::computeMood()
             ODServer::getSingleton().queueServerNotification(serverNotification);
         }
     }
-    if(newMoodValue != ConfigManager::CreatureMoodLevel::Furious)
+    if(newMoodValue != CreatureMoodLevel::Furious)
     {
         mMoodValue = newMoodValue;
         mFirstTurnFurious = -1;
         return;
     }
 
-    if(mMoodValue != ConfigManager::CreatureMoodLevel::Furious)
+    if(mMoodValue != CreatureMoodLevel::Furious)
     {
         mMoodValue = newMoodValue;
         mFirstTurnFurious = getGameMap()->getTurnNumber();

--- a/source/entities/Creature.h
+++ b/source/entities/Creature.h
@@ -592,6 +592,10 @@ private:
 
     void releaseCarriedEntity();
 
+    void increaseHunger(double value);
+
+    void decreaseAwakeness(double value);
+
     void computeMood();
 
     //! \brief Called when an angry creature wants to attack a natural enemy

--- a/source/entities/Creature.h
+++ b/source/entities/Creature.h
@@ -502,83 +502,83 @@ private:
     void decidePrioritaryAction();
 
     //! \brief A sub-function called by doTurn()
-    //! This functions will hanlde the creature idle action logic.
+    //! This functions will handle the creature idle action logic.
     //! \return true when another action should handled after that one.
     bool handleIdleAction(const CreatureAction& actionItem);
 
     //! \brief A sub-function called by doTurn()
-    //! This functions will hanlde the creature walking action logic.
+    //! This functions will handle the creature walking action logic.
     //! \return true when another action should handled after that one.
     bool handleWalkToTileAction(const CreatureAction& actionItem);
 
     //! \brief A sub-function called by doTurn()
-    //! This functions will hanlde the creature claim tile action logic.
+    //! This functions will handle the creature claim tile action logic.
     //! \return true when another action should handled after that one.
     bool handleClaimTileAction(const CreatureAction& actionItem);
 
     //! \brief A sub-function called by doTurn()
-    //! This functions will hanlde the creature claim wall tile action logic.
+    //! This functions will handle the creature claim wall tile action logic.
     //! \return true when another action should handled after that one.
     bool handleClaimWallTileAction(const CreatureAction& actionItem);
 
     //! \brief A sub-function called by doTurn()
-    //! This functions will hanlde the creature dig tile action logic.
+    //! This functions will handle the creature dig tile action logic.
     //! \return true when another action should handled after that one.
     bool handleDigTileAction(const CreatureAction& actionItem);
 
     //! \brief A sub-function called by doTurn()
-    //! This functions will hanlde the creature finding home action logic.
+    //! This functions will handle the creature finding home action logic.
     //! \return true when another action should handled after that one.
     bool handleFindHomeAction(const CreatureAction& actionItem);
 
     //! \brief A sub-function called by doTurn()
-    //! This functions will hanlde the creature job action logic.
+    //! This functions will handle the creature job action logic.
     //! \return true when another action should handled after that one.
     bool handleJobAction(const CreatureAction& actionItem);
 
     //! \brief A sub-function called by doTurn()
-    //! This functions will hanlde the creature eating action logic.
+    //! This functions will handle the creature eating action logic.
     //! \return true when another action should handled after that one.
     bool handleEatingAction(const CreatureAction& actionItem);
 
     //! \brief A sub-function called by doTurn()
-    //! This functions will hanlde the creature attack action logic.
+    //! This functions will handle the creature attack action logic.
     //! \return true when another action should handled after that one.
     bool handleAttackAction(const CreatureAction& actionItem);
 
     //! \brief A sub-function called by doTurn()
-    //! This functions will hanlde the creature fighting action logic.
+    //! This functions will handle the creature fighting action logic.
     //! \return true when another action should handled after that one.
     bool handleFightAction(const CreatureAction& actionItem);
 
     //! \brief A sub-function called by doTurn()
-    //! This functions will hanlde the creature sleeping action logic.
+    //! This functions will handle the creature sleeping action logic.
     //! \return true when another action should handled after that one.
     bool handleSleepAction(const CreatureAction& actionItem);
 
     //! \brief A sub-function called by doTurn()
-    //! This functions will hanlde the creature fleeing action logic.
+    //! This functions will handle the creature fleeing action logic.
     //! \return true when another action should handled after that one.
     bool handleFleeAction(const CreatureAction& actionItem);
 
     //! \brief A sub-function called by doTurn()
-    //! This functions will hanlde the creature action logic about finding a carryable entity.
+    //! This functions will handle the creature action logic about finding a carryable entity.
     //! And trying to carry it to a suitable building
     //! \return true when another action should handled after that one.
     bool handleCarryableEntities(const CreatureAction& actionItem);
 
     //! \brief A sub-function called by doTurn()
-    //! This functions will hanlde the creature action logic about getting the creature fee.
+    //! This functions will handle the creature action logic about getting the creature fee.
     //! \return true when another action should handled after that one.
     bool handleGetFee(const CreatureAction& actionItem);
 
     //! \brief A sub-function called by doTurn()
-    //! This functions will hanlde the creature action logic about trying to leave the dungeon.
+    //! This functions will handle the creature action logic about trying to leave the dungeon.
     //! \return true when another action should handled after that one.
     bool handleLeaveDungeon(const CreatureAction& actionItem);
 
     //! \brief A sub-function called by doTurn()
-    //! This functions will hanlde the creature fighting action logic when
+    //! This functions will handle the creature fighting action logic when
     //! fighting an allied natural enemy (when in bad mood)
     //! \return true when another action should handled after that one.
     bool handleFightAlliedNaturalEnemyAction(const CreatureAction& actionItem);

--- a/source/entities/Creature.h
+++ b/source/entities/Creature.h
@@ -39,6 +39,8 @@ class GameMap;
 class Creature;
 class Weapon;
 
+enum class CreatureMoodLevel;
+
 namespace CEGUI
 {
 class Window;
@@ -461,7 +463,7 @@ private:
 
     //! \brief Mood value. Depending on this value, the creature will be in bad mood and
     //! might attack allied creatures or refuse to work or to go to combat
-    ConfigManager::CreatureMoodLevel mMoodValue;
+    CreatureMoodLevel               mMoodValue;
     //! \brief Mood points. Computed by the creature MoodModifiers. It is promoted to class variable for debug purposes and
     //! should not be used to check mood. If the mood is to be tested, mMoodValue should be used
     int32_t                         mMoodPoints;

--- a/source/entities/CreatureAction.cpp
+++ b/source/entities/CreatureAction.cpp
@@ -95,6 +95,12 @@ std::string CreatureAction::toString() const
 
     case idle:
         return "idle";
+
+    case leaveDungeon:
+        return "leaveDungeon";
+
+    case fightNaturalEnemy:
+        return "fightNaturalEnemy";
     }
 
     return "unhandledAct";

--- a/source/entities/CreatureAction.h
+++ b/source/entities/CreatureAction.h
@@ -47,6 +47,8 @@ public:
         flee, // If a fighter is weak (low hp) or a worker is attacked by a fighter, he will flee
         carryEntity, // (worker only) Carry an entity to a suitable building
         getFee, // (fighter only) Gets the creature fee
+        leaveDungeon, // (fighter only) Try to go to the portal to leave the dungeon
+        fightNaturalEnemy, // (fighter only) Attacks an allied natural enemy
         idle // Stand around doing nothing.
     };
 

--- a/source/entities/CreatureDefinition.cpp
+++ b/source/entities/CreatureDefinition.cpp
@@ -90,6 +90,7 @@ ODPacket& operator<<(ODPacket& os, const CreatureDefinition* c)
     os << c->mAttackWarmupTime;
     os << c->mFeeBase;
     os << c->mFeePerLevel;
+    os << c->mMoodModifierName;
     os << c->mWeaponSpawnL;
     os << c->mWeaponSpawnR;
 
@@ -122,6 +123,7 @@ ODPacket& operator>>(ODPacket& is, CreatureDefinition* c)
     is >> c->mAttackWarmupTime;
     is >> c->mFeeBase;
     is >> c->mFeePerLevel;
+    is >> c->mMoodModifierName;
     is >> c->mWeaponSpawnL;
     is >> c->mWeaponSpawnR;
 
@@ -445,6 +447,12 @@ bool CreatureDefinition::update(CreatureDefinition* creatureDef, std::stringstre
             {
                 defFile >> nextParam;
                 creatureDef->mFeePerLevel = Helper::toInt(nextParam);
+                continue;
+            }
+            else if (nextParam == "CreatureMoodName")
+            {
+                defFile >> nextParam;
+                creatureDef->mMoodModifierName = nextParam;
                 continue;
             }
             else if (nextParam == "WeaponSpawnL")

--- a/source/entities/CreatureDefinition.h
+++ b/source/entities/CreatureDefinition.h
@@ -234,6 +234,9 @@ public:
 
     const CreatureRoomAffinity& getRoomAffinity(Room::RoomType roomType) const;
 
+    inline const std::string& getMoodModifierName() const
+    { return mMoodModifierName; }
+
 private:
     //! \brief The job of the creature (e.g. worker, fighter, ...)
     CreatureJob mCreatureJob;
@@ -330,6 +333,10 @@ private:
 
     //! \brief The rooms the creature should choose according to availability
     std::vector<CreatureRoomAffinity> mRoomAffinity;
+
+    //! \brief The rooms the creature mood modifier that should be used to compute
+    //! creature mood
+    std::string mMoodModifierName;
 
     //! \brief Loads the creature XP values for the given definition.
     static void loadXPTable(std::stringstream& defFile, CreatureDefinition* creatureDef);

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -375,7 +375,7 @@ const CreatureDefinition* Seat::getNextCreatureClassToSpawn()
         return nullptr;
 
     // We choose randomly a creature to spawn according to their points
-    int32_t cpt = Random::Int(0, nbPointsTotal);
+    int32_t cpt = Random::Int(0, nbPointsTotal - 1);
     for(std::pair<const CreatureDefinition*, int32_t>& def : defSpawnable)
     {
         if(cpt < def.second)

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -708,16 +708,35 @@ const std::string Seat::getFactionFromLine(const std::string& line)
     return std::string();
 }
 
+Seat* Seat::getRogueSeat(GameMap* gameMap)
+{
+    Seat* seat = new Seat(gameMap);
+    seat->mId = 0;
+    seat->mTeamId = 0;
+    seat->mAvailableTeamIds.push_back(0);
+    seat->mPlayerType = PLAYER_TYPE_INACTIVE;
+    seat->mStartingX = 0;
+    seat->mStartingY = 0;
+    seat->mStartingGold = 0;
+    return seat;
+}
+
 void Seat::loadFromLine(const std::string& line, Seat *s)
 {
     std::vector<std::string> elems = Helper::split(line, '\t');
 
     int32_t i = 0;
     s->mId = Helper::toInt(elems[i++]);
+    OD_ASSERT_TRUE_MSG(s->mId != 0, "Forbidden seatId for line=" + line);
     std::vector<std::string> teamIds = Helper::split(elems[i++], '/');
     for(const std::string& strTeamId : teamIds)
     {
-        s->mAvailableTeamIds.push_back(Helper::toInt(strTeamId));
+        int teamId = Helper::toInt(strTeamId);
+        OD_ASSERT_TRUE_MSG(teamId != 0, "Forbidden teamId for line=" + line);
+        if(teamId == 0)
+            continue;
+
+        s->mAvailableTeamIds.push_back(teamId);
     }
     s->mPlayerType = elems[i++];
     s->mFaction = elems[i++];

--- a/source/game/Seat.h
+++ b/source/game/Seat.h
@@ -100,27 +100,30 @@ public:
 
     void refreshFromSeat(Seat* s);
 
-    int getTeamId() const
+    inline int getTeamId() const
     { return mTeamId; }
+
+    inline bool isRogueSeat() const
+    { return mId == 0; }
 
     void setTeamId(int teamId);
 
-    const std::vector<int>& getAvailableTeamIds() const
+    inline const std::vector<int>& getAvailableTeamIds() const
     { return mAvailableTeamIds; }
 
-    int getId() const
+    inline int getId() const
     { return mId; }
 
-    const std::string& getFaction() const
+    inline const std::string& getFaction() const
     { return mFaction; }
 
-    void setFaction(const std::string& faction)
+    inline void setFaction(const std::string& faction)
     { mFaction = faction; }
 
-    const std::string& getColorId() const
+    inline const std::string& getColorId() const
     { return mColorId; }
 
-    const Ogre::ColourValue& getColorValue() const
+    inline const Ogre::ColourValue& getColorValue() const
     { return mColorValue; }
 
     inline int getGold() const
@@ -150,10 +153,10 @@ public:
     inline int getNbTreasuries() const
     { return mNbTreasuries; }
 
-    const std::string& getPlayerType() const
+    inline const std::string& getPlayerType() const
     { return mPlayerType; }
 
-    void setPlayerType(const std::string& playerType)
+    inline void setPlayerType(const std::string& playerType)
     { mPlayerType = playerType; }
 
     void setPlayer(Player* player);
@@ -202,6 +205,8 @@ public:
     void computeSeatBeforeSendingToClient();
 
     static bool sortForMapSave(Seat* s1, Seat* s2);
+
+    static Seat* getRogueSeat(GameMap* gameMap);
 
     static std::string getFormat();
     friend ODPacket& operator<<(ODPacket& os, Seat *s);

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -193,6 +193,10 @@ bool GameMap::loadLevel(const std::string& levelFilepath)
     std::string levelPath = ResourceManager::getSingletonPtr()->getGameDataPath()
                             + levelFilepath;
 
+    // We add the rogue default seat (seatId = 0 and teamId = 0)
+    Seat* rogueSeat = Seat::getRogueSeat(this);
+    addSeat(rogueSeat);
+
     // TODO The map loader class should be merged back to GameMap.
     if (MapLoader::readGameMapFromFile(levelPath, *this))
         setLevelFileName(levelFilepath);
@@ -2051,7 +2055,7 @@ void GameMap::addSeat(Seat *s)
     }
 }
 
-Seat* GameMap::getSeatById(int id)
+Seat* GameMap::getSeatById(int id) const
 {
     for (Seat* seat : mSeats)
     {
@@ -2935,10 +2939,16 @@ void GameMap::clearCreatureMoodModifiers()
     mCreatureMoodModifiers.clear();
 }
 
-void GameMap::addCreatureMoodModifiers(const std::string& name,
+bool GameMap::addCreatureMoodModifiers(const std::string& name,
     const std::vector<CreatureMood*>& moodModifiers)
 {
+    uint32_t nb = mCreatureMoodModifiers.count(name);
+    OD_ASSERT_TRUE_MSG(nb <= 0, "Duplicate mood modifier=" + name);
+    if(nb > 0)
+        return false;
+
     mCreatureMoodModifiers[name] = moodModifiers;
+    return true;
 }
 
 int32_t GameMap::computeCreatureMoodModifiers(const Creature* creature) const

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -2974,7 +2974,7 @@ std::vector<GameEntity*> GameMap::getNaturalEnemiesInList(const Creature* creatu
         Creature* alliedCreature = static_cast<Creature*>(entity);
         for(const CreatureMood* mood : moodModifiers)
         {
-            if(mood->getCreatureMoodType() != CreatureMood::CreatureMoodType::creature)
+            if(mood->getCreatureMoodType() != CreatureMoodType::creature)
                 continue;
 
             const CreatureMoodCreature* moodCreature = static_cast<const CreatureMoodCreature*>(mood);

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -259,6 +259,7 @@ void GameMap::clearAll()
     // NOTE : clearRenderedMovableEntities should be called after clearRooms because clearRooms will try to remove the objects from the room
     clearRenderedMovableEntities();
     clearTiles();
+    clearCreatureMoodModifiers();
 
     clearActiveObjects();
 

--- a/source/gamemap/GameMap.h
+++ b/source/gamemap/GameMap.h
@@ -43,8 +43,7 @@ class MapLight;
 class MovableGameEntity;
 class CreatureDefinition;
 class Weapon;
-
-class MiniMap;
+class CreatureMood;
 
 /*! \brief The class which stores the entire game state on the server and a subset of this on each client.
  *
@@ -162,12 +161,19 @@ public:
 
     void saveLevelClassDescriptions(std::ofstream& levelFile);
 
-    void addWeapon(const Weapon *weapon);
+    void addWeapon(const Weapon* weapon);
     const Weapon* getWeapon(int index);
     const Weapon* getWeapon(const std::string& name);
     Weapon* getWeaponForTuning(const std::string& name);
     uint32_t numWeapons();
     void saveLevelEquipments(std::ofstream& levelFile);
+
+    void clearCreatureMoodModifiers();
+    void addCreatureMoodModifiers(const std::string& name,
+        const std::vector<CreatureMood*>& moodModifiers);
+    int32_t computeCreatureMoodModifiers(const Creature* creature) const;
+
+    std::vector<GameEntity*> getNaturalEnemiesInList(const Creature* creature, const std::vector<GameEntity*>& reachableAlliedObjects) const;
 
     //! \brief Calls the deleteYourself() method on each of the rooms in the game map as well as clearing the vector of stored rooms.
     void clearRooms();
@@ -551,6 +557,10 @@ private:
 
     //! AI Handling manager
     AIManager mAiManager;
+
+    //! Creature mood modifiers. Used to compute mood. The name of the mood modifier is associated with
+    //! the list of mood modifier
+    std::map<const std::string, std::vector<CreatureMood*>> mCreatureMoodModifiers;
 
     //! \brief Updates different entities states.
     //! Updates active objects (creatures, rooms, ...), goals, count each team Workers, gold, mana and claimed tiles.

--- a/source/gamemap/GameMap.h
+++ b/source/gamemap/GameMap.h
@@ -169,7 +169,7 @@ public:
     void saveLevelEquipments(std::ofstream& levelFile);
 
     void clearCreatureMoodModifiers();
-    void addCreatureMoodModifiers(const std::string& name,
+    bool addCreatureMoodModifiers(const std::string& name,
         const std::vector<CreatureMood*>& moodModifiers);
     int32_t computeCreatureMoodModifiers(const Creature* creature) const;
 
@@ -259,7 +259,10 @@ public:
     void clearFilledSeats();
     void clearAiManager();
 
-    Seat* getSeatById(int id);
+    Seat* getSeatById(int id) const;
+
+    Seat* getSeatRogue() const
+    { return getSeatById(0); }
 
     void addWinningSeat(Seat *s);
     Seat* getWinningSeat(unsigned int index);

--- a/source/gamemap/MapLoader.cpp
+++ b/source/gamemap/MapLoader.cpp
@@ -511,6 +511,10 @@ void writeGameMapToFile(const std::string& fileName, GameMap& gameMap)
     const std::vector<Seat*> seats = gameMap.getSeats();
     for (Seat* seat : seats)
     {
+        // We don't save rogue seat
+        if(seat->isRogueSeat())
+            continue;
+
         levelFile << seat << std::endl;
     }
     levelFile << "[/Seats]" << std::endl;

--- a/source/gamemap/MapLoader.cpp
+++ b/source/gamemap/MapLoader.cpp
@@ -17,6 +17,8 @@
 
 #include "gamemap/MapLoader.h"
 
+#include "creaturemood/CreatureMood.h"
+
 #include "gamemap/GameMap.h"
 #include "game/Seat.h"
 #include "goals/Goal.h"
@@ -315,6 +317,66 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
     }
 
     levelFile >> nextParam;
+
+    if (nextParam == "[CreaturesMood]")
+    {
+        while(levelFile.good())
+        {
+            if(!(levelFile >> nextParam))
+                break;
+
+            if (nextParam == "[/CreaturesMood]")
+                break;
+
+            if (nextParam == "[/CreatureMood]")
+                continue;
+
+            if (nextParam != "[CreatureMood]")
+            {
+                OD_ASSERT_TRUE_MSG(false, "Invalid CreatureMood format. Line was " + nextParam);
+                return false;
+            }
+
+            if(!(levelFile >> nextParam))
+                    break;
+            if (nextParam != "CreatureMoodName")
+            {
+                OD_ASSERT_TRUE_MSG(false, "Invalid CreatureMoodName format. Line was " + nextParam);
+                return false;
+            }
+            std::string moodModifierName;
+            levelFile >> moodModifierName;
+            std::vector<CreatureMood*> moodModifiers;
+
+            while(levelFile.good())
+            {
+                if(!(levelFile >> nextParam))
+                    break;
+
+                if (nextParam == "[/CreatureMood]")
+                    break;
+
+                if (nextParam != "[MoodModifier]")
+                {
+                    OD_ASSERT_TRUE_MSG(false, "Invalid CreatureMood MoodModifier format. nextParam=" + nextParam);
+                    return false;
+                }
+
+                // Load the definition
+                CreatureMood* def = CreatureMood::load(levelFile);
+                if (def == nullptr)
+                {
+                    OD_ASSERT_TRUE_MSG(false, "Invalid CreatureMood MoodModifier definition");
+                    return false;
+                }
+                moodModifiers.push_back(def);
+            }
+            gameMap.addCreatureMoodModifiers(moodModifierName, moodModifiers);
+        }
+
+        levelFile >> nextParam;
+    }
+
     if (nextParam == "[CreatureDefinitions]")
     {
         while(levelFile.good())

--- a/source/modes/MenuModeConfigureSeats.cpp
+++ b/source/modes/MenuModeConfigureSeats.cpp
@@ -115,6 +115,10 @@ void MenuModeConfigureSeats::activate()
 
     for(Seat* seat : seats)
     {
+        // We do not add the rogue creatures seat
+        if(seat->isRogueSeat())
+            continue;
+
         mSeats.push_back(seat);
         std::string name;
         CEGUI::Combobox* combo;

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -666,6 +666,10 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             packetSend << ServerNotification::seatConfigurationRefresh;
             for(Seat* seat : seats)
             {
+                // Rogue seat do not have to be configured
+                if(seat->isRogueSeat())
+                    continue;
+
                 int seatId;
                 bool isSet;
                 OD_ASSERT_TRUE(packetReceived >> seatId);
@@ -712,6 +716,10 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             const std::vector<std::string>& factions = ConfigManager::getSingleton().getFactions();
             for(Seat* seat : seats)
             {
+                // Rogue seat do not have to be configured
+                if(seat->isRogueSeat())
+                    continue;
+
                 int seatId;
                 bool isSet;
                 uint32_t factionIndex;

--- a/source/utils/ConfigManager.cpp
+++ b/source/utils/ConfigManager.cpp
@@ -1004,40 +1004,20 @@ const std::vector<std::string>& ConfigManager::getFactionSpawnPool(const std::st
     return mFactionSpawnPool.at(faction);
 }
 
-std::string ConfigManager::toString(CreatureMoodLevel moodLevel)
-{
-    switch(moodLevel)
-    {
-        case CreatureMoodLevel::Happy:
-            return "Happy";
-        case CreatureMoodLevel::Neutral:
-            return "Neutral";
-        case CreatureMoodLevel::Upset:
-            return "Upset";
-        case CreatureMoodLevel::Angry:
-            return "Angry";
-        case CreatureMoodLevel::Furious:
-            return "Furious";
-        default:
-            OD_ASSERT_TRUE_MSG(false, "moodLevel=" + Helper::toString(static_cast<int>(moodLevel)));
-            return "";
-    }
-}
-
-ConfigManager::CreatureMoodLevel ConfigManager::getCreatureMoodLevel(int32_t moodModifiersPoints) const
+CreatureMoodLevel ConfigManager::getCreatureMoodLevel(int32_t moodModifiersPoints) const
 {
     int32_t mood = mCreatureBaseMood + moodModifiersPoints;
     if(mood >= mCreatureMoodHappy)
-        return ConfigManager::CreatureMoodLevel::Happy;
+        return CreatureMoodLevel::Happy;
 
     if(mood >= mCreatureMoodUpset)
-        return ConfigManager::CreatureMoodLevel::Neutral;
+        return CreatureMoodLevel::Neutral;
 
     if(mood >= mCreatureMoodAngry)
-        return ConfigManager::CreatureMoodLevel::Upset;
+        return CreatureMoodLevel::Upset;
 
     if(mood >= mCreatureMoodFurious)
-        return ConfigManager::CreatureMoodLevel::Angry;
+        return CreatureMoodLevel::Angry;
 
-    return ConfigManager::CreatureMoodLevel::Furious;
+    return CreatureMoodLevel::Furious;
 }

--- a/source/utils/ConfigManager.h
+++ b/source/utils/ConfigManager.h
@@ -28,19 +28,13 @@ class Weapon;
 class SpawnCondition;
 class CreatureMood;
 
+enum class CreatureMoodLevel;
+
 //! \brief This class is used to manage global configuration such as network configuration, global creature stats, ...
 //! It should NOT be used to load level specific stuff. For that, there if GameMap.
 class ConfigManager : public Ogre::Singleton<ConfigManager>
 {
 public:
-    enum CreatureMoodLevel
-    {
-        Happy,
-        Neutral,
-        Upset,
-        Angry,
-        Furious
-    };
     ConfigManager();
     ~ConfigManager();
 
@@ -70,8 +64,6 @@ public:
 
     inline uint32_t getBaseSpawnPoint() const
     { return mBaseSpawnPoint; }
-
-    static std::string toString(CreatureMoodLevel moodLevel);
 
     inline const std::map<const std::string, std::vector<const CreatureMood*> >& getCreatureMoodModifiers() const
     { return mCreatureMoodModifiers; }

--- a/source/utils/ConfigManager.h
+++ b/source/utils/ConfigManager.h
@@ -26,12 +26,21 @@
 class CreatureDefinition;
 class Weapon;
 class SpawnCondition;
+class CreatureMood;
 
 //! \brief This class is used to manage global configuration such as network configuration, global creature stats, ...
 //! It should NOT be used to load level specific stuff. For that, there if GameMap.
 class ConfigManager : public Ogre::Singleton<ConfigManager>
 {
 public:
+    enum CreatureMoodLevel
+    {
+        Happy,
+        Neutral,
+        Upset,
+        Angry,
+        Furious
+    };
     ConfigManager();
     ~ConfigManager();
 
@@ -61,6 +70,14 @@ public:
 
     inline uint32_t getBaseSpawnPoint() const
     { return mBaseSpawnPoint; }
+
+    static std::string toString(CreatureMoodLevel moodLevel);
+
+    inline const std::map<const std::string, std::vector<const CreatureMood*> >& getCreatureMoodModifiers() const
+    { return mCreatureMoodModifiers; }
+    CreatureMoodLevel getCreatureMoodLevel(int32_t moodModifiersPoints) const;
+    inline int64_t getNbTurnsFuriousMax() const
+    { return mNbTurnsFuriousMax; }
 
     const std::vector<const SpawnCondition*>& getCreatureSpawnConditions(const CreatureDefinition* def) const;
 
@@ -94,6 +111,7 @@ private:
     bool loadFactions(const std::string& fileName);
     bool loadRooms(const std::string& fileName);
     bool loadTraps(const std::string& fileName);
+    bool loadCreaturesMood(const std::string& fileName);
 
     std::map<std::string, Ogre::ColourValue> mSeatColors;
     std::vector<const CreatureDefinition*> mCreatureDefs;
@@ -104,13 +122,21 @@ private:
     std::string mFilenameFactions;
     std::string mFilenameRooms;
     std::string mFilenameTraps;
+    std::string mFilenameCreaturesMood;
     uint32_t mNetworkPort;
     uint32_t mBaseSpawnPoint;
     uint32_t mCreatureDeathCounter;
     uint32_t mMaxCreaturesPerSeat;
+    int32_t mCreatureBaseMood;
+    int32_t mCreatureMoodHappy;
+    int32_t mCreatureMoodUpset;
+    int32_t mCreatureMoodAngry;
+    int32_t mCreatureMoodFurious;
     double mSlapDamagePercent;
     int64_t mTimePayDay;
+    int64_t mNbTurnsFuriousMax;
     std::map<const CreatureDefinition*, std::vector<const SpawnCondition*> > mCreatureSpawnConditions;
+    std::map<const std::string, std::vector<const CreatureMood*> > mCreatureMoodModifiers;
     std::map<const std::string, std::vector<std::string> > mFactionSpawnPool;
     std::vector<std::string> mFactions;
     std::map<const std::string, std::string> mRoomsConfig;


### PR DESCRIPTION
I've not implemented creatures becoming rogue. First we need to decide how rogue creatures are. IMO, we should automatically add a seat id = 0 and team id = 0 for them. That will allow to add rogue creatures in the editor.
Moreover, now that mood is implemented, rogue creatures will be angry as they will not get their fee. We need something we can rely on to disable such unwanted behaviour.

WDYT about using a seat id = 0 for that ?

fixes #11
