### PR TITLE
Avoid sending a message to every player when a creature owned by an inactive keeper becomes rogue

### DIFF
--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -4076,11 +4076,15 @@ void Creature::computeMood()
     else if(getGameMap()->getTurnNumber() > (mFirstTurnFurious + ConfigManager::getSingleton().getNbTurnsFuriousMax()))
     {
         // We couldn't leave the dungeon in time, we become rogue
-        ServerNotification *serverNotification = new ServerNotification(
-            ServerNotificationType::chatServer, getSeat()->getPlayer());
-        std::string msg = getName() + " is not under your control anymore !";
-        serverNotification->mPacket << msg;
-        ODServer::getSingleton().queueServerNotification(serverNotification);
+        if((getSeat()->getPlayer() != nullptr) &&
+           (getSeat()->getPlayer()->getIsHuman()))
+        {
+            ServerNotification *serverNotification = new ServerNotification(
+                ServerNotificationType::chatServer, getSeat()->getPlayer());
+            std::string msg = getName() + " is not under your control anymore !";
+            serverNotification->mPacket << msg;
+            ODServer::getSingleton().queueServerNotification(serverNotification);
+        }
 
         Seat* rogueSeat = getGameMap()->getSeatRogue();
         setSeat(rogueSeat);


### PR DESCRIPTION
fixes #501
