### PR TITLE
Implemented save games

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,7 @@ set(OD_SOURCEFILES
     ${SRC}/modes/MenuMode.cpp
     ${SRC}/modes/MenuModeConfigureSeats.cpp
     ${SRC}/modes/MenuModeEditor.cpp
+    ${SRC}/modes/MenuModeLoad.cpp
     ${SRC}/modes/MenuModeMultiplayerClient.cpp
     ${SRC}/modes/MenuModeMultiplayerServer.cpp
     ${SRC}/modes/MenuModeReplay.cpp

--- a/gui/GameOptionsMenu.layout
+++ b/gui/GameOptionsMenu.layout
@@ -20,7 +20,6 @@
             <Property name="Area" value="{{0.5,-80},{0,136},{0.5,80},{0,169}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/SaveIcon" />
             <Property name="Text" value="Save Game (F5)" />
-            <Property name="Disabled" value="True" />
             <Property name="TooltipText" value="Not implemented yet" />
         </Window>
         <Window type="OD/IconButton" name="LoadGameButton" >

--- a/gui/OpenDungeonsMainMenu.layout
+++ b/gui/OpenDungeonsMainMenu.layout
@@ -27,9 +27,9 @@
             <Property name="Text" value="Skirmish" />
             <Property name="AlwaysOnTop" value="True" />
         </Window>
-        <Window type="OD/MainMenuButton" name="StartReplayButton" >
+        <Window type="OD/MainMenuButton" name="LoadGameButton" >
             <Property name="Area" value="{{0.5,-310},{0.5,100},{0.5,-170},{0.5,180}}" />
-            <Property name="Text" value="Replay" />
+            <Property name="Text" value="Load" />
             <Property name="AlwaysOnTop" value="True" />
         </Window>
         <Window type="OD/MainMenuButton" name="StartMultiplayerClientButton" >
@@ -43,8 +43,13 @@
             <Property name="AlwaysOnTop" value="True" />
         </Window>
         <Window type="OD/MainMenuButton" name="MapEditorButton" >
-            <Property name="Area" value="{{0.5,10},{0.5,40},{0.5,150},{0.5,120}}" />
+            <Property name="Area" value="{{0.5,10},{0.5,-10},{0.5,150},{0.5,70}}" />
             <Property name="Text" value="Map Editor" />
+            <Property name="AlwaysOnTop" value="True" />
+        </Window>
+        <Window type="OD/MainMenuButton" name="StartReplayButton" >
+            <Property name="Area" value="{{0.5,10},{0.5,100},{0.5,150},{0.5,180}}" />
+            <Property name="Text" value="Replay" />
             <Property name="AlwaysOnTop" value="True" />
         </Window>
         <Window type="OD/MainMenuButton" name="QuitButton" >

--- a/gui/OpenDungeonsMenuLoad.layout
+++ b/gui/OpenDungeonsMenuLoad.layout
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<GUILayout version="4" >
+    <Window type="OD/StaticImage" name="Background" >
+        <Property name="Area" value="{{0,0},{0,0},{1,2},{1,0}}" />
+        <Property name="Image" value="ODMainMenuBackground/MainMenuBackground" />
+        <Property name="MaxSize" value="{{1,0},{1,0}}" />
+        <Property name="FrameEnabled" value="False" />
+        <Property name="BackgroundEnabled" value="False" />
+        <Window type="OD/StaticText" name="LoadingText" >
+            <Property name="Area" value="{{0.5,-301},{0.5,240},{0.5,299},{0.5,260}}" />
+            <Property name="Text" value="Loading..." />
+            <Property name="MaxSize" value="{{1,0},{1,0}}" />
+            <Property name="FrameEnabled" value="False" />
+            <Property name="HorzFormatting" value="CentreAligned" />
+            <Property name="BackgroundEnabled" value="False" />
+        </Window>
+        <Window type="OD/StaticImage" name="WelcomeBanner" >
+            <Property name="Area" value="{{0.5,-320},{0,52},{0.5,320},{0,191}}" />
+            <Property name="Image" value="ODLogo/Logo" />
+            <Property name="MaxSize" value="{{1,0},{1,0}}" />
+            <Property name="FrameEnabled" value="False" />
+            <Property name="BackgroundEnabled" value="False" />
+        </Window>
+        <Window type="OD/StaticText" name="VersionText" >
+            <Property name="Area" value="{{0.5,200},{0,171},{0.5,300},{0,191}}" />
+            <Property name="Text" value="undefined" />
+            <Property name="MaxSize" value="{{1,0},{1,0}}" />
+            <Property name="FrameEnabled" value="False" />
+            <Property name="BackgroundEnabled" value="False" />
+        </Window>
+        <Window type="OD/FrameWindow" name="LevelWindowFrame" >
+            <Property name="Area" value="{{0.5,-315},{0.5,-180},{0.5,315},{0.5,240}}" />
+            <Property name="Text" value="Please choose a saved game..." />
+            <Property name="MaxSize" value="{{0,790},{0,470}}" />
+            <Property name="MinSize" value="{{0,630},{0,420}}" />
+            <Property name="AlwaysOnTop" value="True" />
+            <Window type="OD/Listbox" name="SaveGameSelect" >
+                <Property name="Area" value="{{0,15},{0,40},{0.5,-20},{0.7,0}}" />
+                <Property name="ForceVertScrollbar" value="True" />
+                <Property name="Sort" value="True" />
+            </Window>
+            <Window type="OD/StaticText" name="MapDescriptionText" >
+                <Property name="Area" value="{{0.5,0},{0,40},{1,-15},{0.7,0}}" />
+                <Property name="MaxSize" value="{{1,0},{1,0}}" />
+                <Property name="FrameEnabled" value="False" />
+                <Property name="HorzFormatting" value="WordWrapLeftAligned" />
+                <Property name="VertFormatting" value="TopAligned" />
+                <Property name="BackgroundEnabled" value="False" />
+            </Window>
+            <Window type="OD/MainMenuButton" name="BackButton" >
+                <Property name="Area" value="{{0,10},{0.75,0},{0,210},{0.75,80}}" />
+                <Property name="Text" value="Back" />
+            </Window>
+            <Window type="OD/MainMenuButton" name="DeleteButton" >
+                <Property name="Area" value="{{0.5,-100},{0.75,0},{0.5,100},{0.75,80}}" />
+                <Property name="Text" value="Delete saved game" />
+            </Window>
+            <Window type="OD/MainMenuButton" name="LaunchButton" >
+                <Property name="Area" value="{{1,-210},{0.75,0},{1,-10},{0.75,80}}" />
+                <Property name="Text" value="Start saved game" />
+            </Window>
+        </Window>
+    </Window>
+</GUILayout>

--- a/levels/multiplayer/GreedOrMight.level
+++ b/levels/multiplayer/GreedOrMight.level
@@ -2273,16 +2273,8 @@ MineNGold	50
 
 [Creatures]
 # SeatId	Name	MeshName	PosX	PosY	PosZ	ClassName	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	LeftWeapon	RightWeapon
-[Creature]
 4	BossDragon1	BossDragon	62	14	0	BossDragon	4	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 4	BossDragon2	BossDragon	40	68	0	BossDragon	3	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 4	BossDragon3	BossDragon	33	65	0	BossDragon	3	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 4	BossDragon4	BossDragon	9	14	0	BossDragon	4	0	max	100	0	0	none	none
-[/Creature]
 [/Creatures]

--- a/levels/multiplayer/GreedOrMight.level
+++ b/levels/multiplayer/GreedOrMight.level
@@ -8,11 +8,96 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	player	faction	startingX	startingY	color	startingGold
-1	1	Choice	Keeper	37	15	1	1000
-2	2	Choice	Keeper	59	47	2	1000
-3	3	Choice	Keeper	14	45	3	1000
-4	4	Inactive	Keeper	37	37	4	0
+[Seat]
+seatId	1
+teamId	1
+player	Choice
+faction	Keeper
+startingX	37
+startingY	15
+colorId	1
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	2
+teamId	2
+player	Choice
+faction	Keeper
+startingX	59
+startingY	47
+colorId	2
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	3
+teamId	3
+player	Choice
+faction	Keeper
+startingX	14
+startingY	45
+colorId	3
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
 [/Seats]
 
 [Goals]
@@ -35,7 +120,7 @@ MineNGold	50
 # Map Size
 75 # MapSizeX
 75 # MapSizeY
-# posX	posY	type	fullness
+# posX	posY	type	fullness	seatId(optional)
 0	0	3	100
 0	1	3	100
 0	2	3	100
@@ -2252,6 +2337,7 @@ MineNGold	50
     WeakCoef	0.3
     FeeBase	0
     FeePerLevel	0
+    SleepHeal	1
     WeaponSpawnL	none
     WeaponSpawnL	none
     [/Stats]
@@ -2273,8 +2359,32 @@ MineNGold	50
 
 [Creatures]
 # SeatId	Name	MeshName	PosX	PosY	PosZ	ClassName	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	LeftWeapon	RightWeapon
-4	BossDragon1	BossDragon	62	14	0	BossDragon	4	0	max	100	0	0	none	none
-4	BossDragon2	BossDragon	40	68	0	BossDragon	3	0	max	100	0	0	none	none
-4	BossDragon3	BossDragon	33	65	0	BossDragon	3	0	max	100	0	0	none	none
-4	BossDragon4	BossDragon	9	14	0	BossDragon	4	0	max	100	0	0	none	none
+0	BossDragon1	BossDragon	62	14	0	BossDragon	4	0	max	100	0	0	none	none
+0	BossDragon2	BossDragon	40	68	0	BossDragon	3	0	max	100	0	0	none	none
+0	BossDragon3	BossDragon	33	65	0	BossDragon	3	0	max	100	0	0	none	none
+0	BossDragon4	BossDragon	9	14	0	BossDragon	4	0	max	100	0	0	none	none
 [/Creatures]
+
+[Spells]
+# typeSpell	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData	
+[/Spells]
+
+[CraftedTraps]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	trapType	PosX	PosY	PosZ	
+[/CraftedTraps]
+
+[ResearchEntity]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ	
+[/ResearchEntity]
+
+[Missiles]
+# missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData	
+[/Missiles]
+
+[TreasuryObject]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	value	
+[/TreasuryObject]
+
+[Chickens]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	PosX	PosY	PosZ	
+[/Chickens]

--- a/levels/multiplayer/TestMultiplayer.level
+++ b/levels/multiplayer/TestMultiplayer.level
@@ -5881,103 +5881,37 @@ ProtectDungeonTemple	NULL
 
 [Creatures]
 # SeatId	Name	MeshName	PosX	PosY	PosZ	ClassName	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	LeftWeapon	RightWeapon
-[Creature]
 1	ConstructWorker1	ConstructWorker	193	206	0	ConstructWorker	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Gnome2	Gnome	194	311	0	Gnome	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Goblin3	Goblin	161	201	0	Goblin	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 5	PitDemon5	PitDemon	159	202	0	PitDemon	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Wizard7	Wizard	199	311	0	Wizard	1	0	max	100	0	0	Staff	none
-[/Creature]
-[Creature]
 3	Tentacle18	Tentacle1	162	198	0	Tentacle1	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 4	Tentacle29	Tentacle2	158	201	0	Tentacle2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 5	Troll10	Troll	186	235	0	Troll	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Knight_c2	Knight	192	311	0	Knight	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 3	Knight_c3	Knight	192	314	0	Knight	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 4	Knight_c4	Knight	196	315	0	Knight	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 5	Knight_c5	Knight	194	315	0	Knight	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 5	LizardMan_001	LizardMan	185	233	0	LizardMan	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 1	Kobold	Kobold	197	205	0	Kobold	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	Kobold_012	Kobold	193	205	0	Kobold	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 1	Kobold_007	Kobold	195	205	0	Kobold	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Dwarf1_001	Dwarf1	221	189	0	Dwarf1	1	0	max	100	0	0	Roundshield	Sabre
-[/Creature]
-[Creature]
 2	Dwarf1_002	Dwarf2	226	165	0	Dwarf2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Dwarf1_004	Dwarf3	213	157	0	Dwarf3	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Dwarf1_006	Dwarf2	214	141	0	Dwarf2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Dwarf1_007	Dwarf3	212	143	0	Dwarf3	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Dwarf2_001	Dwarf3	264	221	0	Dwarf3	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Dwarf2_002	Dwarf2	216	185	0	Dwarf2	1	0	max	100	0	0	none	Longsword
-[/Creature]
-[Creature]
 2	Dwarf3_001	Dwarf1	217	187	0	Dwarf1	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 3	LizardMan_002	LizardMan	229	168	0	LizardMan	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Kre	Kreatur	262	220	0	Kreatur	10	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Orc_0001	Orc	228	166	0	Orc	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Orc_0002	Orc	262	222	0	Orc	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Kreatur_001	Kreatur	161	113	0	Kreatur	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Kreatur_002	Kreatur	159	101	0	Kreatur	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Kreatur_003	Kreatur	176	98	0	Kreatur	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Kreatur_004	Kreatur	168	99	0	Kreatur	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Kreatur_006	Kreatur	162	100	0	Kreatur	1	0	max	100	0	0	none	none
-[/Creature]
 [/Creatures]

--- a/levels/multiplayer/TestMultiplayer.level
+++ b/levels/multiplayer/TestMultiplayer.level
@@ -8,12 +8,156 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	player	faction	startingX	startingY	color	startingGold
-1	1	Human	Keeper	195	207	1	1000
-2	2	Choice	Choice	252	211	2	1000
-3	3	Choice	Choice	167	104	3	1000
-4	4	Choice	Choice	266	92	4	1000
-5	5	Inactive	Keeper	200	200	5	1000
+[Seat]
+seatId	1
+teamId	1
+player	Human
+faction	Keeper
+startingX	195
+startingY	207
+colorId	1
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	2
+teamId	2
+player	Choice
+faction	Choice
+startingX	252
+startingY	211
+colorId	2
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	3
+teamId	3
+player	Choice
+faction	Choice
+startingX	167
+startingY	104
+colorId	3
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	4
+teamId	4
+player	Choice
+faction	Choice
+startingX	266
+startingY	92
+colorId	4
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	5
+teamId	5
+player	Inactive
+faction	Keeper
+startingX	10
+startingY	10
+colorId	5
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
 [/Seats]
 
 [Goals]
@@ -34,7 +178,7 @@ ProtectDungeonTemple	NULL
 # Map Size
 400 # MapSizeX
 400 # MapSizeY
-# posX	posY	type	fullness
+# posX	posY	type	fullness	seatId(optional)
 146	102	3	100
 146	103	3	100
 146	104	3	100
@@ -5915,3 +6059,27 @@ ProtectDungeonTemple	NULL
 3	Kreatur_004	Kreatur	168	99	0	Kreatur	1	0	max	100	0	0	none	none
 3	Kreatur_006	Kreatur	162	100	0	Kreatur	1	0	max	100	0	0	none	none
 [/Creatures]
+
+[Spells]
+# typeSpell	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData	
+[/Spells]
+
+[CraftedTraps]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	trapType	PosX	PosY	PosZ	
+[/CraftedTraps]
+
+[ResearchEntity]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ	
+[/ResearchEntity]
+
+[Missiles]
+# missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData	
+[/Missiles]
+
+[TreasuryObject]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	value	
+[/TreasuryObject]
+
+[Chickens]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	PosX	PosY	PosZ	
+[/Chickens]

--- a/levels/multiplayer/TestMultiplayer.level
+++ b/levels/multiplayer/TestMultiplayer.level
@@ -5890,6 +5890,7 @@ ProtectDungeonTemple	NULL
 262	210
 262	211
 262	212
+0	0
 [/Room]
 [Room]
 4	2	9

--- a/levels/multiplayer/TestMultiplayerSmall1v1.level
+++ b/levels/multiplayer/TestMultiplayerSmall1v1.level
@@ -8,9 +8,66 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	player	faction	startingX	startingY	color	startingGold
-1	1	Human	Choice	10	10	1	1000
-2	2	Choice	Choice	10	40	2	1000
+[Seat]
+seatId	1
+teamId	1
+player	Human
+faction	Choice
+startingX	10
+startingY	10
+colorId	1
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	2
+teamId	2
+player	Choice
+faction	Choice
+startingX	10
+startingY	40
+colorId	2
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
 [/Seats]
 
 [Goals]
@@ -31,7 +88,7 @@ ProtectDungeonTemple	NULL
 # Map Size
 50 # MapSizeX
 50 # MapSizeY
-# posX	posY	type	fullness
+# posX	posY	type	fullness	seatId(optional)
 1	24	2	100
 1	25	2	100
 2	24	2	100
@@ -502,3 +559,27 @@ ProtectDungeonTemple	NULL
 [Creatures]
 # SeatId	Name	MeshName	PosX	PosY	PosZ	ClassName	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	LeftWeapon	RightWeapon
 [/Creatures]
+
+[Spells]
+# typeSpell	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData	
+[/Spells]
+
+[CraftedTraps]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	trapType	PosX	PosY	PosZ	
+[/CraftedTraps]
+
+[ResearchEntity]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ	
+[/ResearchEntity]
+
+[Missiles]
+# missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData	
+[/Missiles]
+
+[TreasuryObject]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	value	
+[/TreasuryObject]
+
+[Chickens]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	PosX	PosY	PosZ	
+[/Chickens]

--- a/levels/multiplayer/TestMultiplayerSmallAlliance.level
+++ b/levels/multiplayer/TestMultiplayerSmallAlliance.level
@@ -8,11 +8,126 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	player	faction	startingX	startingY	color	startingGold
-1	1	Human	Keeper	10	10	1	1000
-2	1	Choice	Choice	10	40	2	1000
-3	2	Choice	Keeper	40	10	3	1000
-4	2	Choice	Choice	40	40	4	1000
+[Seat]
+seatId	1
+teamId	1
+player	Human
+faction	Choice
+startingX	10
+startingY	10
+colorId	1
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	2
+teamId	2
+player	Choice
+faction	Choice
+startingX	10
+startingY	40
+colorId	2
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	3
+teamId	3
+player	Choice
+faction	Choice
+startingX	40
+startingY	10
+colorId	3
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	4
+teamId	4
+player	Choice
+faction	Choice
+startingX	40
+startingY	40
+colorId	4
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
 [/Seats]
 
 [Goals]
@@ -33,7 +148,7 @@ ProtectDungeonTemple	NULL
 # Map Size
 50 # MapSizeX
 50 # MapSizeY
-# posX	posY	type	fullness
+# posX	posY	type	fullness	seatId(optional)
 1	24	2	100
 1	25	2	100
 2	24	2	100
@@ -758,3 +873,27 @@ ProtectDungeonTemple	NULL
 [Creatures]
 # SeatId	Name	MeshName	PosX	PosY	PosZ	ClassName	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	LeftWeapon	RightWeapon
 [/Creatures]
+
+[Spells]
+# typeSpell	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData	
+[/Spells]
+
+[CraftedTraps]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	trapType	PosX	PosY	PosZ	
+[/CraftedTraps]
+
+[ResearchEntity]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ	
+[/ResearchEntity]
+
+[Missiles]
+# missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData	
+[/Missiles]
+
+[TreasuryObject]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	value	
+[/TreasuryObject]
+
+[Chickens]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	PosX	PosY	PosZ	
+[/Chickens]

--- a/levels/multiplayer/TestMultiplayerSmallFreeForAll.level
+++ b/levels/multiplayer/TestMultiplayerSmallFreeForAll.level
@@ -8,11 +8,126 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	player	faction	startingX	startingY	color	startingGold
-1	1/2/3/4	Choice	Choice	10	10	1	1000
-2	2/3/4/1	Choice	Choice	10	40	2	1000
-3	3/4/1/2	Choice	Choice	40	10	3	1000
-4	4/1/2/3	Choice	Choice	40	40	4	1000
+[Seat]
+seatId	1
+teamId	1/2/3/4
+player	Human
+faction	Choice
+startingX	10
+startingY	10
+colorId	1
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	2
+teamId	2/3/4/1
+player	Choice
+faction	Choice
+startingX	10
+startingY	40
+colorId	2
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	3
+teamId	3/4/1/2
+player	Choice
+faction	Choice
+startingX	40
+startingY	10
+colorId	3
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	4
+teamId	4/1/2/3
+player	Choice
+faction	Choice
+startingX	40
+startingY	40
+colorId	4
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
 [/Seats]
 
 [Goals]
@@ -33,7 +148,7 @@ ProtectDungeonTemple	NULL
 # Map Size
 50 # MapSizeX
 50 # MapSizeY
-# posX	posY	type	fullness
+# posX	posY	type	fullness	seatId(optional)
 1	24	2	100
 1	25	2	100
 2	24	2	100
@@ -758,3 +873,27 @@ ProtectDungeonTemple	NULL
 [Creatures]
 # SeatId	Name	MeshName	PosX	PosY	PosZ	ClassName	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	LeftWeapon	RightWeapon
 [/Creatures]
+
+[Spells]
+# typeSpell	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData	
+[/Spells]
+
+[CraftedTraps]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	trapType	PosX	PosY	PosZ	
+[/CraftedTraps]
+
+[ResearchEntity]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ	
+[/ResearchEntity]
+
+[Missiles]
+# missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData	
+[/Missiles]
+
+[TreasuryObject]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	value	
+[/TreasuryObject]
+
+[Chickens]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	PosX	PosY	PosZ	
+[/Chickens]

--- a/levels/skirmish/GreedOrMight.level
+++ b/levels/skirmish/GreedOrMight.level
@@ -8,10 +8,96 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	player	faction	startingX	startingY	color	startingGold
-1	1	Choice	Keeper	37	15	1	1000
-2	2	Choice	Keeper	59	47	2	1000
-3	3	Choice	Keeper	14	45	3	1000
+[Seat]
+seatId	1
+teamId	1
+player	Choice
+faction	Keeper
+startingX	37
+startingY	15
+colorId	1
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	2
+teamId	2
+player	Choice
+faction	Keeper
+startingX	59
+startingY	47
+colorId	2
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	3
+teamId	3
+player	Choice
+faction	Keeper
+startingX	14
+startingY	45
+colorId	3
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
 [/Seats]
 
 [Goals]
@@ -34,7 +120,7 @@ MineNGold	50
 # Map Size
 75 # MapSizeX
 75 # MapSizeY
-# posX	posY	type	fullness
+# posX	posY	type	fullness	seatId(optional)
 0	0	3	100
 0	1	3	100
 0	2	3	100
@@ -141,8 +227,6 @@ MineNGold	50
 1	28	3	100
 1	31	3	100
 1	32	3	100
-1	33	1	100
-1	34	1	100
 1	35	3	100
 1	36	3	100
 1	37	3	100
@@ -206,11 +290,7 @@ MineNGold	50
 2	23	3	100
 2	24	3	100
 2	25	3	100
-2	26	1	100
 2	27	3	100
-2	28	1	100
-2	35	1	100
-2	36	1	100
 2	37	3	100
 2	38	3	100
 2	39	3	100
@@ -258,13 +338,6 @@ MineNGold	50
 3	18	2	100
 3	19	2	100
 3	20	2	100
-3	24	1	100
-3	25	1	100
-3	26	1	100
-3	27	1	100
-3	28	1	100
-3	29	1	100
-3	33	1	100
 3	43	1	0
 3	44	1	0
 3	45	1	0
@@ -307,12 +380,6 @@ MineNGold	50
 4	20	2	100
 4	21	2	100
 4	22	2	100
-4	24	1	100
-4	25	1	100
-4	26	1	100
-4	27	1	100
-4	28	1	100
-4	29	1	100
 4	43	1	0
 4	44	6	0	3
 4	45	6	0	3
@@ -353,12 +420,6 @@ MineNGold	50
 5	20	2	100
 5	21	2	100
 5	22	2	100
-5	24	1	100
-5	25	1	100
-5	26	1	100
-5	27	1	100
-5	28	1	100
-5	29	1	100
 5	43	1	0
 5	44	6	0	3
 5	45	6	0	3
@@ -561,7 +622,6 @@ MineNGold	50
 11	3	3	100
 11	4	3	100
 11	5	3	100
-11	6	1	100
 11	8	2	100
 11	13	1	0
 11	14	1	0
@@ -587,7 +647,6 @@ MineNGold	50
 12	2	3	100
 12	3	3	100
 12	4	3	100
-12	6	1	100
 12	7	2	100
 12	8	2	100
 12	14	5	0
@@ -690,7 +749,6 @@ MineNGold	50
 18	0	3	100
 18	1	3	100
 18	2	3	100
-18	3	1	100
 18	9	2	100
 18	10	2	100
 18	25	5	0
@@ -787,8 +845,6 @@ MineNGold	50
 26	73	3	100
 26	74	3	100
 27	0	3	100
-27	1	1	100
-27	2	1	100
 27	6	2	100
 27	8	2	100
 27	9	2	100
@@ -802,8 +858,6 @@ MineNGold	50
 27	73	3	100
 27	74	3	100
 28	0	3	100
-28	1	1	100
-28	2	1	100
 28	29	5	0
 28	30	5	0
 28	31	5	0
@@ -817,7 +871,6 @@ MineNGold	50
 28	73	3	100
 28	74	3	100
 29	0	3	100
-29	1	1	100
 29	17	2	100
 29	18	2	100
 29	19	2	100
@@ -872,7 +925,6 @@ MineNGold	50
 31	74	3	100
 32	0	3	100
 32	1	3	100
-32	17	1	100
 32	30	5	0
 32	31	4	0
 32	32	4	0
@@ -1171,9 +1223,6 @@ MineNGold	50
 39	5	1	0
 39	6	1	0
 39	7	1	0
-39	14	1	100
-39	15	1	100
-39	16	1	100
 39	25	4	0
 39	26	4	0
 39	27	2	100
@@ -1393,8 +1442,6 @@ MineNGold	50
 51	0	3	100
 51	1	3	100
 51	2	3	100
-51	4	1	100
-51	5	1	100
 51	29	5	0
 51	30	5	0
 51	71	3	100
@@ -1404,16 +1451,12 @@ MineNGold	50
 52	0	3	100
 52	1	3	100
 52	2	3	100
-52	3	1	100
-52	4	1	100
 52	27	5	0
 52	28	5	0
 52	29	5	0
 52	30	5	0
 52	31	5	0
 52	32	5	0
-52	69	1	100
-52	70	1	100
 52	71	3	100
 52	72	3	100
 52	73	3	100
@@ -1422,7 +1465,6 @@ MineNGold	50
 53	1	3	100
 53	2	3	100
 53	3	3	100
-53	4	1	100
 53	27	5	0
 53	28	5	0
 53	29	5	0
@@ -1430,8 +1472,6 @@ MineNGold	50
 53	31	5	0
 53	32	5	0
 53	40	2	100
-53	69	1	100
-53	70	1	100
 53	71	3	100
 53	72	3	100
 53	73	3	100
@@ -1450,7 +1490,6 @@ MineNGold	50
 54	31	5	0
 54	37	2	100
 54	39	2	100
-54	69	1	100
 54	70	3	100
 54	71	3	100
 54	72	3	100
@@ -1537,8 +1576,6 @@ MineNGold	50
 59	4	3	100
 59	5	3	100
 59	6	3	100
-59	10	1	100
-59	11	1	100
 59	15	5	0
 59	16	5	0
 59	17	5	0
@@ -1596,7 +1633,6 @@ MineNGold	50
 61	16	1	0
 61	18	5	0
 61	47	1	0
-61	67	1	100
 61	68	3	100
 61	69	3	100
 61	70	3	100
@@ -1624,7 +1660,6 @@ MineNGold	50
 62	33	2	100
 62	35	2	100
 62	47	1	0
-62	67	1	100
 62	68	3	100
 62	69	3	100
 62	70	3	100
@@ -1651,7 +1686,6 @@ MineNGold	50
 63	32	2	100
 63	33	2	100
 63	47	1	0
-63	65	1	100
 63	68	3	100
 63	69	3	100
 63	70	3	100
@@ -1727,8 +1761,6 @@ MineNGold	50
 66	10	2	100
 66	11	5	0
 66	12	1	0
-66	13	1	100
-66	14	1	100
 66	15	2	100
 66	16	2	100
 66	45	1	0
@@ -1737,10 +1769,6 @@ MineNGold	50
 66	48	1	0
 66	49	1	0
 66	54	2	100
-66	61	1	100
-66	62	1	100
-66	63	1	100
-66	64	1	100
 66	65	3	100
 66	66	3	100
 66	67	3	100
@@ -1767,7 +1795,6 @@ MineNGold	50
 67	13	3	100
 67	14	3	100
 67	15	2	100
-67	16	1	100
 67	45	1	0
 67	46	6	0	2
 67	47	6	0	2
@@ -1801,7 +1828,6 @@ MineNGold	50
 68	12	3	100
 68	13	3	100
 68	14	3	100
-68	16	1	100
 68	45	1	0
 68	46	6	0	2
 68	47	6	0	2
@@ -1875,7 +1901,6 @@ MineNGold	50
 70	16	3	100
 70	17	3	100
 70	18	3	100
-70	19	1	100
 70	20	3	100
 70	21	3	100
 70	22	3	100
@@ -1918,7 +1943,6 @@ MineNGold	50
 71	16	3	100
 71	17	3	100
 71	18	3	100
-71	19	1	100
 71	20	3	100
 71	21	3	100
 71	22	3	100
@@ -2288,6 +2312,7 @@ MineNGold	50
     AwakenessLost/Turn	0
     HungerGrowth/Turn	0
     TileSightRadius	15
+    MaxGoldCarryable	0
     DigRate	0
     DigRate/Level	0
     ClaimRate	0
@@ -2309,9 +2334,15 @@ MineNGold	50
     AttackRange	1
     AtkRange/Level	0
     AttackWarmupTime	2.5
+    WeakCoef	0.3
+    FeeBase	0
+    FeePerLevel	0
+    SleepHeal	1
     WeaponSpawnL	none
     WeaponSpawnL	none
     [/Stats]
+    [RoomAffinity]
+    [/RoomAffinity]
     [XP]
     # 2-10
     12	24	40	58	78	100	124	152	180
@@ -2333,3 +2364,27 @@ MineNGold	50
 0	BossDragon3	BossDragon	33	65	0	BossDragon	3	0	max	100	0	0	none	none
 0	BossDragon4	BossDragon	9	14	0	BossDragon	4	0	max	100	0	0	none	none
 [/Creatures]
+
+[Spells]
+# typeSpell	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData	
+[/Spells]
+
+[CraftedTraps]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	trapType	PosX	PosY	PosZ	
+[/CraftedTraps]
+
+[ResearchEntity]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ	
+[/ResearchEntity]
+
+[Missiles]
+# missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData	
+[/Missiles]
+
+[TreasuryObject]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	value	
+[/TreasuryObject]
+
+[Chickens]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	PosX	PosY	PosZ	
+[/Chickens]

--- a/levels/skirmish/GreedOrMight.level
+++ b/levels/skirmish/GreedOrMight.level
@@ -2328,16 +2328,8 @@ MineNGold	50
 
 [Creatures]
 # SeatId	Name	MeshName	PosX	PosY	PosZ	ClassName	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	LeftWeapon	RightWeapon
-[Creature]
 0	BossDragon1	BossDragon	62	14	0	BossDragon	4	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	BossDragon2	BossDragon	40	68	0	BossDragon	3	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	BossDragon3	BossDragon	33	65	0	BossDragon	3	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	BossDragon4	BossDragon	9	14	0	BossDragon	4	0	max	100	0	0	none	none
-[/Creature]
 [/Creatures]

--- a/levels/skirmish/Scream in the Dark.level
+++ b/levels/skirmish/Scream in the Dark.level
@@ -4955,6 +4955,7 @@ ProtectDungeonTemple	NULL
 14	84
 14	85
 14	86
+0	0
 [/Room]
 [Room]
 7	3	25
@@ -5161,6 +5162,7 @@ ProtectDungeonTemple	NULL
 95	91
 95	92
 95	93
+0	0
 [/Room]
 [Room]
 4	4	6
@@ -5366,6 +5368,7 @@ ProtectDungeonTemple	NULL
 51	62
 51	63
 51	64
+0	0
 [/Room]
 [Room]
 7	5	12

--- a/levels/skirmish/Scream in the Dark.level
+++ b/levels/skirmish/Scream in the Dark.level
@@ -5281,16 +5281,8 @@ ProtectDungeonTemple	NULL
 
 [Creatures]
 # SeatId	Name	MeshName	PosX	PosY	PosZ	ClassName	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	LeftWeapon	RightWeapon
-[Creature]
 5	Dragon1	Dragon	13	55	0	Dragon	10	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 5	Dragon2	Dragon	13	54	0	Dragon	10	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 5	Dragon3	Dragon	87	58	0	Dragon	10	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 5	Dragon4	Dragon	87	57	0	Dragon	10	0	max	100	0	0	none	none
-[/Creature]
 [/Creatures]

--- a/levels/skirmish/Scream in the Dark.level
+++ b/levels/skirmish/Scream in the Dark.level
@@ -8,12 +8,156 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	player	faction	startingX	startingY	color	startingGold
-1	1	Human	Keeper	5	6	1	1000
-2	1	AI	Keeper	89	15	2	1000
-3	2	AI	Keeper	91	55	3	1000
-4	2	AI	Keeper	47	94	4	1000
-5	3	AI	Keeper	47	94	5	1000
+[Seat]
+seatId	1
+teamId	1
+player	Human
+faction	Keeper
+startingX	5
+startingY	6
+colorId	1
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	2
+teamId	2
+player	AI
+faction	Keeper
+startingX	10
+startingY	10
+colorId	2
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	3
+teamId	3
+player	AI
+faction	Keeper
+startingX	10
+startingY	10
+colorId	3
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	4
+teamId	4
+player	AI
+faction	Keeper
+startingX	10
+startingY	10
+colorId	4
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	5
+teamId	5
+player	AI
+faction	Keeper
+startingX	10
+startingY	10
+colorId	5
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
 [/Seats]
 
 [Goals]
@@ -26,7 +170,7 @@ ProtectDungeonTemple	NULL
 # Map Size
 100 # MapSizeX
 100 # MapSizeY
-# posX	posY	type	fullness
+# posX	posY	type	fullness	seatId(optional)
 0	0	3	100
 0	1	3	100
 0	2	3	100
@@ -5029,7 +5173,27 @@ ProtectDungeonTemple	NULL
 [/Room]
 [Room]
 3	4	1
-86	88
+81	88
+[/Room]
+[Room]
+3	4	1
+81	92
+[/Room]
+[Room]
+3	4	1
+92	87
+[/Room]
+[Room]
+3	4	1
+83	87
+[/Room]
+[Room]
+3	4	1
+90	88
+[/Room]
+[Room]
+3	4	1
+88	87
 [/Room]
 [Room]
 3	4	8
@@ -5044,27 +5208,7 @@ ProtectDungeonTemple	NULL
 [/Room]
 [Room]
 3	4	1
-88	87
-[/Room]
-[Room]
-3	4	1
-90	88
-[/Room]
-[Room]
-3	4	1
-83	87
-[/Room]
-[Room]
-3	4	1
-92	87
-[/Room]
-[Room]
-3	4	1
-81	88
-[/Room]
-[Room]
-3	4	1
-81	92
+86	88
 [/Room]
 [Room]
 6	5	65
@@ -5286,3 +5430,27 @@ ProtectDungeonTemple	NULL
 5	Dragon3	Dragon	87	58	0	Dragon	10	0	max	100	0	0	none	none
 5	Dragon4	Dragon	87	57	0	Dragon	10	0	max	100	0	0	none	none
 [/Creatures]
+
+[Spells]
+# typeSpell	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData	
+[/Spells]
+
+[CraftedTraps]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	trapType	PosX	PosY	PosZ	
+[/CraftedTraps]
+
+[ResearchEntity]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ	
+[/ResearchEntity]
+
+[Missiles]
+# missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData	
+[/Missiles]
+
+[TreasuryObject]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	value	
+[/TreasuryObject]
+
+[Chickens]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	PosX	PosY	PosZ	
+[/Chickens]

--- a/levels/skirmish/Scream in the Dark.level
+++ b/levels/skirmish/Scream in the Dark.level
@@ -4756,6 +4756,7 @@ ProtectDungeonTemple	NULL
 86	14
 86	15
 86	16
+0
 [/Room]
 [Room]
 1	2	9
@@ -4888,6 +4889,7 @@ ProtectDungeonTemple	NULL
 14	89
 14	90
 14	91
+0
 [/Room]
 [Room]
 1	3	9
@@ -5075,6 +5077,7 @@ ProtectDungeonTemple	NULL
 85	91
 85	92
 85	93
+0
 [/Room]
 [Room]
 1	4	9
@@ -5302,6 +5305,7 @@ ProtectDungeonTemple	NULL
 50	56
 50	57
 50	58
+0
 [/Room]
 [Room]
 1	5	9

--- a/levels/skirmish/Stonekeep siege.level
+++ b/levels/skirmish/Stonekeep siege.level
@@ -3976,6 +3976,7 @@ ProtectDungeonTemple	NULL
 55	83
 55	84
 55	85
+0	0
 [/Room]
 [Room]
 7	4	25

--- a/levels/skirmish/Stonekeep siege.level
+++ b/levels/skirmish/Stonekeep siege.level
@@ -8,11 +8,126 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	player	faction	startingX	startingY	color	startingGold
-1	1	Human	Keeper	51	16	1	1000
-2	2	AI	Keeper	7	55	2	1000
-3	3	AI	Keeper	91	55	3	1000
-4	4	AI	Keeper	47	94	4	1000
+[Seat]
+seatId	1
+teamId	1
+player	Human
+faction	Keeper
+startingX	51
+startingY	16
+colorId	1
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	2
+teamId	2
+player	AI
+faction	Keeper
+startingX	7
+startingY	55
+colorId	2
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	3
+teamId	3
+player	AI
+faction	Keeper
+startingX	91
+startingY	55
+colorId	3
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	4
+teamId	4
+player	AI
+faction	Keeper
+startingX	47
+startingY	94
+colorId	4
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
 [/Seats]
 
 [Goals]
@@ -25,7 +140,7 @@ ProtectDungeonTemple	NULL
 # Map Size
 100 # MapSizeX
 100 # MapSizeY
-# posX	posY	type	fullness
+# posX	posY	type	fullness	seatId(optional)
 0	0	5	0
 0	1	5	0
 0	2	5	0
@@ -4062,3 +4177,27 @@ ProtectDungeonTemple	NULL
 4	PitDemon90	PitDemon	48	57	0	PitDemon	1	0	max	100	0	0	none	none
 4	PitDemon91	PitDemon	50	57	0	PitDemon	10	0	max	100	0	0	none	none
 [/Creatures]
+
+[Spells]
+# typeSpell	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData	
+[/Spells]
+
+[CraftedTraps]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	trapType	PosX	PosY	PosZ	
+[/CraftedTraps]
+
+[ResearchEntity]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ	
+[/ResearchEntity]
+
+[Missiles]
+# missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData	
+[/Missiles]
+
+[TreasuryObject]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	value	
+[/TreasuryObject]
+
+[Chickens]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	PosX	PosY	PosZ	
+[/Chickens]

--- a/levels/skirmish/Stonekeep siege.level
+++ b/levels/skirmish/Stonekeep siege.level
@@ -3864,6 +3864,7 @@ ProtectDungeonTemple	NULL
 47	77
 47	78
 47	79
+0
 [/Room]
 [Room]
 1	4	25

--- a/levels/skirmish/Stonekeep siege.level
+++ b/levels/skirmish/Stonekeep siege.level
@@ -4019,130 +4019,46 @@ ProtectDungeonTemple	NULL
 
 [Creatures]
 # SeatId	Name	MeshName	PosX	PosY	PosZ	ClassName	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	LeftWeapon	RightWeapon
-[Creature]
 1	Kobold90	Kobold	51	16	0	Kobold	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	Kobold91	Kobold	51	16	0	Kobold	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Kobold92	Kobold	7	55	0	Kobold	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Kobold93	Kobold	7	55	0	Kobold	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Kobold94	Kobold	91	55	0	Kobold	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Kobold95	Kobold	91	55	0	Kobold	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 4	Kobold96	Kobold	47	94	0	Kobold	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 4	Kobold97	Kobold	47	94	0	Kobold	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Dwarf99	Dwarf3	9	15	0	Dwarf3	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 0	Dwarf98	Dwarf3	9	16	0	Dwarf3	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 0	Dwarf97	Dwarf3	9	17	0	Dwarf3	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 0	Dwarf96	Dwarf3	9	18	0	Dwarf3	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 0	Dwarf95	Dwarf3	9	19	0	Dwarf3	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 0	Dwarf94	Dwarf3	9	20	0	Dwarf3	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 0	Dwarf93	Dwarf3	9	21	0	Dwarf3	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 0	Knight90	Knight	46	42	0	Knight	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 0	Knight91	Knight	47	42	0	Knight	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 0	Knight92	Knight	48	42	0	Knight	1	0	max	100	0	0	Roundshield	Sabre
-[/Creature]
-[Creature]
 0	Knight93	Knight	49	42	0	Knight	1	0	max	100	0	0	Roundshield	Sabre
-[/Creature]
-[Creature]
 0	Knight94	Knight	50	42	0	Knight	1	0	max	100	0	0	Roundshield	Sabre
-[/Creature]
-[Creature]
 0	Knight95	Knight	51	42	0	Knight	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 0	Knight96	Knight	52	42	0	Knight	1	0	max	100	0	0	Longsword	Longsword
-[/Creature]
-[Creature]
 0	Knight97	Knight	49	41	0	Knight	1	0	max	100	0	0	Longsword	Longsword
-[/Creature]
-[Creature]
 0	Dragon90	Dragon	86	20	0	Dragon	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Dragon91	Dragon	92	20	0	Dragon	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Dragon92	Dragon	89	25	0	Dragon	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Dragon93	Dragon	96	18	0	Dragon	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Tentacle90	Tentacle2	73	23	0	Tentacle2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Tentacle91	Tentacle2	73	23	0	Tentacle2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Tentacle92	Tentacle2	73	23	0	Tentacle2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Tentacle93	Tentacle2	73	23	0	Tentacle2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Tentacle94	Tentacle2	75	12	0	Tentacle2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Tentacle95	Tentacle2	75	12	0	Tentacle2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Tentacle96	Tentacle2	75	12	0	Tentacle2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Tentacle97	Tentacle2	75	12	0	Tentacle2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Tentacle98	Tentacle2	72	5	0	Tentacle2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Tentacle99	Tentacle2	72	5	0	Tentacle2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Tentacle100	Tentacle2	69	37	0	Tentacle2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Tentacle101	Tentacle2	69	37	0	Tentacle2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Tentacle102	Tentacle2	69	37	0	Tentacle2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 4	PitDemon90	PitDemon	48	57	0	PitDemon	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 4	PitDemon91	PitDemon	50	57	0	PitDemon	10	0	max	100	0	0	none	none
-[/Creature]
 [/Creatures]

--- a/levels/skirmish/TestSingleplayer.level
+++ b/levels/skirmish/TestSingleplayer.level
@@ -5881,103 +5881,37 @@ ProtectDungeonTemple	NULL
 
 [Creatures]
 # SeatId	Name	MeshName	PosX	PosY	PosZ	ClassName	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	LeftWeapon	RightWeapon
-[Creature]
 1	ConstructWorker1	ConstructWorker	193	206	0	ConstructWorker	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Gnome2	Gnome	194	311	0	Gnome	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Goblin3	Goblin	161	201	0	Goblin	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 5	PitDemon5	PitDemon	159	202	0	PitDemon	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Wizard7	Wizard	199	311	0	Wizard	1	0	max	100	0	0	Staff	none
-[/Creature]
-[Creature]
 3	Tentacle18	Tentacle1	162	198	0	Tentacle1	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 4	Tentacle29	Tentacle2	158	201	0	Tentacle2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 5	Troll10	Troll	186	235	0	Troll	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Knight_c2	Knight	192	311	0	Knight	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 3	Knight_c3	Knight	192	314	0	Knight	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 4	Knight_c4	Knight	196	315	0	Knight	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 5	Knight_c5	Knight	194	315	0	Knight	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 5	LizardMan_001	LizardMan	185	233	0	LizardMan	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 1	Kobold	Kobold	197	205	0	Kobold	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	Kobold_012	Kobold	193	205	0	Kobold	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 1	Kobold_007	Kobold	195	205	0	Kobold	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Dwarf1_001	Dwarf1	221	189	0	Dwarf1	1	0	max	100	0	0	Roundshield	Sabre
-[/Creature]
-[Creature]
 2	Dwarf1_002	Dwarf2	226	165	0	Dwarf2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Dwarf1_004	Dwarf3	213	157	0	Dwarf3	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Dwarf1_006	Dwarf2	214	141	0	Dwarf2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Dwarf1_007	Dwarf3	212	143	0	Dwarf3	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Dwarf2_001	Dwarf3	264	221	0	Dwarf3	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Dwarf2_002	Dwarf2	216	185	0	Dwarf2	1	0	max	100	0	0	none	Longsword
-[/Creature]
-[Creature]
 2	Dwarf3_001	Dwarf1	217	187	0	Dwarf1	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 3	LizardMan_002	LizardMan	229	168	0	LizardMan	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Kre	Kreatur	262	220	0	Kreatur	10	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Orc_0001	Orc	228	166	0	Orc	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Orc_0002	Orc	262	222	0	Orc	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Kreatur_001	Kreatur	161	113	0	Kreatur	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Kreatur_002	Kreatur	159	101	0	Kreatur	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Kreatur_003	Kreatur	176	98	0	Kreatur	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Kreatur_004	Kreatur	168	99	0	Kreatur	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Kreatur_006	Kreatur	162	100	0	Kreatur	1	0	max	100	0	0	none	none
-[/Creature]
 [/Creatures]

--- a/levels/skirmish/TestSingleplayer.level
+++ b/levels/skirmish/TestSingleplayer.level
@@ -8,12 +8,156 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	player	faction	startingX	startingY	color	startingGold
-1	1	Human	Keeper	195	207	1	1000
-2	2	AI	Keeper	200	200	2	1000
-3	3	AI	Keeper	200	200	3	1000
-4	4	AI	Keeper	266	95	4	1000
-5	5	Inactive	Keeper	200	200	5	1000
+[Seat]
+seatId	1
+teamId	1
+player	Human
+faction	Keeper
+startingX	195
+startingY	207
+colorId	1
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	2
+teamId	2
+player	AI
+faction	Keeper
+startingX	200
+startingY	200
+colorId	2
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	3
+teamId	3
+player	AI
+faction	Keeper
+startingX	200
+startingY	200
+colorId	3
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	4
+teamId	4
+player	AI
+faction	Keeper
+startingX	200
+startingY	200
+colorId	4
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	5
+teamId	5
+player	Inactive
+faction	Keeper
+startingX	200
+startingY	200
+colorId	5
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
 [/Seats]
 
 [Goals]
@@ -34,7 +178,7 @@ ProtectDungeonTemple	NULL
 # Map Size
 400 # MapSizeX
 400 # MapSizeY
-# posX	posY	type	fullness
+# posX	posY	type	fullness	seatId(optional)
 146	102	3	100
 146	103	3	100
 146	104	3	100
@@ -5915,3 +6059,27 @@ ProtectDungeonTemple	NULL
 3	Kreatur_004	Kreatur	168	99	0	Kreatur	1	0	max	100	0	0	none	none
 3	Kreatur_006	Kreatur	162	100	0	Kreatur	1	0	max	100	0	0	none	none
 [/Creatures]
+
+[Spells]
+# typeSpell	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData	
+[/Spells]
+
+[CraftedTraps]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	trapType	PosX	PosY	PosZ	
+[/CraftedTraps]
+
+[ResearchEntity]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ	
+[/ResearchEntity]
+
+[Missiles]
+# missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData	
+[/Missiles]
+
+[TreasuryObject]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	value	
+[/TreasuryObject]
+
+[Chickens]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	PosX	PosY	PosZ	
+[/Chickens]

--- a/levels/skirmish/TestSingleplayer.level
+++ b/levels/skirmish/TestSingleplayer.level
@@ -5890,6 +5890,7 @@ ProtectDungeonTemple	NULL
 262	210
 262	211
 262	212
+0	0
 [/Room]
 [Room]
 4	2	9

--- a/levels/skirmish/TestSingleplayerSmall.level
+++ b/levels/skirmish/TestSingleplayerSmall.level
@@ -1015,49 +1015,19 @@ ProtectDungeonTemple	NULL
 
 [Creatures]
 # SeatId	Name	MeshName	PosX	PosY	PosZ	ClassName	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	LeftWeapon	RightWeapon
-[Creature]
 1	DefaultWorker1	Kobold.mesh	11	11	0	DefaultWorker	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	DefaultWorker2	Kobold.mesh	12	39	0	DefaultWorker	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	BigKnight1	BigKnight	7	7	0	BigKnight	1	0	10	100	0	0	Longsword	none
-[/Creature]
-[Creature]
 1	Adventurer2	Adventurer	7	8	0	Adventurer	1	0	10	100	0	0	none	SpecialStaff
-[/Creature]
-[Creature]
 2	Adventurer3	Adventurer	7	40	0	Adventurer	1	0	10	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Dragon1	BigDragon	9	5	0	BigDragon	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Tentacle11	Tentacle1	5	15	0	Tentacle1	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Tentacle12	Tentacle1	5	11	0	Tentacle1	10	0	10	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Tentacle13	Tentacle1	5	13	0	Tentacle1	25	0	10	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Tentacle14	Tentacle1	5	9	0	Tentacle1	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Tentacle15	Tentacle1	5	7	0	Tentacle1	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Kobold2	Kobold	1	19	0	Kobold	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Orc3	Orc	3	20	0	Orc	1	0	0	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Wyvern1	Wyvern	15	18	0	Wyvern	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	DefaultWorker3	Kobold.mesh	12	9	0	DefaultWorker	1	0	max	100	0	0	none	none
-[/Creature]
 [/Creatures]

--- a/levels/skirmish/TestSingleplayerSmall.level
+++ b/levels/skirmish/TestSingleplayerSmall.level
@@ -8,11 +8,126 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	player	faction	startingX	startingY	color	gold	minedGold	mana
-1	1/2	Human	Keeper	10	10	1	1000	100	500
-2	1/2	AI	Hero	10	40	2	1000	100	500
-3	3	Choice	Choice	40	10	3	1000	100	500
-4	3	Choice	Choice	40	40	4	1000	100	500
+[Seat]
+seatId	1
+teamId	1/2
+player	Human
+faction	Keeper
+startingX	10
+startingY	10
+colorId	1
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	2
+teamId	1/2
+player	AI
+faction	Hero
+startingX	10
+startingY	40
+colorId	2
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	3
+teamId	3
+player	Choice
+faction	Choice
+startingX	40
+startingY	10
+colorId	3
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	4
+teamId	3
+player	Choice
+faction	Choice
+startingX	40
+startingY	40
+colorId	4
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
 [/Seats]
 
 [Goals]
@@ -33,7 +148,7 @@ ProtectDungeonTemple	NULL
 # Map Size
 50 # MapSizeX
 50 # MapSizeY
-# posX	posY	type	fullness
+# posX	posY	type	fullness	seatId(optional)
 0	1	1	0
 0	9	6	100	3
 0	10	6	100	3
@@ -977,6 +1092,7 @@ ProtectDungeonTemple	NULL
     WeakCoef	0
     FeeBase	0
     FeePerLevel	0
+    SleepHeal	1
     WeaponSpawnL	none
     WeaponSpawnL	none
     [/Stats]
@@ -1049,7 +1165,7 @@ ProtectDungeonTemple	NULL
 [/Missiles]
 
 [TreasuryObject]
-# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	PosX	PosY	PosZ	value	
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	value	
 [/TreasuryObject]
 
 [Chickens]

--- a/levels/skirmish/TestSingleplayerSmall.level
+++ b/levels/skirmish/TestSingleplayerSmall.level
@@ -911,6 +911,7 @@ ProtectDungeonTemple	NULL
 3	9
 3	10
 3	11
+0
 [/Room]
 [Room]
 1	3	25

--- a/levels/skirmish/TestSingleplayerSmall.level
+++ b/levels/skirmish/TestSingleplayerSmall.level
@@ -8,11 +8,11 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	player	faction	startingX	startingY	color	startingGold
-1	1/2	Human	Keeper	10	10	1	1000
-2	1/2	AI	Hero	10	40	2	1000
-3	3	Choice	Choice	40	10	3	1000
-4	3	Choice	Choice	40	40	4	1000
+# seatId	teamId	player	faction	startingX	startingY	color	gold	minedGold	mana
+1	1/2	Human	Keeper	10	10	1	1000	100	500
+2	1/2	AI	Hero	10	40	2	1000	100	500
+3	3	Choice	Choice	40	10	3	1000	100	500
+4	3	Choice	Choice	40	40	4	1000	100	500
 [/Seats]
 
 [Goals]
@@ -1031,3 +1031,27 @@ ProtectDungeonTemple	NULL
 0	Wyvern1	Wyvern	15	18	0	Wyvern	1	0	max	100	0	0	none	none
 2	DefaultWorker3	Kobold.mesh	12	9	0	DefaultWorker	1	0	max	100	0	0	none	none
 [/Creatures]
+
+[Spells]
+# typeSpell	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData	
+[/Spells]
+
+[CraftedTraps]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	trapType	PosX	PosY	PosZ	
+[/CraftedTraps]
+
+[ResearchEntity]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ	
+[/ResearchEntity]
+
+[Missiles]
+# missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData	
+[/Missiles]
+
+[TreasuryObject]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	PosX	PosY	PosZ	value	
+[/TreasuryObject]
+
+[Chickens]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	PosX	PosY	PosZ	
+[/Chickens]

--- a/levels/skirmish/TestSingleplayerSmallEmpty.level
+++ b/levels/skirmish/TestSingleplayerSmallEmpty.level
@@ -8,8 +8,36 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	player	faction	startingX	startingY	color	startingGold
-1	1	Choice	Keeper	10	10	1	1000
+[Seat]
+seatId	1
+teamId	1
+player	Human
+faction	Keeper
+startingX	10
+startingY	10
+colorId	1
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
 [/Seats]
 
 [Goals]
@@ -30,7 +58,7 @@ ProtectDungeonTemple	NULL
 # Map Size
 50 # MapSizeX
 50 # MapSizeY
-# posX	posY	type	fullness
+# posX	posY	type	fullness	seatId(optional)
 0	0	1	0
 0	1	1	0
 0	2	1	0
@@ -2599,3 +2627,27 @@ ProtectDungeonTemple	NULL
 1	ConstructWorker1	ConstructWorker	7	7	0	ConstructWorker	1	0	max	100	0	0	none	none
 0	Scarab1	Scarab	37	42	0	Scarab	1	0	max	100	0	0	none	none
 [/Creatures]
+
+[Spells]
+# typeSpell	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData	
+[/Spells]
+
+[CraftedTraps]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	trapType	PosX	PosY	PosZ	
+[/CraftedTraps]
+
+[ResearchEntity]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ	
+[/ResearchEntity]
+
+[Missiles]
+# missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData	
+[/Missiles]
+
+[TreasuryObject]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	value	
+[/TreasuryObject]
+
+[Chickens]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	PosX	PosY	PosZ	
+[/Chickens]

--- a/levels/skirmish/TestSingleplayerSmallEmpty.level
+++ b/levels/skirmish/TestSingleplayerSmallEmpty.level
@@ -2596,10 +2596,6 @@ ProtectDungeonTemple	NULL
 
 [Creatures]
 # SeatId	Name	MeshName	PosX	PosY	PosZ	ClassName	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	LeftWeapon	RightWeapon
-[Creature]
 1	ConstructWorker1	ConstructWorker	7	7	0	ConstructWorker	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Scarab1	Scarab	37	42	0	Scarab	1	0	max	100	0	0	none	none
-[/Creature]
 [/Creatures]

--- a/levels/skirmish/TestSingleplayerSmallPassability.level
+++ b/levels/skirmish/TestSingleplayerSmallPassability.level
@@ -180,13 +180,7 @@ ProtectDungeonTemple	NULL
 
 [Creatures]
 # SeatId	Name	MeshName	PosX	PosY	PosZ	ClassName	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	LeftWeapon	RightWeapon
-[Creature]
 1	ConstructWorker1	ConstructWorker	1	1	0	ConstructWorker	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	Lava	PitDemon	2	2	0	PitDemon	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	Water	Slime	2	2	0	Slime	1	0	max	100	0	0	none	none
-[/Creature]
 [/Creatures]

--- a/levels/skirmish/TestSingleplayerSmallPassability.level
+++ b/levels/skirmish/TestSingleplayerSmallPassability.level
@@ -8,8 +8,36 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	player	faction	startingX	startingY	color	startingGold
-1	1	Human	Keeper	1	1	1	1000
+[Seat]
+seatId	1
+teamId	1
+player	Human
+faction	Keeper
+startingX	1
+startingY	1
+colorId	1
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
 [/Seats]
 
 [Goals]
@@ -30,7 +58,7 @@ ProtectDungeonTemple	NULL
 # Map Size
 10 # MapSizeX
 10 # MapSizeY
-# posX	posY	type	fullness
+# posX	posY	type	fullness	seatId(optional)
 0	0	1	0
 0	2	1	0
 0	3	1	0
@@ -184,3 +212,27 @@ ProtectDungeonTemple	NULL
 1	Lava	PitDemon	2	2	0	PitDemon	1	0	max	100	0	0	none	none
 1	Water	Slime	2	2	0	Slime	1	0	max	100	0	0	none	none
 [/Creatures]
+
+[Spells]
+# typeSpell	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData	
+[/Spells]
+
+[CraftedTraps]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	trapType	PosX	PosY	PosZ	
+[/CraftedTraps]
+
+[ResearchEntity]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ	
+[/ResearchEntity]
+
+[Missiles]
+# missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData	
+[/Missiles]
+
+[TreasuryObject]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	value	
+[/TreasuryObject]
+
+[Chickens]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	PosX	PosY	PosZ	
+[/Chickens]

--- a/levels/skirmish/The Bridge.level
+++ b/levels/skirmish/The Bridge.level
@@ -8,9 +8,66 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	player	faction	startingX	startingY	color	startingGold
-1	1	Choice	Choice	50	79	1	1000
-2	2	Choice	Choice	50	21	2	1000
+[Seat]
+seatId	1
+teamId	1
+player	Choice
+faction	Choice
+startingX	50
+startingY	79
+colorId	1
+gold	1000
+goldMined	0
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	2
+teamId	2
+player	Choice
+faction	Choice
+startingX	50
+startingY	21
+colorId	2
+gold	1000
+goldMined	0
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
 [/Seats]
 
 [Goals]
@@ -23,7 +80,7 @@ ProtectDungeonTemple	NULL
 # Map Size
 100 # MapSizeX
 100 # MapSizeY
-# posX	posY	type	fullness
+# posX	posY	type	fullness	seatId(optional)
 0	0	3	100
 0	1	3	100
 0	2	3	100
@@ -4421,3 +4478,27 @@ ProtectDungeonTemple	NULL
 0	Spider17	Spider	50	57	0	Spider	3	0	max	100	0	0	none	none
 0	Spider18	Spider	51	59	0	Spider	3	0	max	100	0	0	none	none
 [/Creatures]
+
+[Spells]
+# typeSpell	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData	
+[/Spells]
+
+[CraftedTraps]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	trapType	PosX	PosY	PosZ	
+[/CraftedTraps]
+
+[ResearchEntity]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ	
+[/ResearchEntity]
+
+[Missiles]
+# missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData	
+[/Missiles]
+
+[TreasuryObject]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	value	
+[/TreasuryObject]
+
+[Chickens]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	PosX	PosY	PosZ	
+[/Chickens]

--- a/levels/skirmish/The Bridge.level
+++ b/levels/skirmish/The Bridge.level
@@ -4402,58 +4402,22 @@ ProtectDungeonTemple	NULL
 
 [Creatures]
 # SeatId	Name	MeshName	PosX	PosY	PosZ	ClassName	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	LeftWeapon	RightWeapon
-[Creature]
 0	Spider1	Spider	17	67	0	Spider	2	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Spider2	Spider	16	67	0	Spider	2	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Spider3	Spider	15	67	0	Spider	2	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Spider4	Spider	16	68	0	Spider	2	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Spider5	Spider	16	66	0	Spider	2	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Spider6	Spider	83	33	0	Spider	2	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Spider7	Spider	84	33	0	Spider	2	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Spider8	Spider	82	33	0	Spider	2	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Spider9	Spider	83	34	0	Spider	2	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Spider10	Spider	83	32	0	Spider	2	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Spider11	Spider	50	41	0	Spider	3	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Spider12	Spider	51	43	0	Spider	3	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Spider13	Spider	50	45	0	Spider	3	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Spider14	Spider	51	47	0	Spider	3	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Spider15	Spider	50	53	0	Spider	3	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Spider16	Spider	51	55	0	Spider	3	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Spider17	Spider	50	57	0	Spider	3	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 0	Spider18	Spider	51	59	0	Spider	3	0	max	100	0	0	none	none
-[/Creature]
 [/Creatures]

--- a/levels/skirmish/oldTest.level
+++ b/levels/skirmish/oldTest.level
@@ -8,12 +8,156 @@ FightMusic	The_Dark_Amulet.ogg
 [/Info]
 
 [Seats]
-# seatId	teamId	player	faction	startingX	startingY	color	startingGold
-1	1	Human	Keeper	200	200	1	1000
-2	2	AI	Choice	200	200	2	1000
-3	3	AI	Choice	200	200	3	1000
-4	4	Inactive	Keeper	200	200	4	1000
-5	5	Inactive	Keeper	200	200	5	1000
+[Seat]
+seatId	1
+teamId	1
+player	Human
+faction	Keeper
+startingX	200
+startingY	200
+colorId	1
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	2
+teamId	2
+player	AI
+faction	Keeper
+startingX	10
+startingY	10
+colorId	2
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	3
+teamId	3
+player	AI
+faction	Keeper
+startingX	10
+startingY	10
+colorId	3
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	4
+teamId	4
+player	Inactive
+faction	Keeper
+startingX	10
+startingY	10
+colorId	4
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
+[Seat]
+seatId	5
+teamId	5
+player	Inactive
+faction	Keeper
+startingX	10
+startingY	10
+colorId	5
+gold	1000
+goldMined	100
+mana	500
+[ResearchDone]
+roomTreasury
+roomDormitory
+roomHatchery
+roomLibrary
+trapCannon
+spellSummonWorker
+[/ResearchDone]
+[ResearchNotAllowed]
+[/ResearchNotAllowed]
+[ResearchPending]
+roomTrainingHall
+spellCallToWar
+trapSpike
+roomForge
+roomCrypt
+trapBoulder
+[/ResearchPending]
+[/Seat]
 [/Seats]
 
 [Goals]
@@ -35,7 +179,7 @@ ProtectDungeonTemple	NULL
 # Map Size
 400 # MapSizeX
 400 # MapSizeY
-# posX	posY	type	fullness
+# posX	posY	type	fullness	seatId(optional)
 146	102	3	100
 146	103	3	100
 146	104	3	100
@@ -6698,3 +6842,27 @@ ProtectDungeonTemple	NULL
 3	Kreatur_004	Kreatur	156	106	0	Kreatur	1	0	max	100	0	0	none	none
 3	Kreatur_005	Kreatur	163	112	0	Kreatur	1	0	max	100	0	0	none	none
 [/Creatures]
+
+[Spells]
+# typeSpell	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData	
+[/Spells]
+
+[CraftedTraps]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	trapType	PosX	PosY	PosZ	
+[/CraftedTraps]
+
+[ResearchEntity]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ	
+[/ResearchEntity]
+
+[Missiles]
+# missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData	
+[/Missiles]
+
+[TreasuryObject]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	value	
+[/TreasuryObject]
+
+[Chickens]
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	PosX	PosY	PosZ	
+[/Chickens]

--- a/levels/skirmish/oldTest.level
+++ b/levels/skirmish/oldTest.level
@@ -6551,6 +6551,7 @@ ProtectDungeonTemple	NULL
 2	1	2
 195	213
 194	213
+0
 [/Room]
 [Room]
 1	1	25
@@ -6634,6 +6635,7 @@ ProtectDungeonTemple	NULL
 206	209
 206	210
 206	211
+0
 [/Room]
 [Room]
 1	2	25
@@ -6718,6 +6720,7 @@ ProtectDungeonTemple	NULL
 174	100
 174	101
 174	102
+0
 [/Room]
 [Room]
 2	3	16
@@ -6737,6 +6740,7 @@ ProtectDungeonTemple	NULL
 170	98
 170	99
 170	100
+0
 [/Room]
 [Room]
 1	3	25

--- a/levels/skirmish/oldTest.level
+++ b/levels/skirmish/oldTest.level
@@ -6643,166 +6643,58 @@ ProtectDungeonTemple	NULL
 
 [Creatures]
 # SeatId	Name	MeshName	PosX	PosY	PosZ	ClassName	Level	CurrentXP	CurrentHP	CurrentAwakeness	CurrentHunger	GoldToDeposit	LeftWeapon	RightWeapon
-[Creature]
 1	Adventurer_001	Adventurer	196	200	0	Adventurer	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	ConstructWorker1	ConstructWorker	196	230	0	ConstructWorker	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Gnome2	Gnome	192	229	0	Gnome	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	Goblin3	Goblin	183	229	0	Goblin	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 5	PitDemon5	PitDemon	210	236	0	PitDemon	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	Spider6	Spider	198	231	0	Spider	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	CaveHornet1	CaveHornet	198	231	0	CaveHornet	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Wizard7	Wizard	190	229	0	Wizard	1	0	max	100	0	0	Staff	none
-[/Creature]
-[Creature]
 3	Tentacle18	Tentacle1	186	229	0	Tentacle1	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 4	Tentacle29	Tentacle2	203	230	0	Tentacle2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 5	Troll10	Troll	209	231	0	Troll	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	Troll11	Troll	193	214	0	Troll	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 1	Knight_c1	Knight	198	233	0	Knight	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 2	Knight_c2	Knight	192	233	0	Knight	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 3	Knight_c3	Knight	184	233	0	Knight	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 4	Knight_c4	Knight	204	233	0	Knight	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 5	Knight_c5	Knight	210	233	0	Knight	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 5	LizardMan_001	LizardMan	210	233	0	LizardMan	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 1	Kobold	Kobold	195	202	0	Kobold	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	Kobold_012	Kobold	188	200	0	Kobold	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 1	Kobold_007	Kobold	193	218	0	Kobold	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	Mage	Wizard	193	213	0	Wizard	1	0	max	100	0	0	Staff	none
-[/Creature]
-[Creature]
 1	Wiz	Wizard	193	213	0	Wizard	1	0	max	100	0	0	Staff	none
-[/Creature]
-[Creature]
 1	King	BigKnight	191	216	0	BigKnight	1	0	max	100	0	0	Roundshield	Staff
-[/Creature]
-[Creature]
 1	Knight_005	Knight	229	138	0	Knight	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 1	Knight_004	Knight	196	200	0	Knight	1	0	max	100	0	0	Longsword	none
-[/Creature]
-[Creature]
 1	Knight_006	Knight	199	204	0	Knight	1	0	max	100	0	0	Longsword	Sabre
-[/Creature]
-[Creature]
 1	Knight	Knight	188	198	0	Knight	1	0	max	100	0	0	none	Sabre
-[/Creature]
-[Creature]
 1	Knight_007	Knight	191	207	0	Knight	1	0	max	100	0	0	none	Sabre
-[/Creature]
-[Creature]
 1	Knight_003	Knight	184	201	0	Knight	1	0	max	100	0	0	none	Longsword
-[/Creature]
-[Creature]
 1	Dragon_001	Dragon	159	108	0	Dragon	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	Dragon_002	Dragon	191	193	0	Dragon	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	Dragon_003	Dragon	193	204	0	Dragon	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	Dragon_004	Dragon	196	214	0	Dragon	5	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	Wyvern_001	Wyvern	177	90	0	Wyvern	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	Wyvern_002	Wyvern	186	85	0	Wyvern	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 1	Wyvern_003	Wyvern	183	105	0	Wyvern	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Dwarf1_001	Dwarf1	201	192	0	Dwarf1	1	0	max	100	0	0	Roundshield	Sabre
-[/Creature]
-[Creature]
 2	Dwarf2_001	Dwarf2	206	168	0	Dwarf2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Dwarf3_001	Dwarf3	213	157	0	Dwarf3	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Dwarf2_002	Dwarf2	214	141	0	Dwarf2	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Dwarf3_002	Dwarf3	212	143	0	Dwarf3	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Dwarf3_003	Dwarf3	213	213	0	Dwarf3	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Dwarf2_003	Dwarf2	202	191	0	Dwarf2	1	0	max	100	0	0	none	Longsword
-[/Creature]
-[Creature]
 2	Dwarf1_002	Dwarf1	201	192	0	Dwarf1	1	0	max	100	0	0	Roundshield	Longsword
-[/Creature]
-[Creature]
 3	LizardMan_002	LizardMan	206	172	0	LizardMan	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Kre	Kreatur	215	216	0	Kreatur	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 2	Orc_001	Orc	203	199	0	Orc	1	0	max	100	0	0	none	Longsword
-[/Creature]
-[Creature]
 2	Orc_002	Orc	207	212	0	Orc	1	0	max	100	0	0	none	Longsword
-[/Creature]
-[Creature]
 3	Kreatur_001	Kreatur	155	110	0	Kreatur	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Kreatur_002	Kreatur	159	112	0	Kreatur	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Kreatur_003	Kreatur	158	103	0	Kreatur	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Kreatur_004	Kreatur	156	106	0	Kreatur	1	0	max	100	0	0	none	none
-[/Creature]
-[Creature]
 3	Kreatur_005	Kreatur	163	112	0	Kreatur	1	0	max	100	0	0	none	none
-[/Creature]
 [/Creatures]

--- a/levels/skirmish/oldTest.level
+++ b/levels/skirmish/oldTest.level
@@ -6598,6 +6598,7 @@ ProtectDungeonTemple	NULL
 188	202
 188	203
 188	204
+0	0
 [/Room]
 [Room]
 4	1	9
@@ -6680,6 +6681,7 @@ ProtectDungeonTemple	NULL
 212	210
 212	211
 212	212
+0	0
 [/Room]
 [Room]
 4	2	9

--- a/source/ai/KeeperAI.cpp
+++ b/source/ai/KeeperAI.cpp
@@ -484,11 +484,11 @@ bool KeeperAI::lookForGold()
 bool KeeperAI::buildMostNeededRoom()
 {
     uint32_t nbDormitory = 0;
-    if(mPlayer.isRoomAvailableForPlayer(RoomType::dormitory))
+    if(mPlayer.getSeat()->isRoomAvailable(RoomType::dormitory))
     {
         std::vector<Room*> rooms = mGameMap.getRoomsByTypeAndSeat(RoomType::dormitory, mPlayer.getSeat());
         nbDormitory = rooms.size();
-        if(mPlayer.isRoomAvailableForPlayer(RoomType::dormitory) && nbDormitory == 0)
+        if(mPlayer.getSeat()->isRoomAvailable(RoomType::dormitory) && nbDormitory == 0)
         {
             std::vector<Tile*> tiles;
             int goldRequired;
@@ -506,7 +506,7 @@ bool KeeperAI::buildMostNeededRoom()
         }
     }
 
-    if(mPlayer.isRoomAvailableForPlayer(RoomType::treasury))
+    if(mPlayer.getSeat()->isRoomAvailable(RoomType::treasury))
     {
         std::vector<Room*> treasuriesOwned = mGameMap.getRoomsByTypeAndSeat(RoomType::treasury,
             mPlayer.getSeat());
@@ -537,7 +537,7 @@ bool KeeperAI::buildMostNeededRoom()
         }
     }
 
-    if(mPlayer.isRoomAvailableForPlayer(RoomType::hatchery))
+    if(mPlayer.getSeat()->isRoomAvailable(RoomType::hatchery))
     {
         std::vector<Room*> rooms = mGameMap.getRoomsByTypeAndSeat(RoomType::hatchery, mPlayer.getSeat());
         if(rooms.empty())
@@ -558,7 +558,7 @@ bool KeeperAI::buildMostNeededRoom()
         }
     }
 
-    if(mPlayer.isRoomAvailableForPlayer(RoomType::trainingHall))
+    if(mPlayer.getSeat()->isRoomAvailable(RoomType::trainingHall))
     {
         std::vector<Room*> rooms = mGameMap.getRoomsByTypeAndSeat(RoomType::trainingHall, mPlayer.getSeat());
         if(rooms.empty())
@@ -579,7 +579,7 @@ bool KeeperAI::buildMostNeededRoom()
         }
     }
 
-    if(mPlayer.isRoomAvailableForPlayer(RoomType::forge))
+    if(mPlayer.getSeat()->isRoomAvailable(RoomType::forge))
     {
         std::vector<Room*> rooms = mGameMap.getRoomsByTypeAndSeat(RoomType::forge, mPlayer.getSeat());
         if(rooms.empty())
@@ -600,7 +600,7 @@ bool KeeperAI::buildMostNeededRoom()
         }
     }
 
-    if(mPlayer.isRoomAvailableForPlayer(RoomType::library))
+    if(mPlayer.getSeat()->isRoomAvailable(RoomType::library))
     {
         std::vector<Room*> rooms = mGameMap.getRoomsByTypeAndSeat(RoomType::library, mPlayer.getSeat());
         if(rooms.empty())
@@ -621,7 +621,7 @@ bool KeeperAI::buildMostNeededRoom()
         }
     }
 
-    if(mPlayer.isRoomAvailableForPlayer(RoomType::crypt))
+    if(mPlayer.getSeat()->isRoomAvailable(RoomType::crypt))
     {
         std::vector<Room*> rooms = mGameMap.getRoomsByTypeAndSeat(RoomType::crypt, mPlayer.getSeat());
         if(rooms.empty())
@@ -643,7 +643,7 @@ bool KeeperAI::buildMostNeededRoom()
     }
 
     // Once we have done all the basic buildings, we go for another dormitory
-    if(mPlayer.isRoomAvailableForPlayer(RoomType::dormitory) && nbDormitory == 1)
+    if(mPlayer.getSeat()->isRoomAvailable(RoomType::dormitory) && nbDormitory == 1)
     {
         std::vector<Tile*> tiles;
         int goldRequired;

--- a/source/entities/ChickenEntity.cpp
+++ b/source/entities/ChickenEntity.cpp
@@ -289,8 +289,20 @@ ChickenEntity* ChickenEntity::getChickenEntityFromPacket(GameMap* gameMap, ODPac
     return obj;
 }
 
-const char* ChickenEntity::getFormat()
+void ChickenEntity::exportToStream(std::ostream& os) const
 {
-    // TODO : implement saving/loading in the level file
-    return "position";
+    RenderedMovableEntity::exportToStream(os);
+    os << mPosition.x << "\t" << mPosition.y << "\t" << mPosition.z << "\t";
+}
+
+void ChickenEntity::importFromStream(std::istream& is)
+{
+    RenderedMovableEntity::importFromStream(is);
+    OD_ASSERT_TRUE(is >> mPosition.x >> mPosition.y >> mPosition.z);
+}
+
+std::string ChickenEntity::getChickenEntityStreamFormat()
+{
+    return RenderedMovableEntity::getRenderedMovableEntityStreamFormat()
+        + "PosX\tPosY\tPosZ\t";
 }

--- a/source/entities/ChickenEntity.h
+++ b/source/entities/ChickenEntity.h
@@ -36,25 +36,28 @@ public:
     ChickenEntity(GameMap* gameMap, const std::string& hatcheryName);
     ChickenEntity(GameMap* gameMap);
 
-    virtual void doUpkeep();
+    virtual void doUpkeep() override;
 
     virtual GameEntityType getObjectType() const override
     { return GameEntityType::chickenEntity; }
 
-    virtual bool tryPickup(Seat* seat);
-    virtual void pickup();
-    virtual bool tryDrop(Seat* seat, Tile* tile);
+    virtual bool tryPickup(Seat* seat) override;
+    virtual void pickup() override;
+    virtual bool tryDrop(Seat* seat, Tile* tile) override;
 
     bool eatChicken(Creature* creature);
 
-    bool canSlap(Seat* seat);
+    bool canSlap(Seat* seat) override;
 
-    void slap()
+    void slap() override
     { mIsSlapped = true; }
+
+    void exportToStream(std::ostream& os) const override;
+    void importFromStream(std::istream& is) override;
 
     static ChickenEntity* getChickenEntityFromStream(GameMap* gameMap, std::istream& is);
     static ChickenEntity* getChickenEntityFromPacket(GameMap* gameMap, ODPacket& is);
-    static const char* getFormat();
+    static std::string getChickenEntityStreamFormat();
 private:
     enum ChickenState
     {

--- a/source/entities/CraftedTrap.cpp
+++ b/source/entities/CraftedTrap.cpp
@@ -111,8 +111,20 @@ CraftedTrap* CraftedTrap::getCraftedTrapFromPacket(GameMap* gameMap, ODPacket& i
     return obj;
 }
 
-const char* CraftedTrap::getFormat()
+void CraftedTrap::exportToStream(std::ostream& os) const
 {
-    // TODO : implement saving/loading in the level file
-    return "position";
+    RenderedMovableEntity::exportToStream(os);
+    os << mTrapType << mPosition.x << "\t" << mPosition.y << "\t" << mPosition.z << "\t";
+}
+
+void CraftedTrap::importFromStream(std::istream& is)
+{
+    RenderedMovableEntity::importFromStream(is);
+    OD_ASSERT_TRUE(is >> mTrapType >> mPosition.x >> mPosition.y >> mPosition.z);
+}
+
+std::string CraftedTrap::getCraftedTrapStreamFormat()
+{
+    return RenderedMovableEntity::getRenderedMovableEntityStreamFormat()
+        + "trapType\tPosX\tPosY\tPosZ\t";
 }

--- a/source/entities/CraftedTrap.h
+++ b/source/entities/CraftedTrap.h
@@ -46,15 +46,18 @@ public:
     TrapType getTrapType() const
     { return mTrapType; }
 
-    virtual EntityCarryType getEntityCarryType()
+    virtual EntityCarryType getEntityCarryType() override
     { return EntityCarryType::craftedTrap; }
 
-    virtual void notifyEntityCarryOn(Creature* carrier);
-    virtual void notifyEntityCarryOff(const Ogre::Vector3& position);
+    virtual void notifyEntityCarryOn(Creature* carrier) override;
+    virtual void notifyEntityCarryOff(const Ogre::Vector3& position) override;
+
+    void exportToStream(std::ostream& os) const override;
+    void importFromStream(std::istream& is) override;
 
     static CraftedTrap* getCraftedTrapFromStream(GameMap* gameMap, std::istream& is);
     static CraftedTrap* getCraftedTrapFromPacket(GameMap* gameMap, ODPacket& is);
-    static const char* getFormat();
+    static std::string getCraftedTrapStreamFormat();
 private:
     TrapType mTrapType;
 

--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -908,10 +908,6 @@ void Creature::decidePrioritaryAction()
             // We check if we can attack a natural enemy
             if(Random::Int(0, 100) > 80)
             {
-                clearDestinations();
-                clearActionQueue();
-                stopJob();
-                stopEating();
                 pushAction(CreatureActionType::fightNaturalEnemy, true);
                 return;
             }
@@ -2823,6 +2819,13 @@ bool Creature::handleFightAlliedNaturalEnemyAction(const CreatureAction& actionI
     {
         if(entityAttack != nullptr)
         {
+            // We found a natural enemy. We stop what we were doing
+            clearDestinations();
+            clearActionQueue();
+            stopJob();
+            stopEating();
+
+            // And we attack
             OD_ASSERT_TRUE_MSG(entityAttack->getObjectType() == GameEntityType::creature, "attacker=" + getName() + ", attacked=" + entityAttack->getName());
             Creature* attackedCreature = static_cast<Creature*>(entityAttack);
             attackedCreature->engageAlliedNaturalEnemy(this);

--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -543,6 +543,8 @@ void Creature::importFromPacket(ODPacket& is)
 void Creature::setPosition(const Ogre::Vector3& v, bool isMove)
 {
     MovableGameEntity::setPosition(v, isMove);
+    if(mCarriedEntity != nullptr)
+        mCarriedEntity->notifyCarryMove(v);
 }
 
 void Creature::drop(const Ogre::Vector3& v)

--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -337,10 +337,10 @@ void Creature::removeFromGameMap()
     getGameMap()->removeActiveObject(this);
 }
 
-
-std::string Creature::getFormat()
+std::string Creature::getCreatureStreamFormat()
 {
-    return "SeatId\tName\tMeshName\tPosX\tPosY\tPosZ\tClassName\tLevel\tCurrentXP\tCurrentHP\tCurrentAwakeness\t"
+    return MovableGameEntity::getMovableGameEntityStreamFormat()
+        + "ClassName\tLevel\tCurrentXP\tCurrentHP\tCurrentAwakeness\t"
            "CurrentHunger\tGoldToDeposit\tLeftWeapon\tRightWeapon";
 }
 

--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -2966,7 +2966,6 @@ void Creature::refreshCreature(ODPacket& packet)
 {
     OD_ASSERT_TRUE(packet >> mLevel);
     OD_ASSERT_TRUE(packet >> mOverlayHealthValue);
-    // DAN_TEST modifier overlay
     RenderManager::getSingleton().rrScaleEntity(this);
 }
 

--- a/source/entities/Creature.h
+++ b/source/entities/Creature.h
@@ -284,10 +284,9 @@ public:
     inline void setOverlayStatus(CreatureOverlayStatus* overlayStatus)
     { mOverlayStatus = overlayStatus; }
 
-    //! \FIXME Those functions are lacking parameters to be actually functional
     //! \brief Get the text format of creatures in level files (already spawned at startup).
     //! \returns A string describing the IO format the creatures need to have in file.
-    static std::string getFormat();
+    static std::string getCreatureStreamFormat();
 
     static Creature* getCreatureFromStream(GameMap* gameMap, std::istream& is);
     static Creature* getCreatureFromPacket(GameMap* gameMap, ODPacket& is);

--- a/source/entities/GameEntity.cpp
+++ b/source/entities/GameEntity.cpp
@@ -266,7 +266,8 @@ void GameEntity::fireRemoveEntityToSeatsWithVision()
 
 void GameEntity::exportHeadersToStream(std::ostream& os)
 {
-    os << getObjectType() << "\t";
+    // GameEntity are saved in the level file per type. For this reason, there is no
+    // need to save the type
 }
 
 void GameEntity::exportHeadersToPacket(ODPacket& os)
@@ -322,11 +323,14 @@ void GameEntity::importFromStream(std::istream& is)
     OD_ASSERT_TRUE(is >> mPosition.x >> mPosition.y >> mPosition.z);
 }
 
-GameEntity* GameEntity::getGameEntityeEntityFromStream(GameMap* gameMap, std::istream& is)
+std::string GameEntity::getGameEntityStreamFormat()
+{
+    return "SeatId\tName\tMeshName\tPosX\tPosY\tPosZ\t";
+}
+
+GameEntity* GameEntity::getGameEntityeEntityFromStream(GameMap* gameMap, GameEntityType type, std::istream& is)
 {
     GameEntity* entity = nullptr;
-    GameEntityType type;
-    OD_ASSERT_TRUE(is >> type);
     switch(type)
     {
         case GameEntityType::buildingObject:

--- a/source/entities/GameEntity.h
+++ b/source/entities/GameEntity.h
@@ -306,8 +306,10 @@ class GameEntity
     virtual void exportToPacket(ODPacket& os) const;
     virtual void importFromPacket(ODPacket& is);
 
-    static GameEntity* getGameEntityeEntityFromStream(GameMap* gameMap, std::istream& is);
+    static GameEntity* getGameEntityeEntityFromStream(GameMap* gameMap, GameEntityType type, std::istream& is);
     static GameEntity* getGameEntityFromPacket(GameMap* gameMap, ODPacket& is);
+
+    static std::string getGameEntityStreamFormat();
 
   protected:
     //! \brief Function that implements the mesh creation

--- a/source/entities/GameEntity.h
+++ b/source/entities/GameEntity.h
@@ -291,6 +291,14 @@ class GameEntity
     virtual void restoreEntityState()
     {}
 
+    /*! This function should be called on server side on entities loaded from level files and only them. It will
+     * be called after all entities are created and added to the gamemap on all of them to allow to restore
+     * links between entities (like beds and creatures). It will be called on Creature, Room, Trap, RenderedMovableEntity
+     * and Spell
+     */
+    virtual void restoreInitialEntityState()
+    {}
+
     /*! \brief Exports the headers needed to recreate the GameEntity. For example, for missile objects
      * type cannon, it exports GameEntityType::missileObject and MissileType::oneHit. The content of the
      * GameEntityType will be exported by exportToPacket. exportHeadersTo* should export the needed information

--- a/source/entities/GameEntity.h
+++ b/source/entities/GameEntity.h
@@ -276,9 +276,13 @@ class GameEntity
     virtual void notifyEntityCarryOn(Creature* carrier)
     {}
 
-    //! \brief Called when the entity is being carried
+    //! \brief Called when the entity is being carried and is dropped
     virtual void notifyEntityCarryOff(const Ogre::Vector3& position)
     {}
+
+    //! \brief Called when the entity is being carriedand moves
+    virtual void notifyCarryMove(const Ogre::Vector3& position)
+    { mPosition = position; }
 
     //! This function should be called on client side just after the entity is added to the gamemap.
     //! It should restore the entity state (if it was dead before the client got vision, it should

--- a/source/entities/MapLight.cpp
+++ b/source/entities/MapLight.cpp
@@ -264,7 +264,7 @@ void MapLight::slap()
     return;
 }
 
-std::string MapLight::getFormat()
+std::string MapLight::getMapLightStreamFormat()
 {
     return "posX\tposY\tposZ\tdiffuseR\tdiffuseG\tdiffuseB\tspecularR\tspecularG\tspecularB\tattenRange\tattenConst\tattenLin\tattenQuad";
 }

--- a/source/entities/MapLight.h
+++ b/source/entities/MapLight.h
@@ -117,7 +117,7 @@ public:
     static MapLight* getMapLightFromStream(GameMap* gameMap, std::istream& is);
     static MapLight* getMapLightFromPacket(GameMap* gameMap, ODPacket& is);
 
-    static std::string getFormat();
+    static std::string getMapLightStreamFormat();
     virtual void exportToStream(std::ostream& os) const override;
     virtual void importFromStream(std::istream& is) override;
     virtual void exportToPacket(ODPacket& os) const override;

--- a/source/entities/MissileBoulder.cpp
+++ b/source/entities/MissileBoulder.cpp
@@ -86,3 +86,17 @@ MissileBoulder* MissileBoulder::getMissileBoulderFromPacket(GameMap* gameMap, OD
     MissileBoulder* obj = new MissileBoulder(gameMap);
     return obj;
 }
+
+void MissileBoulder::exportToStream(std::ostream& os) const
+{
+    MissileObject::exportToStream(os);
+    os << mDamage << "\t";
+    os << mNbHits << "\t";
+}
+
+void MissileBoulder::importFromStream(std::istream& is)
+{
+    MissileObject::importFromStream(is);
+    OD_ASSERT_TRUE(is >> mDamage);
+    OD_ASSERT_TRUE(is >> mNbHits);
+}

--- a/source/entities/MissileBoulder.h
+++ b/source/entities/MissileBoulder.h
@@ -37,11 +37,14 @@ public:
         const Ogre::Vector3& direction, double damage);
     MissileBoulder(GameMap* gameMap);
 
-    virtual MissileType getMissileType()
-    { return MissileType::boulder; }
+    virtual MissileObjectType getMissileType() const override
+    { return MissileObjectType::boulder; }
 
-    virtual bool hitCreature(GameEntity* entity);
-    virtual bool wallHitNextDirection(const Ogre::Vector3& actDirection, Tile* tile, Ogre::Vector3& nextDirection);
+    virtual bool hitCreature(GameEntity* entity) override;
+    virtual bool wallHitNextDirection(const Ogre::Vector3& actDirection, Tile* tile, Ogre::Vector3& nextDirection) override;
+
+    void exportToStream(std::ostream& os) const override;
+    void importFromStream(std::istream& is) override;
 
     static MissileBoulder* getMissileBoulderFromStream(GameMap* gameMap, std::istream& is);
     static MissileBoulder* getMissileBoulderFromPacket(GameMap* gameMap, ODPacket& packet);

--- a/source/entities/MissileObject.cpp
+++ b/source/entities/MissileObject.cpp
@@ -191,19 +191,41 @@ void MissileObject::exportHeadersToPacket(ODPacket& os)
     os << getMissileType();
 }
 
+void MissileObject::exportToStream(std::ostream& os) const
+{
+    RenderedMovableEntity::exportToStream(os);
+    os << mDirection.x << "\t" << mDirection.y << "\t" << mDirection.z << "\t";
+    os << mIsMissileAlive << "\t";
+    os << mDamageAllies << "\t";
+}
+
+void MissileObject::importFromStream(std::istream& is)
+{
+    RenderedMovableEntity::importFromStream(is);
+    OD_ASSERT_TRUE(is >> mDirection.x >> mDirection.y >> mDirection.z);
+    OD_ASSERT_TRUE(is >> mIsMissileAlive);
+    OD_ASSERT_TRUE(is >> mDamageAllies);
+}
+
+std::string MissileObject::getMissileObjectStreamFormat()
+{
+    return "missileType\t" + RenderedMovableEntity::getRenderedMovableEntityStreamFormat()
+    + "directionX\tdirectionY\tdirectionZ\tmissileAlive\tdamageAllies\toptionalData\t";
+}
+
 MissileObject* MissileObject::getMissileObjectFromStream(GameMap* gameMap, std::istream& is)
 {
     MissileObject* obj = nullptr;
-    MissileType type;
+    MissileObjectType type;
     OD_ASSERT_TRUE(is >> type);
     switch(type)
     {
-        case MissileType::oneHit:
+        case MissileObjectType::oneHit:
         {
             obj = MissileOneHit::getMissileOneHitFromStream(gameMap, is);
             break;
         }
-        case MissileType::boulder:
+        case MissileObjectType::boulder:
         {
             obj = MissileBoulder::getMissileBoulderFromStream(gameMap, is);
             break;
@@ -219,16 +241,16 @@ MissileObject* MissileObject::getMissileObjectFromStream(GameMap* gameMap, std::
 MissileObject* MissileObject::getMissileObjectFromPacket(GameMap* gameMap, ODPacket& is)
 {
     MissileObject* obj = nullptr;
-    MissileType type;
+    MissileObjectType type;
     OD_ASSERT_TRUE(is >> type);
     switch(type)
     {
-        case MissileType::oneHit:
+        case MissileObjectType::oneHit:
         {
             obj = MissileOneHit::getMissileOneHitFromPacket(gameMap, is);
             break;
         }
-        case MissileType::boulder:
+        case MissileObjectType::boulder:
         {
             obj = MissileBoulder::getMissileBoulderFromPacket(gameMap, is);
             break;
@@ -241,32 +263,32 @@ MissileObject* MissileObject::getMissileObjectFromPacket(GameMap* gameMap, ODPac
     return obj;
 }
 
-ODPacket& operator<<(ODPacket& os, const MissileObject::MissileType& type)
+ODPacket& operator<<(ODPacket& os, const MissileObjectType& type)
 {
-    uint32_t intType = static_cast<MissileObject::MissileType>(type);
+    uint32_t intType = static_cast<uint32_t>(type);
     os << intType;
     return os;
 }
 
-ODPacket& operator>>(ODPacket& is, MissileObject::MissileType& type)
+ODPacket& operator>>(ODPacket& is, MissileObjectType& type)
 {
     uint32_t intType;
     is >> intType;
-    type = static_cast<MissileObject::MissileType>(intType);
+    type = static_cast<MissileObjectType>(intType);
     return is;
 }
 
-std::ostream& operator<<(std::ostream& os, const MissileObject::MissileType& type)
+std::ostream& operator<<(std::ostream& os, const MissileObjectType& type)
 {
-    uint32_t intType = static_cast<MissileObject::MissileType>(type);
+    uint32_t intType = static_cast<uint32_t>(type);
     os << intType;
     return os;
 }
 
-std::istream& operator>>(std::istream& is, MissileObject::MissileType& type)
+std::istream& operator>>(std::istream& is, MissileObjectType& type)
 {
     uint32_t intType;
     is >> intType;
-    type = static_cast<MissileObject::MissileType>(intType);
+    type = static_cast<MissileObjectType>(intType);
     return is;
 }

--- a/source/entities/MissileObject.h
+++ b/source/entities/MissileObject.h
@@ -30,14 +30,20 @@ class GameMap;
 class Tile;
 class ODPacket;
 
+enum class MissileObjectType
+{
+    oneHit,
+    boulder
+};
+
+ODPacket& operator<<(ODPacket& os, const MissileObjectType& rot);
+ODPacket& operator>>(ODPacket& is, MissileObjectType& rot);
+std::ostream& operator<<(std::ostream& os, const MissileObjectType& rot);
+std::istream& operator>>(std::istream& is, MissileObjectType& rot);
+
 class MissileObject: public RenderedMovableEntity
 {
 public:
-    enum MissileType
-    {
-        oneHit,
-        boulder
-    };
     MissileObject(GameMap* gameMap, Seat* seat, const std::string& senderName,
         const std::string& meshName, const Ogre::Vector3& direction, bool damageAllies);
     MissileObject(GameMap* gameMap);
@@ -60,18 +66,17 @@ public:
     virtual GameEntityType getObjectType() const override
     { return GameEntityType::missileObject; }
 
-    virtual MissileType getMissileType() = 0;
+    virtual MissileObjectType getMissileType() const = 0;
 
-    virtual void exportHeadersToStream(std::ostream& os);
-    virtual void exportHeadersToPacket(ODPacket& os);
+    virtual void exportHeadersToStream(std::ostream& os) override;
+    virtual void exportHeadersToPacket(ODPacket& os) override;
+    void exportToStream(std::ostream& os) const override;
+    void importFromStream(std::istream& is) override;
+
+    static std::string getMissileObjectStreamFormat();
 
     static MissileObject* getMissileObjectFromStream(GameMap* gameMap, std::istream& is);
     static MissileObject* getMissileObjectFromPacket(GameMap* gameMap, ODPacket& is);
-
-    friend ODPacket& operator<<(ODPacket& os, const MissileObject::MissileType& rot);
-    friend ODPacket& operator>>(ODPacket& is, MissileObject::MissileType& rot);
-    friend std::ostream& operator<<(std::ostream& os, const MissileObject::MissileType& rot);
-    friend std::istream& operator>>(std::istream& is, MissileObject::MissileType& rot);
 private:
     bool computeDestination(const Ogre::Vector3& position, double moveDist, const Ogre::Vector3& direction,
         Ogre::Vector3& destination, std::list<Tile*>& tiles);

--- a/source/entities/MissileOneHit.cpp
+++ b/source/entities/MissileOneHit.cpp
@@ -61,3 +61,17 @@ MissileOneHit* MissileOneHit::getMissileOneHitFromPacket(GameMap* gameMap, ODPac
     MissileOneHit* obj = new MissileOneHit(gameMap);
     return obj;
 }
+
+void MissileOneHit::exportToStream(std::ostream& os) const
+{
+    MissileObject::exportToStream(os);
+    os << mPhysicalDamage << "\t";
+    os << mMagicalDamage << "\t";
+}
+
+void MissileOneHit::importFromStream(std::istream& is)
+{
+    MissileObject::importFromStream(is);
+    OD_ASSERT_TRUE(is >> mPhysicalDamage);
+    OD_ASSERT_TRUE(is >> mMagicalDamage);
+}

--- a/source/entities/MissileOneHit.h
+++ b/source/entities/MissileOneHit.h
@@ -37,10 +37,13 @@ public:
         const Ogre::Vector3& direction, double physicalDamage, double magicalDamage, bool damageAllies);
     MissileOneHit(GameMap* gameMap);
 
-    virtual MissileType getMissileType()
-    { return MissileType::oneHit; }
+    virtual MissileObjectType getMissileType() const override
+    { return MissileObjectType::oneHit; }
 
-    virtual bool hitCreature(GameEntity* entity);
+    virtual bool hitCreature(GameEntity* entity) override;
+
+    void exportToStream(std::ostream& os) const override;
+    void importFromStream(std::istream& is) override;
 
     static MissileOneHit* getMissileOneHitFromStream(GameMap* gameMap, std::istream& is);
     static MissileOneHit* getMissileOneHitFromPacket(GameMap* gameMap, ODPacket& packet);

--- a/source/entities/MovableGameEntity.cpp
+++ b/source/entities/MovableGameEntity.cpp
@@ -325,6 +325,11 @@ void MovableGameEntity::importFromStream(std::istream& is)
     // about animation (like importFromPacket does)
 }
 
+std::string MovableGameEntity::getMovableGameEntityStreamFormat()
+{
+    return GameEntity::getGameEntityStreamFormat();
+}
+
 void MovableGameEntity::exportToPacket(ODPacket& os) const
 {
     GameEntity::exportToPacket(os);

--- a/source/entities/MovableGameEntity.h
+++ b/source/entities/MovableGameEntity.h
@@ -93,6 +93,8 @@ public:
 
     virtual void restoreEntityState() override;
 
+    static std::string getMovableGameEntityStreamFormat();
+
 protected:
     std::deque<Ogre::Vector3> mWalkQueue;
 

--- a/source/entities/RenderedMovableEntity.cpp
+++ b/source/entities/RenderedMovableEntity.cpp
@@ -193,9 +193,10 @@ void RenderedMovableEntity::fireRemoveEntity(Seat* seat)
     ODServer::getSingleton().queueServerNotification(serverNotification);
 }
 
-const char* RenderedMovableEntity::getFormat()
+std::string RenderedMovableEntity::getRenderedMovableEntityStreamFormat()
 {
-    return "name\tmeshName";
+    return MovableGameEntity::getMovableGameEntityStreamFormat()
+        + "opacity\trotationAngle\t";
 }
 
 std::vector<Tile*> RenderedMovableEntity::getCoveredTiles()

--- a/source/entities/RenderedMovableEntity.h
+++ b/source/entities/RenderedMovableEntity.h
@@ -83,7 +83,7 @@ public:
     virtual void exportToPacket(ODPacket& os) const override;
     virtual void importFromPacket(ODPacket& is) override;
 
-    static const char* getFormat();
+    static std::string getRenderedMovableEntityStreamFormat();
 
 protected:
     virtual void createMeshLocal();

--- a/source/entities/ResearchEntity.cpp
+++ b/source/entities/ResearchEntity.cpp
@@ -22,6 +22,8 @@
 
 #include "network/ODPacket.h"
 
+#include "game/Research.h"
+
 #include "gamemap/GameMap.h"
 
 #include "traps/Trap.h"
@@ -91,8 +93,22 @@ ResearchEntity* ResearchEntity::getResearchEntityFromPacket(GameMap* gameMap, OD
     return obj;
 }
 
-const char* ResearchEntity::getFormat()
+void ResearchEntity::exportToStream(std::ostream& os) const
 {
-    // TODO : implement saving/loading in the level file
-    return "position";
+    RenderedMovableEntity::exportToStream(os);
+    os << mResearchType << "\t";
+    os << mPosition.x << "\t" << mPosition.y << "\t" << mPosition.z << "\t";
+}
+
+void ResearchEntity::importFromStream(std::istream& is)
+{
+    RenderedMovableEntity::importFromStream(is);
+    OD_ASSERT_TRUE(is >> mResearchType);
+    OD_ASSERT_TRUE(is >> mPosition.x >> mPosition.y >> mPosition.z);
+}
+
+std::string ResearchEntity::getResearchEntityStreamFormat()
+{
+    return RenderedMovableEntity::getRenderedMovableEntityStreamFormat()
+        + "researchType\tPosX\tPosY\tPosZ\t";
 }

--- a/source/entities/ResearchEntity.h
+++ b/source/entities/ResearchEntity.h
@@ -41,20 +41,23 @@ public:
     virtual GameEntityType getObjectType() const override
     { return GameEntityType::researchEntity; }
 
-    virtual const Ogre::Vector3& getScale() const;
+    virtual const Ogre::Vector3& getScale() const override;
 
     ResearchType getResearchType() const
     { return mResearchType; }
 
-    virtual EntityCarryType getEntityCarryType()
+    virtual EntityCarryType getEntityCarryType() override
     { return EntityCarryType::researchEntity; }
 
-    virtual void notifyEntityCarryOn(Creature* carrier);
-    virtual void notifyEntityCarryOff(const Ogre::Vector3& position);
+    virtual void notifyEntityCarryOn(Creature* carrier) override;
+    virtual void notifyEntityCarryOff(const Ogre::Vector3& position) override;
+
+    void exportToStream(std::ostream& os) const override;
+    void importFromStream(std::istream& is) override;
 
     static ResearchEntity* getResearchEntityFromStream(GameMap* gameMap, std::istream& is);
     static ResearchEntity* getResearchEntityFromPacket(GameMap* gameMap, ODPacket& is);
-    static const char* getFormat();
+    static std::string getResearchEntityStreamFormat();
 private:
     ResearchType mResearchType;
 };

--- a/source/entities/SmallSpiderEntity.cpp
+++ b/source/entities/SmallSpiderEntity.cpp
@@ -150,9 +150,3 @@ SmallSpiderEntity* SmallSpiderEntity::getSmallSpiderEntityFromPacket(GameMap* ga
     SmallSpiderEntity* obj = new SmallSpiderEntity(gameMap);
     return obj;
 }
-
-const char* SmallSpiderEntity::getFormat()
-{
-    // Small spider are not to be saved in file
-    return "Unused";
-}

--- a/source/entities/SmallSpiderEntity.h
+++ b/source/entities/SmallSpiderEntity.h
@@ -47,7 +47,6 @@ public:
     { mIsSlapped = true; }
 
     static SmallSpiderEntity* getSmallSpiderEntityFromPacket(GameMap* gameMap, ODPacket& is);
-    static const char* getFormat();
 
 private:
     void addTileToListIfPossible(int x, int y, Room* currentCrypt, std::vector<Tile*>& possibleTileMove);

--- a/source/entities/Tile.cpp
+++ b/source/entities/Tile.cpp
@@ -575,9 +575,9 @@ bool Tile::isWallClaimedForSeat(Seat* seat)
     return true;
 }
 
-const char* Tile::getFormat()
+std::string Tile::getFormat()
 {
-    return "posX\tposY\ttype\tfullness";
+    return "posX\tposY\ttype\tfullness\tseatId(optional)";
 }
 
 void Tile::exportToStream(std::ostream& os) const
@@ -1044,9 +1044,8 @@ void Tile::setSelected(bool ss, Player* pp)
 
 void Tile::setMarkedForDiggingForAllPlayersExcept(bool s, Seat* exceptSeat)
 {
-    for (unsigned int i = 0, num = getGameMap()->numPlayers(); i < num; ++i)
+    for (Player* player : getGameMap()->getPlayers())
     {
-        Player* player = getGameMap()->getPlayer(i);
         if(exceptSeat == nullptr || (player->getSeat() != nullptr && !exceptSeat->isAlliedSeat(player->getSeat())))
             setMarkedForDigging(s, player);
     }
@@ -1102,16 +1101,6 @@ void Tile::removePlayerMarkingTile(Player *p)
         return;
 
     mPlayersMarkingTile.erase(it);
-}
-
-unsigned int Tile::numPlayersMarkingTile() const
-{
-    return mPlayersMarkingTile.size();
-}
-
-Player* Tile::getPlayerMarkingTile(int index)
-{
-    return mPlayersMarkingTile[index];
 }
 
 void Tile::addNeighbor(Tile *n)

--- a/source/entities/Tile.h
+++ b/source/entities/Tile.h
@@ -184,12 +184,9 @@ public:
     //! \brief Tells whether the tile is selected for digging by any player/AI.
     bool isMarkedForDiggingByAnySeat();
 
-    //! \brief Add a player to the vector of players who have marked this tile for digging.
+    //! \brief Add/Remove a player to the vector of players who have marked this tile for digging.
     void addPlayerMarkingTile(Player *p);
-
     void removePlayerMarkingTile(Player *p);
-    unsigned numPlayersMarkingTile() const;
-    Player* getPlayerMarkingTile(int index);
 
     //! \brief This function adds an entity to the list of entities in this tile.
     bool addEntity(GameEntity *entity);
@@ -251,7 +248,7 @@ public:
 
     void exportToStream(std::ostream& os) const override;
 
-    static const char* getFormat();
+    static std::string getFormat();
 
     //! \brief Loads the tile data from a level line.
     static void loadFromLine(const std::string& line, Tile *t);

--- a/source/entities/TreasuryObject.cpp
+++ b/source/entities/TreasuryObject.cpp
@@ -237,12 +237,6 @@ const char* TreasuryObject::getMeshNameForGold(int gold)
     return "GoldstackLv4";
 }
 
-const char* TreasuryObject::getFormat()
-{
-    // TODO : implement saving/loading in the level file
-    return "position\tvalue";
-}
-
 TreasuryObject* TreasuryObject::getTreasuryObjectFromStream(GameMap* gameMap, std::istream& is)
 {
     TreasuryObject* obj = new TreasuryObject(gameMap);
@@ -277,4 +271,10 @@ void TreasuryObject::importFromStream(std::istream& is)
 {
     RenderedMovableEntity::importFromStream(is);
     OD_ASSERT_TRUE(is >> mGoldValue);
+}
+
+std::string TreasuryObject::getTreasuryObjectStreamFormat()
+{
+    return RenderedMovableEntity::getRenderedMovableEntityStreamFormat()
+        + "value\t";
 }

--- a/source/entities/TreasuryObject.h
+++ b/source/entities/TreasuryObject.h
@@ -34,13 +34,13 @@ public:
     TreasuryObject(GameMap* gameMap, int goldValue);
     TreasuryObject(GameMap* gameMap);
 
-    virtual void doUpkeep();
+    virtual void doUpkeep() override;
 
     virtual GameEntityType getObjectType() const override
     { return GameEntityType::treasuryObject; }
 
-    virtual bool tryPickup(Seat* seat);
-    virtual bool tryDrop(Seat* seat, Tile* tile);
+    virtual bool tryPickup(Seat* seat) override;
+    virtual bool tryDrop(Seat* seat, Tile* tile) override;
     void mergeGold(TreasuryObject* obj);
     void addGold(int goldValue);
 
@@ -49,20 +49,20 @@ public:
     virtual void exportToPacket(ODPacket& os) const override;
     virtual void importFromPacket(ODPacket& is) override;
 
-    virtual void pickup();
+    virtual void pickup() override;
 
-    virtual EntityCarryType getEntityCarryType();
-    virtual void notifyEntityCarryOn(Creature* carrier);
-    virtual void notifyEntityCarryOff(const Ogre::Vector3& position);
+    virtual EntityCarryType getEntityCarryType() override;
+    virtual void notifyEntityCarryOn(Creature* carrier) override;
+    virtual void notifyEntityCarryOff(const Ogre::Vector3& position) override;
 
     static const char* getMeshNameForGold(int gold);
 
-    static const char* getFormat();
+    static std::string getTreasuryObjectStreamFormat();
     static TreasuryObject* getTreasuryObjectFromStream(GameMap* gameMap, std::istream& is);
     static TreasuryObject* getTreasuryObjectFromPacket(GameMap* gameMap, ODPacket& is);
 protected:
-    virtual bool addEntityToTile(Tile* tile);
-    virtual bool removeEntityFromTile(Tile* tile);
+    virtual bool addEntityToTile(Tile* tile) override;
+    virtual bool removeEntityFromTile(Tile* tile) override;
 
 private:
     int mGoldValue;

--- a/source/game/Player.cpp
+++ b/source/game/Player.cpp
@@ -17,25 +17,17 @@
 
 #include "game/Player.h"
 
-#include "game/Seat.h"
-
-#include "entities/Creature.h"
-#include "entities/RenderedMovableEntity.h"
-#include "entities/ResearchEntity.h"
 #include "entities/Tile.h"
 
-#include "game/Research.h"
+#include "game/Seat.h"
 
 #include "gamemap/GameMap.h"
-
-#include "modes/ModeManager.h"
 
 #include "network/ODServer.h"
 #include "network/ServerNotification.h"
 #include "network/ODClient.h"
 
 #include "render/RenderManager.h"
-#include "render/ODFrameListener.h"
 
 #include "rooms/Room.h"
 
@@ -43,8 +35,6 @@
 
 #include "traps/Trap.h"
 
-#include "utils/ConfigManager.h"
-#include "utils/Helper.h"
 #include "utils/LogManager.h"
 
 #include <cmath>
@@ -79,11 +69,7 @@ Player::Player(GameMap* gameMap, int32_t id) :
     mSeat(nullptr),
     mIsHuman(false),
     mNoTreasuryAvailableTime(0.0f),
-    mIsPlayerLostSent(false),
-    mResearchPoints(0),
-    mCurrentResearch(nullptr),
-    mNeedRefreshGuiResearchDone(false),
-    mNeedRefreshGuiResearchPending(false)
+    mIsPlayerLostSent(false)
 {
 }
 
@@ -390,292 +376,6 @@ void Player::setCurrentAction(SelectedAction action)
     mNewTrapType = TrapType::nullTrapType;
     mNewRoomType = RoomType::nullRoomType;
     mNewSpellType = SpellType::nullSpellType;
-}
-
-void Player::initPlayer()
-{
-    // TODO: If we want to change the available rooms/traps/spells at game start, we can do that here
-    // We add the rooms available from start
-    std::vector<ResearchType> researchesDone;
-    researchesDone.push_back(ResearchType::roomTreasury);
-    researchesDone.push_back(ResearchType::roomHatchery);
-    researchesDone.push_back(ResearchType::roomDormitory);
-    researchesDone.push_back(ResearchType::roomLibrary);
-    researchesDone.push_back(ResearchType::trapCannon);
-    researchesDone.push_back(ResearchType::spellSummonWorker);
-    setResearchesDone(researchesDone);
-
-    // TODO: fill researches from the server depending on the player input
-    std::vector<ResearchType> researches;
-
-    researches.push_back(ResearchType::spellCallToWar);
-    researches.push_back(ResearchType::roomTrainingHall);
-    researches.push_back(ResearchType::roomForge);
-    researches.push_back(ResearchType::trapSpike);
-    researches.push_back(ResearchType::roomCrypt);
-    researches.push_back(ResearchType::trapBoulder);
-    setResearchTree(researches);
-}
-
-bool Player::isSpellAvailableForPlayer(SpellType type) const
-{
-    switch(type)
-    {
-        case SpellType::summonWorker:
-            return isResearchDone(ResearchType::spellSummonWorker);
-        case SpellType::callToWar:
-            return isResearchDone(ResearchType::spellCallToWar);
-        default:
-            OD_ASSERT_TRUE_MSG(false, "Unknown enum value : " + Helper::toString(
-                static_cast<int>(type)) + " for player " + getNick());
-            return false;
-    }
-    return false;
-}
-
-bool Player::isRoomAvailableForPlayer(RoomType type) const
-{
-    switch(type)
-    {
-        case RoomType::treasury:
-            return isResearchDone(ResearchType::roomTreasury);
-        case RoomType::dormitory:
-            return isResearchDone(ResearchType::roomDormitory);
-        case RoomType::hatchery:
-            return isResearchDone(ResearchType::roomHatchery);
-        case RoomType::trainingHall:
-            return isResearchDone(ResearchType::roomTrainingHall);
-        case RoomType::library:
-            return isResearchDone(ResearchType::roomLibrary);
-        case RoomType::forge:
-            return isResearchDone(ResearchType::roomForge);
-        case RoomType::crypt:
-            return isResearchDone(ResearchType::roomCrypt);
-        default:
-            OD_ASSERT_TRUE_MSG(false, "Unknown enum value : " + Helper::toString(
-                static_cast<int>(type)) + " for player " + getNick());
-            return false;
-    }
-    return false;
-}
-
-bool Player::isTrapAvailableForPlayer(TrapType type) const
-{
-    switch(type)
-    {
-        case TrapType::boulder:
-            return isResearchDone(ResearchType::trapBoulder);
-        case TrapType::cannon:
-            return isResearchDone(ResearchType::trapCannon);
-        case TrapType::spike:
-            return isResearchDone(ResearchType::trapSpike);
-        default:
-            OD_ASSERT_TRUE_MSG(false, "Unknown enum value : " + Helper::toString(
-                static_cast<int>(type)) + " for player " + getNick());
-            return false;
-    }
-    return false;
-}
-
-bool Player::addResearch(ResearchType type)
-{
-    if(std::find(mResearchDone.begin(), mResearchDone.end(), type) != mResearchDone.end())
-        return false;
-
-    std::vector<ResearchType> researchDone = mResearchDone;
-    researchDone.push_back(type);
-    setResearchesDone(researchDone);
-
-    return true;
-}
-
-bool Player::isResearchDone(ResearchType type) const
-{
-    for(ResearchType researchDone : mResearchDone)
-    {
-        if(researchDone != type)
-            continue;
-
-        return true;
-    }
-
-    return false;
-}
-
-const Research* Player::addResearchPoints(int32_t points)
-{
-    if(mCurrentResearch == nullptr)
-        return nullptr;
-
-    mResearchPoints += points;
-    if(mResearchPoints < mCurrentResearch->getNeededResearchPoints())
-        return nullptr;
-
-    const Research* ret = mCurrentResearch;
-    mResearchPoints -= mCurrentResearch->getNeededResearchPoints();
-
-    // The current research is complete. The library that completed it will release
-    // a ResearchEntity. Once it will reach its destination, the research will be
-    // added to the done list
-
-    setNextResearch(mCurrentResearch->getType());
-    return ret;
-}
-
-void Player::setNextResearch(ResearchType researchedType)
-{
-    mCurrentResearch = nullptr;
-    if(!mResearchPending.empty())
-    {
-        // We search for the first pending research we don't own a corresponding ResearchEntity
-        const std::vector<RenderedMovableEntity*>& renderables = mGameMap->getRenderedMovableEntities();
-        ResearchType researchType = ResearchType::nullResearchType;
-        for(ResearchType pending : mResearchPending)
-        {
-            if(pending == researchedType)
-                continue;
-
-            researchType = pending;
-            for(RenderedMovableEntity* renderable : renderables)
-            {
-                if(renderable->getObjectType() != GameEntityType::researchEntity)
-                    continue;
-
-                if(renderable->getSeat() != getSeat())
-                    continue;
-
-                ResearchEntity* researchEntity = static_cast<ResearchEntity*>(renderable);
-                if(researchEntity->getResearchType() != pending)
-                    continue;
-
-                // We found a ResearchEntity of the same Research. We should work on
-                // something else
-                researchType = ResearchType::nullResearchType;
-                break;
-            }
-
-            if(researchType != ResearchType::nullResearchType)
-                break;
-        }
-
-        if(researchType == ResearchType::nullResearchType)
-            return;
-
-        // We have found a fitting research. We retrieve the corresponding Research
-        // object and start working on that
-        const std::vector<const Research*>& researches = ConfigManager::getSingleton().getResearches();
-        for(const Research* research : researches)
-        {
-            if(research->getType() != researchType)
-                continue;
-
-            mCurrentResearch = research;
-            break;
-        }
-    }
-}
-
-void Player::setResearchesDone(const std::vector<ResearchType>& researches)
-{
-    mResearchDone = researches;
-    // We remove the researches done from the pending researches (if it was there,
-    // which may not be true if the research list changed after creating the
-    // researchEntity for example)
-    for(ResearchType type : researches)
-    {
-        auto research = std::find(mResearchPending.begin(), mResearchPending.end(), type);
-        if(research == mResearchPending.end())
-            continue;
-
-        mResearchPending.erase(research);
-    }
-
-    if(mGameMap->isServerGameMap())
-    {
-        if(getIsHuman())
-        {
-            // We notify the client
-            ServerNotification *serverNotification = new ServerNotification(
-                ServerNotificationType::researchesDone, this);
-
-            uint32_t nbItems = mResearchDone.size();
-            serverNotification->mPacket << nbItems;
-            for(ResearchType research : mResearchDone)
-                serverNotification->mPacket << research;
-
-            ODServer::getSingleton().queueServerNotification(serverNotification);
-        }
-    }
-    else
-    {
-        // We notify the mode that the available researches changed. This way, it will
-        // be able to update the UI as needed
-        mNeedRefreshGuiResearchDone = true;
-    }
-}
-
-void Player::setResearchTree(const std::vector<ResearchType>& researches)
-{
-    if(mGameMap->isServerGameMap())
-    {
-        // We check if all the researches in the vector are allowed. If not, we don't update the list
-        const std::vector<const Research*>& researchList = ConfigManager::getSingleton().getResearches();
-        std::vector<ResearchType> researchesDoneInTree = mResearchDone;
-        for(ResearchType researchType : researches)
-        {
-            const Research* research = nullptr;
-            for(const Research* researchTmp : researchList)
-            {
-                if(researchTmp->getType() != researchType)
-                    continue;
-
-                research = researchTmp;
-                break;
-            }
-
-            if(research == nullptr)
-            {
-                // We found an unknow research
-                OD_ASSERT_TRUE_MSG(false, "Unknow research: " + Research::researchTypeToString(researchType));
-                return;
-            }
-
-            if(!research->canBeResearched(researches))
-            {
-                // Invalid research. This might be allowed in the gui to enter invalid
-                // values. In this case, we should remove the assert
-                OD_ASSERT_TRUE_MSG(false, "Unallowed research: " + Research::researchTypeToString(researchType));
-                return;
-            }
-
-            // This research is valid. We add it in the list and we check if the next one also is
-            researchesDoneInTree.push_back(researchType);
-        }
-
-        mResearchPending = researches;
-        if(getIsHuman())
-        {
-            // We notify the client
-            ServerNotification *serverNotification = new ServerNotification(
-                ServerNotificationType::researchTree, this);
-
-            uint32_t nbItems = mResearchPending.size();
-            serverNotification->mPacket << nbItems;
-            for(ResearchType research : mResearchPending)
-                serverNotification->mPacket << research;
-
-            ODServer::getSingleton().queueServerNotification(serverNotification);
-        }
-
-        // We start working on the research tree
-        setNextResearch(ResearchType::nullResearchType);
-    }
-    else
-    {
-        // On client side, no need to check if the research tree is allowed
-        mResearchPending = researches;
-        mNeedRefreshGuiResearchPending = true;
-    }
 }
 
 ODPacket& operator<<(ODPacket& os, const PlayerEventType& type)

--- a/source/game/Player.h
+++ b/source/game/Player.h
@@ -193,8 +193,6 @@ public:
 
     void setCurrentAction(SelectedAction action);
 
-    void initPlayer();
-
     //! \brief Notify the player is fighting
     //! Should be called on the server game map for human players only. tile represents
     //! the place where the fight is happening and player is the Player actually fighting
@@ -207,57 +205,6 @@ public:
     //! \brief Allows to handle timed events like fighting music
     //! Should be called on the server game map for human players only
     void updateTime(Ogre::Real timeSinceLastUpdate);
-
-    //! \brief Checks if the given spell is available for the Player. This check
-    //! should be done on server side to avoid cheating
-    bool isSpellAvailableForPlayer(SpellType type) const;
-
-    //! \brief Gets the current research to do
-    bool isResearching() const
-    { return mCurrentResearch != nullptr; }
-
-    //! \brief Checks if the given room is available for the Player. This check
-    //! should be done on server side to avoid cheating
-    bool isRoomAvailableForPlayer(RoomType type) const;
-
-    //! \brief Checks if the given trap is available for the Player. This check
-    //! should be done on server side to avoid cheating
-    bool isTrapAvailableForPlayer(TrapType type) const;
-
-    //! Returns true if the given ResearchType is already done for this player. False
-    //! otherwise
-    bool isResearchDone(ResearchType type) const;
-
-    //! Called when the research entity reaches its destination. From there, the researched
-    //! thing is available
-    //! Returns true if the type was inserted and false otherwise
-    bool addResearch(ResearchType type);
-
-    //! Called from the library as creatures are researching. When enough points are gathered,
-    //! the corresponding research will become available.
-    //! Returns the research done if enough points have been gathered and nullptr otherwise
-    const Research* addResearchPoints(int32_t points);
-
-    //! Used on both client and server side. On server side, the research tree's validity will be
-    //! checked. If ok, it will be sent to the client. If not, the research tree will not be
-    //! changed. Note that the order of the research matters as the first researches in the given
-    //! vector can needed for the next ones
-    void setResearchTree(const std::vector<ResearchType>& researches);
-
-    //! Used on both client and server side
-    void setResearchesDone(const std::vector<ResearchType>& researches);
-
-    inline bool getNeedRefreshGuiResearchDone() const
-    { return mNeedRefreshGuiResearchDone; }
-
-    inline void guiResearchRefreshedDone()
-    { mNeedRefreshGuiResearchDone = false; }
-
-    inline bool getNeedRefreshGuiResearchPending() const
-    { return mNeedRefreshGuiResearchPending; }
-
-    inline void guiResearchRefreshedPending()
-    { mNeedRefreshGuiResearchPending = false; }
 
     void fireEvents();
 
@@ -301,26 +248,6 @@ private:
 
     bool mIsPlayerLostSent;
 
-    //! \brief Counter for research points
-    int32_t mResearchPoints;
-
-    //! \brief Currently researched Research. This pointer is external and should not be deleted
-    const Research* mCurrentResearch;
-
-    //! \brief true if the available list of research changed. False otherwise. This will be pulled
-    //! by the GameMode to know if it should refresh GUI or not.
-    bool mNeedRefreshGuiResearchDone;
-
-    //! true if the pending researches have changed. False otherwise. This will be pulled
-    //! by the GameMode to know if it should refresh GUI or not.
-    bool mNeedRefreshGuiResearchPending;
-
-    //! \brief Researches already done. This is used on both client and server side and should be updated
-    std::vector<ResearchType> mResearchDone;
-
-    //! \brief Researches pending. Used on server side only
-    std::vector<ResearchType> mResearchPending;
-
     //! \brief List of tiles there is an event on. Used on client and server
     std::vector<PlayerEvent*> mEvents;
 
@@ -328,11 +255,6 @@ private:
     //! note this should NOT be called directly for creatures on the map,
     //! for that you should use the correct function like pickUpEntity() instead.
     void addEntityToHand(GameEntity *entity);
-
-    //! \brief Sets mCurrentResearch to the first entry in mResearchPending. If the pending
-    //! list in empty, mCurrentResearch will be set to null
-    //! researchedType is the currently researched type if any (nullResearchType if none)
-    void setNextResearch(ResearchType researchedType);
 };
 
 #endif // PLAYER_H

--- a/source/game/Research.cpp
+++ b/source/game/Research.cpp
@@ -92,3 +92,17 @@ ODPacket& operator>>(ODPacket& is, ResearchType& type)
     type = static_cast<ResearchType>(tmp);
     return is;
 }
+
+std::ostream& operator<<(std::ostream& os, const ResearchType& type)
+{
+    os << static_cast<int32_t>(type);
+    return os;
+}
+
+std::istream& operator>>(std::istream& is, ResearchType& type)
+{
+    int32_t tmp;
+    is >> tmp;
+    type = static_cast<ResearchType>(tmp);
+    return is;
+}

--- a/source/game/Research.h
+++ b/source/game/Research.h
@@ -45,7 +45,10 @@ enum class ResearchType
 
     // Spells
     spellSummonWorker,
-    spellCallToWar
+    spellCallToWar,
+
+    // This should be the last
+    countResearch
 };
 
 ODPacket& operator<<(ODPacket& os, const ResearchType& type);

--- a/source/game/Research.h
+++ b/source/game/Research.h
@@ -50,6 +50,8 @@ enum class ResearchType
 
 ODPacket& operator<<(ODPacket& os, const ResearchType& type);
 ODPacket& operator>>(ODPacket& is, ResearchType& type);
+std::ostream& operator<<(std::ostream& os, const ResearchType& type);
+std::istream& operator>>(std::istream& is, ResearchType& type);
 
 class Research
 {

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -53,7 +53,6 @@ Seat::Seat(GameMap* gameMap) :
     mStartingY(0),
     mGoldMined(0),
     mNumCreaturesControlled(0),
-    mStartingGold(0),
     mDefaultWorkerClass(nullptr),
     mNumClaimedTiles(0),
     mHasGoalsChanged(true),
@@ -678,7 +677,7 @@ void Seat::computeSeatBeforeSendingToClient()
 
 std::string Seat::getFormat()
 {
-    return "seatId\tteamId\tplayer\tfaction\tstartingX\tstartingY\tcolor\tstartingGold";
+    return "seatId\tteamId\tplayer\tfaction\tstartingX\tstartingY\tcolor\tgold\tgoldMined\tmana";
 }
 
 ODPacket& operator<<(ODPacket& os, Seat *s)
@@ -739,7 +738,9 @@ Seat* Seat::getRogueSeat(GameMap* gameMap)
     seat->mPlayerType = PLAYER_TYPE_INACTIVE;
     seat->mStartingX = 0;
     seat->mStartingY = 0;
-    seat->mStartingGold = 0;
+    seat->mGold = 0;
+    seat->mGoldMined = 0;
+    seat->mMana = 0;
     return seat;
 }
 
@@ -765,7 +766,9 @@ void Seat::loadFromLine(const std::string& line, Seat *s)
     s->mStartingX = Helper::toInt(elems[i++]);
     s->mStartingY = Helper::toInt(elems[i++]);
     s->mColorId = elems[i++];
-    s->mStartingGold = Helper::toInt(elems[i++]);
+    s->mGold = Helper::toInt(elems[i++]);
+    s->mGoldMined = Helper::toInt(elems[i++]);
+    s->mMana = Helper::toInt(elems[i++]);
     s->mColorValue = ConfigManager::getSingleton().getColorFromId(s->mColorId);
 }
 
@@ -820,6 +823,8 @@ std::ostream& operator<<(std::ostream& os, Seat *s)
     os << "\t" << s->mPlayerType << "\t" << s->mFaction << "\t" << s->mStartingX
        << "\t"<< s->mStartingY;
     os << "\t" << s->mColorId;
-    os << "\t" << s->mStartingGold;
+    os << "\t" << s->mGold;
+    os << "\t" << s->mGoldMined;
+    os << "\t" << s->mMana;
     return os;
 }

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -1003,9 +1003,24 @@ bool Seat::exportSeatToStream(std::ostream& os) const
     }
     os << std::endl;
 
-    os << "player\t";
-    os << mPlayerType;
-    os << std::endl;
+    // On editor, we write the original player type. If we are saving a game, we keep the assigned type
+    if((mGameMap->isInEditorMode()) ||
+       (getPlayer() == nullptr))
+    {
+        os << "player\t";
+        os << mPlayerType;
+        os << std::endl;
+    }
+    else
+    {
+        os << "player\t";
+        if(getPlayer()->getIsHuman())
+            os << PLAYER_TYPE_HUMAN;
+        else
+            os << PLAYER_TYPE_AI;
+
+        os << std::endl;
+    }
 
     os << "faction\t";
     os << mFaction;

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -17,21 +17,19 @@
 
 #include "entities/CreatureDefinition.h"
 
+#include "entities/ResearchEntity.h"
 #include "entities/Tile.h"
-
 #include "game/Seat.h"
 #include "gamemap/GameMap.h"
-
+#include "game/Research.h"
 #include "goals/Goal.h"
 #include "network/ODPacket.h"
-
 #include "spawnconditions/SpawnCondition.h"
-
 #include "network/ServerNotification.h"
 #include "network/ODServer.h"
-
 #include "rooms/Room.h"
-
+#include "spell/Spell.h"
+#include "traps/Trap.h"
 #include "utils/ConfigManager.h"
 #include "utils/Helper.h"
 #include "utils/LogManager.h"
@@ -59,7 +57,11 @@ Seat::Seat(GameMap* gameMap) :
     mGold(0),
     mId(-1),
     mNbTreasuries(0),
-    mIsDebuggingVision(false)
+    mIsDebuggingVision(false),
+    mResearchPoints(0),
+    mCurrentResearch(nullptr),
+    mNeedRefreshGuiResearchDone(false),
+    mNeedRefreshGuiResearchPending(false)
 {
 }
 
@@ -350,7 +352,14 @@ void Seat::initSeat()
     mDefaultWorkerClass = mGameMap->getClassDescription(defaultWorkerClass);
     OD_ASSERT_TRUE_MSG(mDefaultWorkerClass != nullptr, "No valid default worker class for faction: " + mFaction);
 
-    getPlayer()->initPlayer();
+    // We use a temporary vector to allow the corresponding functions to check the vector validity
+    // and reject its content if it is not valid
+    std::vector<ResearchType> researches = mResearchDone;
+    mResearchDone.clear();
+    setResearchesDone(researches);
+    researches = mResearchPending;
+    mResearchPending.clear();
+    setResearchTree(researches);
 }
 
 const CreatureDefinition* Seat::getNextFighterClassToSpawn()
@@ -675,11 +684,6 @@ void Seat::computeSeatBeforeSendingToClient()
     }
 }
 
-std::string Seat::getFormat()
-{
-    return "seatId\tteamId\tplayer\tfaction\tstartingX\tstartingY\tcolor\tgold\tgoldMined\tmana";
-}
-
 ODPacket& operator<<(ODPacket& os, Seat *s)
 {
     os << s->mId << s->mTeamId << s->mPlayerType << s->mFaction << s->mStartingX
@@ -744,34 +748,6 @@ Seat* Seat::getRogueSeat(GameMap* gameMap)
     return seat;
 }
 
-void Seat::loadFromLine(const std::string& line, Seat *s)
-{
-    std::vector<std::string> elems = Helper::split(line, '\t');
-
-    int32_t i = 0;
-    s->mId = Helper::toInt(elems[i++]);
-    OD_ASSERT_TRUE_MSG(s->mId != 0, "Forbidden seatId for line=" + line);
-    std::vector<std::string> teamIds = Helper::split(elems[i++], '/');
-    for(const std::string& strTeamId : teamIds)
-    {
-        int teamId = Helper::toInt(strTeamId);
-        OD_ASSERT_TRUE_MSG(teamId != 0, "Forbidden teamId for line=" + line);
-        if(teamId == 0)
-            continue;
-
-        s->mAvailableTeamIds.push_back(teamId);
-    }
-    s->mPlayerType = elems[i++];
-    s->mFaction = elems[i++];
-    s->mStartingX = Helper::toInt(elems[i++]);
-    s->mStartingY = Helper::toInt(elems[i++]);
-    s->mColorId = elems[i++];
-    s->mGold = Helper::toInt(elems[i++]);
-    s->mGoldMined = Helper::toInt(elems[i++]);
-    s->mMana = Helper::toInt(elems[i++]);
-    s->mColorValue = ConfigManager::getSingleton().getColorFromId(s->mColorId);
-}
-
 void Seat::refreshFromSeat(Seat* s)
 {
     // We only refresh data that changes over time (gold, mana, ...)
@@ -797,34 +773,557 @@ bool Seat::sortForMapSave(Seat* s1, Seat* s2)
     return s1->mId < s2->mId;
 }
 
-std::ostream& operator<<(std::ostream& os, Seat *s)
+bool Seat::importSeatFromStream(std::istream& is)
 {
-    os << s->mId;
+    std::string str;
+    OD_ASSERT_TRUE(is >> str);
+    if(str != "seatId")
+    {
+        LogManager::getSingleton().logMessage("WARNING: expected seatId and read " + str);
+        return false;
+    }
+    OD_ASSERT_TRUE(is >> mId);
+    if(mId == 0)
+    {
+        LogManager::getSingleton().logMessage("WARNING: Forbidden seatId used");
+        return false;
+    }
+
+    OD_ASSERT_TRUE(is >> str);
+    if(str != "teamId")
+    {
+        LogManager::getSingleton().logMessage("WARNING: expected teamId and read " + str);
+        return false;
+    }
+    OD_ASSERT_TRUE(is >> str);
+
+    std::vector<std::string> teamIds = Helper::split(str, '/');
+    for(const std::string& strTeamId : teamIds)
+    {
+        int teamId = Helper::toInt(strTeamId);
+        if(teamId == 0)
+        {
+            LogManager::getSingleton().logMessage("WARNING: forbidden teamId in seat id=" + Helper::toString(mId));
+            continue;
+        }
+
+        mAvailableTeamIds.push_back(teamId);
+    }
+
+    OD_ASSERT_TRUE(is >> str);
+    if(str != "player")
+    {
+        LogManager::getSingleton().logMessage("WARNING: expected player and read " + str);
+        return false;
+    }
+    OD_ASSERT_TRUE(is >> mPlayerType);
+
+    OD_ASSERT_TRUE(is >> str);
+    if(str != "faction")
+    {
+        LogManager::getSingleton().logMessage("WARNING: expected faction and read " + str);
+        return false;
+    }
+    OD_ASSERT_TRUE(is >> mFaction);
+
+    OD_ASSERT_TRUE(is >> str);
+    if(str != "startingX")
+    {
+        LogManager::getSingleton().logMessage("WARNING: expected startingX and read " + str);
+        return false;
+    }
+    OD_ASSERT_TRUE(is >> mStartingX);
+
+    OD_ASSERT_TRUE(is >> str);
+    if(str != "startingY")
+    {
+        LogManager::getSingleton().logMessage("WARNING: expected startingY and read " + str);
+        return false;
+    }
+    OD_ASSERT_TRUE(is >> mStartingY);
+
+    OD_ASSERT_TRUE(is >> str);
+    if(str != "colorId")
+    {
+        LogManager::getSingleton().logMessage("WARNING: expected colorId and read " + str);
+        return false;
+    }
+    OD_ASSERT_TRUE(is >> mColorId);
+
+    OD_ASSERT_TRUE(is >> str);
+    if(str != "gold")
+    {
+        LogManager::getSingleton().logMessage("WARNING: expected gold and read " + str);
+        return false;
+    }
+    OD_ASSERT_TRUE(is >> mGold);
+
+    OD_ASSERT_TRUE(is >> str);
+    if(str != "goldMined")
+    {
+        LogManager::getSingleton().logMessage("WARNING: expected goldMined and read " + str);
+        return false;
+    }
+    OD_ASSERT_TRUE(is >> mGoldMined);
+
+    OD_ASSERT_TRUE(is >> str);
+    if(str != "mana")
+    {
+        LogManager::getSingleton().logMessage("WARNING: expected mana and read " + str);
+        return false;
+    }
+    OD_ASSERT_TRUE(is >> mMana);
+
+    mColorValue = ConfigManager::getSingleton().getColorFromId(mColorId);
+
+    uint32_t nbResearch = static_cast<uint32_t>(ResearchType::countResearch);
+    OD_ASSERT_TRUE(is >> str);
+    if(str != "[ResearchDone]")
+    {
+        LogManager::getSingleton().logMessage("WARNING: expected [ResearchDone] and read " + str);
+        return false;
+    }
+    while(true)
+    {
+        OD_ASSERT_TRUE(is >> str);
+        if(str == "[/ResearchDone]")
+            break;
+
+        for(uint32_t i = 0; i < nbResearch; ++i)
+        {
+            ResearchType type = static_cast<ResearchType>(i);
+            if(type == ResearchType::nullResearchType)
+                continue;
+            if(str.compare(Research::researchTypeToString(type)) != 0)
+                continue;
+
+            if(std::find(mResearchDone.begin(), mResearchDone.end(), type) != mResearchDone.end())
+                break;
+
+            // We found a valid research
+            mResearchDone.push_back(type);
+
+            break;
+        }
+    }
+
+    OD_ASSERT_TRUE(is >> str);
+    if(str != "[ResearchNotAllowed]")
+    {
+        LogManager::getSingleton().logMessage("WARNING: expected [ResearchNotAllowed] and read " + str);
+        return false;
+    }
+
+    while(true)
+    {
+        OD_ASSERT_TRUE(is >> str);
+        if(str == "[/ResearchNotAllowed]")
+            break;
+
+        for(uint32_t i = 0; i < nbResearch; ++i)
+        {
+            ResearchType type = static_cast<ResearchType>(i);
+            if(type == ResearchType::nullResearchType)
+                continue;
+            if(str.compare(Research::researchTypeToString(type)) != 0)
+                continue;
+
+            // We do not allow a research to be done and not allowed
+            if(std::find(mResearchDone.begin(), mResearchDone.end(), type) != mResearchDone.end())
+                break;
+            if(std::find(mResearchNotAllowed.begin(), mResearchNotAllowed.end(), type) != mResearchNotAllowed.end())
+                break;
+
+            // We found a valid research
+            mResearchNotAllowed.push_back(type);
+
+            break;
+        }
+    }
+
+    OD_ASSERT_TRUE(is >> str);
+    if(str != "[ResearchPending]")
+    {
+        LogManager::getSingleton().logMessage("WARNING: expected [ResearchPending] and read " + str);
+        return false;
+    }
+
+    while(true)
+    {
+        OD_ASSERT_TRUE(is >> str);
+        if(str == "[/ResearchPending]")
+            break;
+
+        for(uint32_t i = 0; i < nbResearch; ++i)
+        {
+            ResearchType type = static_cast<ResearchType>(i);
+            if(type == ResearchType::nullResearchType)
+                continue;
+            if(str.compare(Research::researchTypeToString(type)) != 0)
+                continue;
+
+            // We do not allow researches already done or not allowed
+            if(std::find(mResearchDone.begin(), mResearchDone.end(), type) != mResearchDone.end())
+                break;
+            if(std::find(mResearchNotAllowed.begin(), mResearchNotAllowed.end(), type) != mResearchNotAllowed.end())
+                break;
+            if(std::find(mResearchPending.begin(), mResearchPending.end(), type) != mResearchPending.end())
+                break;
+
+            // We found a valid research
+            mResearchPending.push_back(type);
+        }
+    }
+    return true;
+}
+
+bool Seat::exportSeatToStream(std::ostream& os) const
+{
+    os << "seatId\t";
+    os << mId;
+    os << std::endl;
     // If the team id is set, we save it. Otherwise, we save all the available team ids
     // That way, save map will work in both editor and in game.
-    if(s->mTeamId != -1)
+    os << "teamId\t";
+    if(mTeamId != -1)
     {
-        os << "\t" << s->mTeamId;
+        os << mTeamId;
     }
     else
     {
         int cpt = 0;
-        for(int teamId : s->mAvailableTeamIds)
+        for(int teamId : mAvailableTeamIds)
         {
-            if(cpt == 0)
-                os << "\t";
-            else
+            if(cpt > 0)
                 os << "/";
 
             os << teamId;
             ++cpt;
         }
     }
-    os << "\t" << s->mPlayerType << "\t" << s->mFaction << "\t" << s->mStartingX
-       << "\t"<< s->mStartingY;
-    os << "\t" << s->mColorId;
-    os << "\t" << s->mGold;
-    os << "\t" << s->mGoldMined;
-    os << "\t" << s->mMana;
-    return os;
+    os << std::endl;
+
+    os << "player\t";
+    os << mPlayerType;
+    os << std::endl;
+
+    os << "faction\t";
+    os << mFaction;
+    os << std::endl;
+
+    os << "startingX\t";
+    os << mStartingX;
+    os << std::endl;
+
+    os << "startingY\t";
+    os << mStartingY;
+    os << std::endl;
+
+    os << "colorId\t";
+    os << mColorId;
+    os << std::endl;
+
+    os << "gold\t";
+    os << mGold;
+    os << std::endl;
+
+    os << "goldMined\t";
+    os << mGoldMined;
+    os << std::endl;
+
+    os << "mana\t";
+    os << mMana;
+    os << std::endl;
+
+    os << "[ResearchDone]" << std::endl;
+    for(ResearchType type : mResearchDone)
+    {
+        os << Research::researchTypeToString(type) << std::endl;
+    }
+    os << "[/ResearchDone]" << std::endl;
+
+    os << "[ResearchNotAllowed]" << std::endl;
+    for(ResearchType type : mResearchNotAllowed)
+    {
+        os << Research::researchTypeToString(type) << std::endl;
+    }
+    os << "[/ResearchNotAllowed]" << std::endl;
+
+    os << "[ResearchPending]" << std::endl;
+    for(ResearchType type : mResearchPending)
+    {
+        os << Research::researchTypeToString(type) << std::endl;
+    }
+    os << "[/ResearchPending]" << std::endl;
+
+    return true;
+}
+
+bool Seat::isSpellAvailable(SpellType type) const
+{
+    switch(type)
+    {
+        case SpellType::summonWorker:
+            return isResearchDone(ResearchType::spellSummonWorker);
+        case SpellType::callToWar:
+            return isResearchDone(ResearchType::spellCallToWar);
+        default:
+            OD_ASSERT_TRUE_MSG(false, "Unknown enum value : " + Helper::toString(
+                static_cast<int>(type)) + " for seatId " + Helper::toString(getId()));
+            return false;
+    }
+    return false;
+}
+
+bool Seat::isRoomAvailable(RoomType type) const
+{
+    switch(type)
+    {
+        case RoomType::treasury:
+            return isResearchDone(ResearchType::roomTreasury);
+        case RoomType::dormitory:
+            return isResearchDone(ResearchType::roomDormitory);
+        case RoomType::hatchery:
+            return isResearchDone(ResearchType::roomHatchery);
+        case RoomType::trainingHall:
+            return isResearchDone(ResearchType::roomTrainingHall);
+        case RoomType::library:
+            return isResearchDone(ResearchType::roomLibrary);
+        case RoomType::forge:
+            return isResearchDone(ResearchType::roomForge);
+        case RoomType::crypt:
+            return isResearchDone(ResearchType::roomCrypt);
+        default:
+            OD_ASSERT_TRUE_MSG(false, "Unknown enum value : " + Helper::toString(
+                static_cast<int>(type)) + " for seatId " + Helper::toString(getId()));
+            return false;
+    }
+    return false;
+}
+
+bool Seat::isTrapAvailable(TrapType type) const
+{
+    switch(type)
+    {
+        case TrapType::boulder:
+            return isResearchDone(ResearchType::trapBoulder);
+        case TrapType::cannon:
+            return isResearchDone(ResearchType::trapCannon);
+        case TrapType::spike:
+            return isResearchDone(ResearchType::trapSpike);
+        default:
+            OD_ASSERT_TRUE_MSG(false, "Unknown enum value : " + Helper::toString(
+                static_cast<int>(type)) + " for seatId " + Helper::toString(getId()));
+            return false;
+    }
+    return false;
+}
+
+bool Seat::addResearch(ResearchType type)
+{
+    if(std::find(mResearchDone.begin(), mResearchDone.end(), type) != mResearchDone.end())
+        return false;
+
+    std::vector<ResearchType> researchDone = mResearchDone;
+    researchDone.push_back(type);
+    setResearchesDone(researchDone);
+
+    return true;
+}
+
+bool Seat::isResearchDone(ResearchType type) const
+{
+    for(ResearchType researchDone : mResearchDone)
+    {
+        if(researchDone != type)
+            continue;
+
+        return true;
+    }
+
+    return false;
+}
+
+const Research* Seat::addResearchPoints(int32_t points)
+{
+    if(mCurrentResearch == nullptr)
+        return nullptr;
+
+    mResearchPoints += points;
+    if(mResearchPoints < mCurrentResearch->getNeededResearchPoints())
+        return nullptr;
+
+    const Research* ret = mCurrentResearch;
+    mResearchPoints -= mCurrentResearch->getNeededResearchPoints();
+
+    // The current research is complete. The library that completed it will release
+    // a ResearchEntity. Once it will reach its destination, the research will be
+    // added to the done list
+
+    setNextResearch(mCurrentResearch->getType());
+    return ret;
+}
+
+void Seat::setNextResearch(ResearchType researchedType)
+{
+    mCurrentResearch = nullptr;
+    if(!mResearchPending.empty())
+    {
+        // We search for the first pending research we don't own a corresponding ResearchEntity
+        const std::vector<RenderedMovableEntity*>& renderables = mGameMap->getRenderedMovableEntities();
+        ResearchType researchType = ResearchType::nullResearchType;
+        for(ResearchType pending : mResearchPending)
+        {
+            if(pending == researchedType)
+                continue;
+
+            researchType = pending;
+            for(RenderedMovableEntity* renderable : renderables)
+            {
+                if(renderable->getObjectType() != GameEntityType::researchEntity)
+                    continue;
+
+                if(renderable->getSeat() != this)
+                    continue;
+
+                ResearchEntity* researchEntity = static_cast<ResearchEntity*>(renderable);
+                if(researchEntity->getResearchType() != pending)
+                    continue;
+
+                // We found a ResearchEntity of the same Research. We should work on
+                // something else
+                researchType = ResearchType::nullResearchType;
+                break;
+            }
+
+            if(researchType != ResearchType::nullResearchType)
+                break;
+        }
+
+        if(researchType == ResearchType::nullResearchType)
+            return;
+
+        // We have found a fitting research. We retrieve the corresponding Research
+        // object and start working on that
+        const std::vector<const Research*>& researches = ConfigManager::getSingleton().getResearches();
+        for(const Research* research : researches)
+        {
+            if(research->getType() != researchType)
+                continue;
+
+            mCurrentResearch = research;
+            break;
+        }
+    }
+}
+
+void Seat::setResearchesDone(const std::vector<ResearchType>& researches)
+{
+    mResearchDone = researches;
+    // We remove the researches done from the pending researches (if it was there,
+    // which may not be true if the research list changed after creating the
+    // researchEntity for example)
+    for(ResearchType type : researches)
+    {
+        auto research = std::find(mResearchPending.begin(), mResearchPending.end(), type);
+        if(research == mResearchPending.end())
+            continue;
+
+        mResearchPending.erase(research);
+    }
+
+    if(mGameMap->isServerGameMap())
+    {
+        if((getPlayer() != nullptr) && getPlayer()->getIsHuman())
+        {
+            // We notify the client
+            ServerNotification *serverNotification = new ServerNotification(
+                ServerNotificationType::researchesDone, getPlayer());
+
+            uint32_t nbItems = mResearchDone.size();
+            serverNotification->mPacket << nbItems;
+            for(ResearchType research : mResearchDone)
+                serverNotification->mPacket << research;
+
+            ODServer::getSingleton().queueServerNotification(serverNotification);
+        }
+    }
+    else
+    {
+        // We notify the mode that the available researches changed. This way, it will
+        // be able to update the UI as needed
+        mNeedRefreshGuiResearchDone = true;
+    }
+}
+
+void Seat::setResearchTree(const std::vector<ResearchType>& researches)
+{
+    if(mGameMap->isServerGameMap())
+    {
+        // We check if all the researches in the vector are allowed. If not, we don't update the list
+        const std::vector<const Research*>& researchList = ConfigManager::getSingleton().getResearches();
+        std::vector<ResearchType> researchesDoneInTree = mResearchDone;
+        for(ResearchType researchType : researches)
+        {
+            // We check if the research is allowed
+            if(std::find(mResearchNotAllowed.begin(), mResearchNotAllowed.end(), researchType) != mResearchNotAllowed.end())
+            {
+                // Invalid research. This might be allowed in the gui to enter invalid
+                // values. In this case, we should remove the assert
+                OD_ASSERT_TRUE_MSG(false, "Unallowed research: " + Research::researchTypeToString(researchType));
+                return;
+            }
+            const Research* research = nullptr;
+            for(const Research* researchTmp : researchList)
+            {
+                if(researchTmp->getType() != researchType)
+                    continue;
+
+                research = researchTmp;
+                break;
+            }
+
+            if(research == nullptr)
+            {
+                // We found an unknow research
+                OD_ASSERT_TRUE_MSG(false, "Unknow research: " + Research::researchTypeToString(researchType));
+                return;
+            }
+
+            if(!research->canBeResearched(researchesDoneInTree))
+            {
+                // Invalid research. This might be allowed in the gui to enter invalid
+                // values. In this case, we should remove the assert
+                OD_ASSERT_TRUE_MSG(false, "Unallowed research: " + Research::researchTypeToString(researchType));
+                return;
+            }
+
+            // This research is valid. We add it in the list and we check if the next one also is
+            researchesDoneInTree.push_back(researchType);
+        }
+
+        mResearchPending = researches;
+        if((getPlayer() != nullptr) && getPlayer()->getIsHuman())
+        {
+            // We notify the client
+            ServerNotification *serverNotification = new ServerNotification(
+                ServerNotificationType::researchTree, getPlayer());
+
+            uint32_t nbItems = mResearchPending.size();
+            serverNotification->mPacket << nbItems;
+            for(ResearchType research : mResearchPending)
+                serverNotification->mPacket << research;
+
+            ODServer::getSingleton().queueServerNotification(serverNotification);
+        }
+
+        // We start working on the research tree
+        setNextResearch(ResearchType::nullResearchType);
+    }
+    else
+    {
+        // On client side, no need to check if the research tree is allowed
+        mResearchPending = researches;
+        mNeedRefreshGuiResearchPending = true;
+    }
 }

--- a/source/game/Seat.h
+++ b/source/game/Seat.h
@@ -48,7 +48,7 @@ public:
     // Constructors
     Seat(GameMap* gameMap);
 
-    inline Player* getPlayer()
+    inline Player* getPlayer() const
     { return mPlayer; }
 
     //! \brief Adds a goal to the vector of goals which must be completed by this seat before it can be declared a winner.

--- a/source/game/Seat.h
+++ b/source/game/Seat.h
@@ -140,9 +140,6 @@ public:
 
     bool takeMana(double mana);
 
-    inline int getStartingGold() const
-    { return mStartingGold; }
-
     inline Ogre::Vector3 getStartingPosition() const
     { return Ogre::Vector3(static_cast<Ogre::Real>(mStartingX), static_cast<Ogre::Real>(mStartingY), 0); }
 
@@ -174,9 +171,7 @@ public:
 
     //! \brief Returns the first (default) worker class definition.
     inline const CreatureDefinition* getWorkerClassToSpawn()
-    {
-        return mDefaultWorkerClass;
-    }
+    { return mDefaultWorkerClass; }
 
     //! \brief Returns true if the given seat is allied. False otherwise
     bool isAlliedSeat(Seat *seat);
@@ -208,7 +203,7 @@ public:
     void refreshVisualDebugEntities(const std::vector<Tile*>& tiles);
     void stopVisualDebugEntities();
 
-    const std::vector<Seat*>& getAlliedSeats()
+    inline const std::vector<Seat*>& getAlliedSeats()
     { return mAlliedSeats; }
 
     void computeSeatBeforeSendingToClient();
@@ -264,8 +259,6 @@ private:
     int mGoldMined;
 
     int mNumCreaturesControlled;
-
-    int mStartingGold;
 
     //! \brief The actual color that this color index translates into.
     std::string mColorId;

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -203,10 +203,6 @@ bool GameMap::loadLevel(const std::string& levelFilepath)
         addCreatureMoodModifiers(p.first, moodModifiersClone);
     }
 
-    // Read in the game map filepath
-    std::string levelPath = ResourceManager::getSingletonPtr()->getGameDataPath()
-                            + levelFilepath;
-
     // We add the rogue default seat (seatId = 0 and teamId = 0)
     Seat* rogueSeat = Seat::getRogueSeat(this);
     if(!addSeat(rogueSeat))
@@ -216,7 +212,7 @@ bool GameMap::loadLevel(const std::string& levelFilepath)
     }
 
     // TODO The map loader class should be merged back to GameMap.
-    if (MapLoader::readGameMapFromFile(levelPath, *this))
+    if (MapLoader::readGameMapFromFile(levelFilepath, *this))
         setLevelFileName(levelFilepath);
     else
         return false;

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -801,15 +801,7 @@ void GameMap::removeAnimatedObject(MovableGameEntity *a)
     mAnimatedObjects.erase(it);
 }
 
-MovableGameEntity* GameMap::getAnimatedObject(int index)
-{
-    OD_ASSERT_TRUE_MSG(index < static_cast<int>(mAnimatedObjects.size()), "index=" + Ogre::StringConverter::toString(index));
-    MovableGameEntity* tempAnimatedObject = mAnimatedObjects[index];
-
-    return tempAnimatedObject;
-}
-
-MovableGameEntity* GameMap::getAnimatedObject(const std::string& name)
+MovableGameEntity* GameMap::getAnimatedObject(const std::string& name) const
 {
     for (MovableGameEntity* mge : mAnimatedObjects)
     {
@@ -847,12 +839,6 @@ RenderedMovableEntity* GameMap::getRenderedMovableEntity(const std::string& name
             return renderedMovableEntity;
     }
     return nullptr;
-}
-
-
-unsigned int GameMap::numAnimatedObjects()
-{
-    return mAnimatedObjects.size();
 }
 
 void GameMap::addActiveObject(GameEntity *a)
@@ -945,6 +931,20 @@ void GameMap::createAllEntities()
     {
         trap->createMesh();
         trap->updateActiveSpots();
+    }
+
+    // Create OGRE entities for spells
+    for (Spell* spell : mSpells)
+    {
+        spell->createMesh();
+        spell->setPosition(spell->getPosition(), false);
+    }
+
+    // Create OGRE entities for rendered entities
+    for (RenderedMovableEntity* rendered : mRenderedMovableEntities)
+    {
+        rendered->createMesh();
+        rendered->setPosition(rendered->getPosition(), false);
     }
     LogManager::getSingleton().logMessage("entities created");
 }
@@ -1589,21 +1589,7 @@ bool GameMap::assignAI(Player& player, const std::string& aiType, const std::str
     return false;
 }
 
-Player* GameMap::getPlayer(unsigned int index)
-{
-    if (index < mPlayers.size())
-        return mPlayers[index];
-    return nullptr;
-}
-
-const Player* GameMap::getPlayer(unsigned int index) const
-{
-    if (index < mPlayers.size())
-        return mPlayers[index];
-    return nullptr;
-}
-
-Player* GameMap::getPlayer(const std::string& pName)
+Player* GameMap::getPlayer(const std::string& pName) const
 {
     for (Player* player : mPlayers)
     {
@@ -1616,25 +1602,7 @@ Player* GameMap::getPlayer(const std::string& pName)
     return nullptr;
 }
 
-const Player* GameMap::getPlayer(const std::string& pName) const
-{
-    for (Player* player : mPlayers)
-    {
-        if (player->getNick().compare(pName) == 0)
-        {
-            return player;
-        }
-    }
-
-    return nullptr;
-}
-
-unsigned int GameMap::numPlayers() const
-{
-    return mPlayers.size();
-}
-
-Player* GameMap::getPlayerBySeatId(int seatId)
+Player* GameMap::getPlayerBySeatId(int seatId) const
 {
     for (Player* player : mPlayers)
     {
@@ -1644,7 +1612,7 @@ Player* GameMap::getPlayerBySeatId(int seatId)
     return nullptr;
 }
 
-Player* GameMap::getPlayerBySeat(Seat* seat)
+Player* GameMap::getPlayerBySeat(Seat* seat) const
 {
     for (Player* player : mPlayers)
     {
@@ -1744,16 +1712,6 @@ void GameMap::removeRoom(Room *r)
         return;
 
     mRooms.erase(it);
-}
-
-Room* GameMap::getRoom(int index)
-{
-    return mRooms[index];
-}
-
-unsigned int GameMap::numRooms()
-{
-    return mRooms.size();
 }
 
 std::vector<Room*> GameMap::getRoomsByType(RoomType type)
@@ -1912,16 +1870,6 @@ void GameMap::removeTrap(Trap *t)
     mTraps.erase(it);
 }
 
-Trap* GameMap::getTrap(int index)
-{
-    return mTraps[index];
-}
-
-unsigned int GameMap::numTraps()
-{
-    return mTraps.size();
-}
-
 int GameMap::getTotalGoldForSeat(Seat* seat)
 {
     int tempInt = 0;
@@ -2055,17 +2003,7 @@ void GameMap::addWinningSeat(Seat *s)
     mWinningSeats.push_back(s);
 }
 
-Seat* GameMap::getWinningSeat(unsigned int index)
-{
-    return mWinningSeats[index];
-}
-
-unsigned int GameMap::getNumWinningSeats()
-{
-    return mWinningSeats.size();
-}
-
-bool GameMap::seatIsAWinner(Seat *s)
+bool GameMap::seatIsAWinner(Seat *s) const
 {
     if(std::find(mWinningSeats.begin(), mWinningSeats.end(), s) != mWinningSeats.end())
         return true;
@@ -2080,21 +2018,6 @@ void GameMap::addGoalForAllSeats(Goal *g)
     // Add the goal to each of the empty seats currently in the game.
     for (Seat* seat : mSeats)
         seat->addGoal(g);
-}
-
-Goal* GameMap::getGoalForAllSeats(unsigned int i)
-{
-    return mGoalsForAllSeats[i];
-}
-
-const Goal* GameMap::getGoalForAllSeats(unsigned int i) const
-{
-    return mGoalsForAllSeats[i];
-}
-
-unsigned int GameMap::numGoalsForAllSeats() const
-{
-    return mGoalsForAllSeats.size();
 }
 
 void GameMap::clearGoalsForAllSeats()

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -892,6 +892,7 @@ const CreatureDefinition* GameMap::getClassDescription(int index)
 
 void GameMap::createAllEntities()
 {
+    std::vector<GameEntity*> entities;
     // Create OGRE entities for map tiles
     for (int jj = 0; jj < getMapSizeY(); ++jj)
     {
@@ -908,6 +909,7 @@ void GameMap::createAllEntities()
     {
         rendered->createMesh();
         rendered->setPosition(rendered->getPosition(), false);
+        entities.push_back(rendered);
     }
 
     // Create OGRE entities for the creatures
@@ -915,6 +917,7 @@ void GameMap::createAllEntities()
     {
         creature->createMesh();
         creature->setPosition(creature->getPosition(), false);
+        entities.push_back(creature);
     }
 
     // Create OGRE entities for the map lights.
@@ -929,6 +932,7 @@ void GameMap::createAllEntities()
     {
         room->createMesh();
         room->updateActiveSpots();
+        entities.push_back(room);
     }
 
     // Create OGRE entities for the rooms
@@ -936,6 +940,7 @@ void GameMap::createAllEntities()
     {
         trap->createMesh();
         trap->updateActiveSpots();
+        entities.push_back(trap);
     }
 
     // Create OGRE entities for spells
@@ -943,6 +948,13 @@ void GameMap::createAllEntities()
     {
         spell->createMesh();
         spell->setPosition(spell->getPosition(), false);
+        entities.push_back(spell);
+    }
+
+    for(GameEntity* entity : entities)
+    {
+        // We restore the initial states
+        entity->restoreInitialEntityState();
     }
 
     LogManager::getSingleton().logMessage("entities created");

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -905,6 +905,15 @@ void GameMap::createAllEntities()
         }
     }
 
+    // Create OGRE entities for rendered entities
+    // Note that RenderedMovableEntity should be created before rooms and traps
+    // because they might create new ones (building objects).
+    for (RenderedMovableEntity* rendered : mRenderedMovableEntities)
+    {
+        rendered->createMesh();
+        rendered->setPosition(rendered->getPosition(), false);
+    }
+
     // Create OGRE entities for the creatures
     for (Creature* creature : mCreatures)
     {
@@ -940,12 +949,6 @@ void GameMap::createAllEntities()
         spell->setPosition(spell->getPosition(), false);
     }
 
-    // Create OGRE entities for rendered entities
-    for (RenderedMovableEntity* rendered : mRenderedMovableEntities)
-    {
-        rendered->createMesh();
-        rendered->setPosition(rendered->getPosition(), false);
-    }
     LogManager::getSingleton().logMessage("entities created");
 }
 

--- a/source/gamemap/GameMap.h
+++ b/source/gamemap/GameMap.h
@@ -72,7 +72,7 @@ public:
     GameMap(bool isServerGameMap);
     ~GameMap();
 
-    const std::string serverStr()
+    inline const std::string serverStr()
     { return std::string( mIsServerGameMap ? "SERVER - " : "CLIENT - "); }
 
     //! \brief Tells whether the game map is currently used for the map editor mode
@@ -119,10 +119,11 @@ public:
     /** \brief Adds the given map light to the queue to be deleted at the end of the turn. */
     void queueMapLightForDeletion(MapLight *ml);
 
-    //! \brief Returns a pointer to the creature whose name matches name
+    //! \brief Returns a pointer to the creature whose name matches name or
+    //! nullptr if it is not found
     Creature* getCreature(const std::string& cName) const;
 
-    bool getIsFOWActivated() const
+    inline bool getIsFOWActivated() const
     { return mIsFOWActivated; }
 
     //! \brief Returns a vector containing all the creatures controlled by the given seat.
@@ -139,9 +140,7 @@ public:
     void clearAnimatedObjects();
     void addAnimatedObject(MovableGameEntity *a);
     void removeAnimatedObject(MovableGameEntity *a);
-    MovableGameEntity* getAnimatedObject(int index);
-    MovableGameEntity* getAnimatedObject(const std::string& name);
-    unsigned int numAnimatedObjects();
+    MovableGameEntity* getAnimatedObject(const std::string& name) const;
 
     void addActiveObject(GameEntity* a);
     void removeActiveObject(GameEntity* a);
@@ -198,7 +197,8 @@ public:
     Room* getRoom(int index);
 
     //! \brief A simple accessor method to return the number of Rooms stored in the GameMap.
-    unsigned int numRooms();
+    inline const std::vector<Room*>& getRooms() const
+    { return mRooms; }
 
     std::vector<Room*> getRoomsByType(RoomType type);
     std::vector<Room*> getRoomsByTypeAndSeat(RoomType type,
@@ -218,8 +218,8 @@ public:
     void clearTraps();
     void addTrap(Trap *t);
     void removeTrap(Trap *t);
-    Trap* getTrap(int index);
-    unsigned int numTraps();
+    inline const std::vector<Trap*>& getTraps() const
+    { return mTraps; }
 
     //! \brief Map Lights related functions.
     void clearMapLights();
@@ -238,26 +238,18 @@ public:
     //! \brief Assigns an ai to the chosen player
     bool assignAI(Player& player, const std::string& aiType, const std::string& parameters = std::string());
 
-    //! \brief Returns a pointer to the i'th player structure stored by this GameMap.
-    Player* getPlayer(unsigned int index);
-    const Player* getPlayer(unsigned int index) const;
-
     //! \brief Returns a pointer to the player structure stored by this GameMap whose name matches pName.
-    Player* getPlayer(const std::string& cName);
-    const Player* getPlayer(const std::string& cName) const;
+    Player* getPlayer(const std::string& cName) const;
 
-    const std::vector<Player*>& getPlayers() const
+    inline const std::vector<Player*>& getPlayers() const
     { return mPlayers; }
 
-    const std::vector<Seat*>& getSeats() const
+    inline const std::vector<Seat*>& getSeats() const
     { return mSeats; }
 
     //! \brief Returns a pointer to the player structure stored by this GameMap whose seat id matches seatId.
-    Player* getPlayerBySeatId(int seatId);
-    Player* getPlayerBySeat(Seat* seat);
-
-    //! \brief Returns the number of player structures stored in this GameMap.
-    unsigned int numPlayers() const;
+    Player* getPlayerBySeatId(int seatId) const;
+    Player* getPlayerBySeat(Seat* seat) const;
 
     //! \brief A simple mutator method to clear the vector of Seats stored in the GameMap.
     void clearSeats();
@@ -274,18 +266,15 @@ public:
 
     Seat* getSeatById(int id) const;
 
-    Seat* getSeatRogue() const
+    inline Seat* getSeatRogue() const
     { return getSeatById(0); }
 
     void addWinningSeat(Seat *s);
-    Seat* getWinningSeat(unsigned int index);
-    unsigned int getNumWinningSeats();
-    bool seatIsAWinner(Seat *s);
+    bool seatIsAWinner(Seat *s) const;
 
     void addGoalForAllSeats(Goal *g);
-    Goal* getGoalForAllSeats(unsigned int i);
-    const Goal* getGoalForAllSeats(unsigned int i) const;
-    unsigned int numGoalsForAllSeats() const;
+    inline const std::vector<Goal*>& getGoalsForAllSeats() const
+    { return mGoalsForAllSeats; }
     void clearGoalsForAllSeats();
 
     int getTotalGoldForSeat(Seat* seat);
@@ -415,30 +404,20 @@ public:
     //! \brief Updates the different entities animations.
     void updateAnimations(Ogre::Real timeSinceLastFrame);
 
-    int64_t getTurnNumber() const
-    {
-        return mTurnNumber;
-    }
+    inline int64_t getTurnNumber() const
+    { return mTurnNumber; }
 
-    void setTurnNumber(int64_t turnNumber)
-    {
-        mTurnNumber = turnNumber;
-    }
+    inline void setTurnNumber(int64_t turnNumber)
+    { mTurnNumber = turnNumber; }
 
-    bool isServerGameMap() const
-    {
-        return mIsServerGameMap;
-    }
+    inline bool isServerGameMap() const
+    { return mIsServerGameMap; }
 
-    bool getGamePaused() const
-    {
-        return mIsPaused;
-    }
+    inline bool getGamePaused() const
+    { return mIsPaused; }
 
-    void setGamePaused(bool paused)
-    {
-        mIsPaused = paused;
-    }
+    inline void setGamePaused(bool paused)
+    { mIsPaused = paused; }
 
     //! \brief Refresh the tiles borders based a recent change on the map
     void refreshBorderingTilesOf(const std::vector<Tile*>& affectedTiles);
@@ -490,6 +469,8 @@ public:
         const std::string& entityName);
 
     //! brief Functions to add/remove/get Spells
+    inline const std::vector<Spell*>& getSpells() const
+    { return mSpells; }
     void addSpell(Spell *spell);
     void removeSpell(Spell *spell);
     Spell* getSpell(const std::string& name) const;
@@ -510,7 +491,7 @@ public:
 
     void updateVisibleEntities();
 
-    const std::vector<RenderedMovableEntity*>& getRenderedMovableEntities() const
+    inline const std::vector<RenderedMovableEntity*>& getRenderedMovableEntities() const
     { return mRenderedMovableEntities; }
 
 private:

--- a/source/gamemap/MapLoader.cpp
+++ b/source/gamemap/MapLoader.cpp
@@ -473,23 +473,21 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
         if (nextParam == "[/Creatures]")
             break;
 
-        if (nextParam != "[Creature]")
-            return false;
+        std::string entire_line = nextParam;
+        std::getline(levelFile, nextParam);
+        entire_line += nextParam;
 
-        Creature* tempCreature = Creature::getCreatureFromStream(&gameMap, levelFile);
+        std::stringstream ss(entire_line);
+        Creature* tempCreature = Creature::getCreatureFromStream(&gameMap, ss);
         OD_ASSERT_TRUE(tempCreature != nullptr);
         if(tempCreature == nullptr)
             return false;
 
-        tempCreature->importFromStream(levelFile);
+        tempCreature->importFromStream(ss);
         tempCreature->addToGameMap();
         ++nbCreatures;
-
-        levelFile >> nextParam;
-        if (nextParam != "[/Creature]")
-            return false;
     }
-    std::cout << "Loaded " << nbCreatures << " creatures in level" << std::endl;
+    LogManager::getSingleton().logMessage("Loaded " + Helper::toString(nbCreatures) + " creatures in level");
 
     return true;
 }

--- a/source/gamemap/MapLoader.h
+++ b/source/gamemap/MapLoader.h
@@ -25,6 +25,8 @@
 
 class GameMap;
 
+enum class GameEntityType;
+
 //! \brief A small structure storing level info for the player
 struct LevelInfo
 {
@@ -43,6 +45,8 @@ namespace MapLoader
     bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap);
 
     void writeGameMapToFile(const std::string& fileName, GameMap& gameMap);
+
+    bool readGameEntity(GameMap& gameMap, const std::string& item, GameEntityType type, std::stringstream& levelFile);
 
     bool loadEquipments(const std::string& fileName, GameMap& gameMap);
 

--- a/source/modes/AbstractModeManager.h
+++ b/source/modes/AbstractModeManager.h
@@ -34,6 +34,7 @@ public:
         MENU_EDITOR,
         MENU_CONFIGURE_SEATS,
         MENU_REPLAY,
+        MENU_LOAD_SAVEDGAME,
         GAME,
         EDITOR,
         CONSOLE,

--- a/source/modes/ConsoleCommands.cpp
+++ b/source/modes/ConsoleCommands.cpp
@@ -181,10 +181,9 @@ Command::Result cList(const Command::ArgumentList_t& args, ConsoleInterface& c, 
         {
             stringStr << "Player:\tNick:\tSeatId\tTeamId:\n\n";
 
-            for (unsigned int i = 0; i < gameMap->numPlayers(); ++i)
+            for (Player* player : gameMap->getPlayers())
             {
-                Player* player = gameMap->getPlayer(i);
-                stringStr << i << "\t\t" << player->getNick() << "\t"
+                stringStr << player->getId() << "\t\t" << player->getNick() << "\t"
                         << player->getSeat()->getId() << "\t"
                         << player->getSeat()->getTeamId() << "\n\n";
             }
@@ -208,9 +207,8 @@ Command::Result cList(const Command::ArgumentList_t& args, ConsoleInterface& c, 
     else if (args[1].compare("rooms") == 0)
     {
         stringStr << "Name:\tSeat Id:\tNum tiles:\n\n";
-        for (unsigned int i = 0 ; i < gameMap->numRooms(); ++i)
+        for (Room* room : gameMap->getRooms())
         {
-            Room* room = gameMap->getRoom(i);
             stringStr << room->getName() << "\t" << room->getSeat()->getId()
                     << "\t" << room->numCoveredTiles() << "\n";
         }

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -682,7 +682,7 @@ bool EditorMode::keyPressed(const OIS::KeyEvent &arg)
 
     switch (arg.key)
     {
-    case OIS::KC_F8:
+    case OIS::KC_F5:
         onSaveButtonClickFromOptions();
         break;
 

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -974,7 +974,7 @@ bool EditorMode::onSaveButtonClickFromOptions(const CEGUI::EventArgs& /*arg*/)
     {
         // Send a message to the server telling it we want to drop the creature
         ClientNotification *clientNotification = new ClientNotification(
-            ClientNotificationType::editorAskSaveMap);
+            ClientNotificationType::askSaveMap);
         ODClient::getSingleton().queueClientNotification(clientNotification);
     }
     return true;

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -893,6 +893,16 @@ bool GameMode::keyPressedNormal(const OIS::KeyEvent &arg)
         popupExit(!mGameMap->getGamePaused());
         break;
 
+    case OIS::KC_F8:
+        if(ODClient::getSingleton().isConnected())
+        {
+            // Send a message to the server telling it we want to drop the creature
+            ClientNotification *clientNotification = new ClientNotification(
+                ClientNotificationType::editorAskSaveMap);
+            ODClient::getSingleton().queueClientNotification(clientNotification);
+        }
+        break;
+
     // Print a screenshot
     case OIS::KC_SYSRQ:
         ResourceManager::getSingleton().takeScreenshot(frameListener.getRenderWindow());

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -898,7 +898,7 @@ bool GameMode::keyPressedNormal(const OIS::KeyEvent &arg)
         {
             // Send a message to the server telling it we want to drop the creature
             ClientNotification *clientNotification = new ClientNotification(
-                ClientNotificationType::editorAskSaveMap);
+                ClientNotificationType::askSaveMap);
             ODClient::getSingleton().queueClientNotification(clientNotification);
         }
         break;

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -1289,70 +1289,70 @@ bool GameMode::onMinimapClick(const CEGUI::EventArgs& arg)
 }
 void GameMode::refreshGuiResearch()
 {
-    Player* localPlayer = mGameMap->getLocalPlayer();
-    if(!localPlayer->getNeedRefreshGuiResearchDone())
+    Seat* localPlayerSeat = mGameMap->getLocalPlayer()->getSeat();
+    if(!localPlayerSeat->getNeedRefreshGuiResearchDone())
         return;
 
-    localPlayer->guiResearchRefreshedDone();
+    localPlayerSeat->guiResearchRefreshedDone();
 
     // We show/hide the icons depending on available researches
     CEGUI::Window* guiSheet = getModeManager().getGui().getGuiSheet(Gui::inGameMenu);
-    if(localPlayer->isResearchDone(ResearchType::roomDormitory))
+    if(localPlayerSeat->isResearchDone(ResearchType::roomDormitory))
         guiSheet->getChild(Gui::BUTTON_DORMITORY)->show();
     else
         guiSheet->getChild(Gui::BUTTON_DORMITORY)->hide();
 
-    if(localPlayer->isResearchDone(ResearchType::roomTreasury))
+    if(localPlayerSeat->isResearchDone(ResearchType::roomTreasury))
         guiSheet->getChild(Gui::BUTTON_TREASURY)->show();
     else
         guiSheet->getChild(Gui::BUTTON_TREASURY)->hide();
 
-    if(localPlayer->isResearchDone(ResearchType::roomHatchery))
+    if(localPlayerSeat->isResearchDone(ResearchType::roomHatchery))
         guiSheet->getChild(Gui::BUTTON_HATCHERY)->show();
     else
         guiSheet->getChild(Gui::BUTTON_HATCHERY)->hide();
 
-    if(localPlayer->isResearchDone(ResearchType::roomLibrary))
+    if(localPlayerSeat->isResearchDone(ResearchType::roomLibrary))
         guiSheet->getChild(Gui::BUTTON_LIBRARY)->show();
     else
         guiSheet->getChild(Gui::BUTTON_LIBRARY)->hide();
 
-    if(localPlayer->isResearchDone(ResearchType::roomCrypt))
+    if(localPlayerSeat->isResearchDone(ResearchType::roomCrypt))
         guiSheet->getChild(Gui::BUTTON_CRYPT)->show();
     else
         guiSheet->getChild(Gui::BUTTON_CRYPT)->hide();
 
-    if(localPlayer->isResearchDone(ResearchType::roomTrainingHall))
+    if(localPlayerSeat->isResearchDone(ResearchType::roomTrainingHall))
         guiSheet->getChild(Gui::BUTTON_TRAININGHALL)->show();
     else
         guiSheet->getChild(Gui::BUTTON_TRAININGHALL)->hide();
 
-    if(localPlayer->isResearchDone(ResearchType::roomForge))
+    if(localPlayerSeat->isResearchDone(ResearchType::roomForge))
         guiSheet->getChild(Gui::BUTTON_FORGE)->show();
     else
         guiSheet->getChild(Gui::BUTTON_FORGE)->hide();
 
-    if(localPlayer->isResearchDone(ResearchType::trapCannon))
+    if(localPlayerSeat->isResearchDone(ResearchType::trapCannon))
         guiSheet->getChild(Gui::BUTTON_TRAP_CANNON)->show();
     else
         guiSheet->getChild(Gui::BUTTON_TRAP_CANNON)->hide();
 
-    if(localPlayer->isResearchDone(ResearchType::trapSpike))
+    if(localPlayerSeat->isResearchDone(ResearchType::trapSpike))
         guiSheet->getChild(Gui::BUTTON_TRAP_SPIKE)->show();
     else
         guiSheet->getChild(Gui::BUTTON_TRAP_SPIKE)->hide();
 
-    if(localPlayer->isResearchDone(ResearchType::trapBoulder))
+    if(localPlayerSeat->isResearchDone(ResearchType::trapBoulder))
         guiSheet->getChild(Gui::BUTTON_TRAP_BOULDER)->show();
     else
         guiSheet->getChild(Gui::BUTTON_TRAP_BOULDER)->hide();
 
-    if(localPlayer->isResearchDone(ResearchType::spellSummonWorker))
+    if(localPlayerSeat->isResearchDone(ResearchType::spellSummonWorker))
         guiSheet->getChild(Gui::BUTTON_SPELL_SUMMON_WORKER)->show();
     else
         guiSheet->getChild(Gui::BUTTON_SPELL_SUMMON_WORKER)->hide();
 
-    if(localPlayer->isResearchDone(ResearchType::spellCallToWar))
+    if(localPlayerSeat->isResearchDone(ResearchType::spellCallToWar))
         guiSheet->getChild(Gui::BUTTON_SPELL_CALLTOWAR)->show();
     else
         guiSheet->getChild(Gui::BUTTON_SPELL_CALLTOWAR)->hide();

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -133,6 +133,12 @@ void GameMode::activate()
         )
     );
     addEventConnection(
+        guiSheet->getChild("GameOptionsWindow/SaveGameButton")->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&GameMode::saveGame, this)
+        )
+    );
+    addEventConnection(
         guiSheet->getChild("GameOptionsWindow/SettingsButton")->subscribeEvent(
             CEGUI::PushButton::EventClicked,
             CEGUI::Event::Subscriber(&GameMode::showSettingsFromOptions, this)
@@ -893,14 +899,8 @@ bool GameMode::keyPressedNormal(const OIS::KeyEvent &arg)
         popupExit(!mGameMap->getGamePaused());
         break;
 
-    case OIS::KC_F8:
-        if(ODClient::getSingleton().isConnected())
-        {
-            // Send a message to the server telling it we want to drop the creature
-            ClientNotification *clientNotification = new ClientNotification(
-                ClientNotificationType::askSaveMap);
-            ODClient::getSingleton().queueClientNotification(clientNotification);
-        }
+    case OIS::KC_F5:
+        saveGame();
         break;
 
     // Print a screenshot
@@ -1175,6 +1175,18 @@ bool GameMode::showObjectivesFromOptions(const CEGUI::EventArgs& /*e*/)
     CEGUI::Window* guiSheet = getModeManager().getGui().getGuiSheet(Gui::inGameMenu);
     guiSheet->getChild("GameOptionsWindow")->hide();
     guiSheet->getChild("ObjectivesWindow")->show();
+    return true;
+}
+
+bool GameMode::saveGame(const CEGUI::EventArgs& /*e*/)
+{
+    if(ODClient::getSingleton().isConnected())
+    {
+        // Send a message to the server telling it we want to drop the creature
+        ClientNotification *clientNotification = new ClientNotification(
+            ClientNotificationType::askSaveMap);
+        ODClient::getSingleton().queueClientNotification(clientNotification);
+    }
     return true;
 }
 

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -107,6 +107,7 @@ protected:
     //! \brief The different Game Options Menu handlers
     bool showQuitMenuFromOptions(const CEGUI::EventArgs& e = {});
     bool showObjectivesFromOptions(const CEGUI::EventArgs& e = {});
+    bool saveGame(const CEGUI::EventArgs& e = {});
     bool showSettingsFromOptions(const CEGUI::EventArgs& e = {});
 
     //! \brief Handle the keyboard input in normal mode

--- a/source/modes/MenuMode.cpp
+++ b/source/modes/MenuMode.cpp
@@ -47,6 +47,7 @@ MenuMode::MenuMode(ModeManager *modeManager):
     connectModeChangeEvent(Gui::MM_BUTTON_START_REPLAY, AbstractModeManager::ModeType::MENU_REPLAY);
     connectModeChangeEvent(Gui::MM_BUTTON_START_MULTIPLAYER_CLIENT, AbstractModeManager::ModeType::MENU_MULTIPLAYER_CLIENT);
     connectModeChangeEvent(Gui::MM_BUTTON_START_MULTIPLAYER_SERVER, AbstractModeManager::ModeType::MENU_MULTIPLAYER_SERVER);
+    connectModeChangeEvent(Gui::MM_BUTTON_LOAD_GAME, AbstractModeManager::ModeType::MENU_LOAD_SAVEDGAME);
     addEventConnection(
         getModeManager().getGui().getGuiSheet(Gui::mainMenu)->getChild(Gui::MM_BUTTON_QUIT)->subscribeEvent(
             CEGUI::PushButton::EventClicked,

--- a/source/modes/MenuModeEditor.cpp
+++ b/source/modes/MenuModeEditor.cpp
@@ -122,11 +122,6 @@ void MenuModeEditor::activate()
             item->setID(n);
             item->setSelectionBrushImage("OpenDungeonsSkin/SelectionBrush");
             levelSelectList->addItem(item);
-
-            // We reconstruct the filename to be relative to the levels/ folder
-            // because we'll need a relative reference for the even local client.
-            std::string levelFile = LEVEL_PATH_SKIRMISH + boost::filesystem::path(mFilesList[n]).filename().string();
-            mFilesList[n] = levelFile;
         }
     }
 
@@ -159,10 +154,10 @@ void MenuModeEditor::activate()
             item->setSelectionBrushImage("OpenDungeonsSkin/SelectionBrush");
             levelSelectList->addItem(item);
 
-            // We reconstruct the filename to be relative to the levels/ folder
-            // because we'll need a relative reference for the even local client.
-            std::string levelFile = LEVEL_PATH_MULTIPLAYER + boost::filesystem::path(mFilesList[n]).filename().string();
-            mFilesList[n] = levelFile;
+            // We save the absolute path
+            boost::filesystem::path p(mFilesList[n]);
+            p = boost::filesystem::canonical(p);
+            mFilesList[n] = p.string();
         }
     }
 }
@@ -187,7 +182,7 @@ bool MenuModeEditor::launchSelectedButtonPressed(const CEGUI::EventArgs&)
     CEGUI::ListboxItem* selItem = levelSelectList->getFirstSelectedItem();
     int id = selItem->getID();
 
-    std::string level = mFilesList[id];
+    const std::string& level = mFilesList[id];
 
     // In single player mode, we act as a server
     if(!ODServer::getSingleton().startServer(level, ODServer::ServerMode::ModeEditor))

--- a/source/modes/MenuModeLoad.cpp
+++ b/source/modes/MenuModeLoad.cpp
@@ -98,7 +98,6 @@ void MenuModeLoad::activate()
     tmpWin = getModeManager().getGui().getGuiSheet(Gui::loadSavedGameMenu)->getChild("LoadingText");
     tmpWin->hide();
     mFilesList.clear();
-    mDescriptionList.clear();
     levelSelectList->resetList();
 
     std::string levelPath = ResourceManager::getSingleton().getSaveGamePath();
@@ -106,24 +105,8 @@ void MenuModeLoad::activate()
     {
         for (uint32_t n = 0; n < mFilesList.size(); ++n)
         {
-            std::string filename = mFilesList[n];
-
-            LevelInfo levelInfo;
-            std::string mapName;
-            std::string mapDescription;
-            if(MapLoader::getMapInfo(filename, levelInfo))
-            {
-                mapName = levelInfo.mLevelName;
-                mapDescription = levelInfo.mLevelDescription;
-            }
-            else
-            {
-                mapName = "invalid map";
-                mapDescription = "invalid map";
-            }
-
-            mDescriptionList.push_back(mapDescription);
-            CEGUI::ListboxTextItem* item = new CEGUI::ListboxTextItem(mapName);
+            std::string filename = boost::filesystem::path(mFilesList[n]).filename().string();
+            CEGUI::ListboxTextItem* item = new CEGUI::ListboxTextItem(filename);
             item->setID(n);
             item->setSelectionBrushImage("OpenDungeonsSkin/SelectionBrush");
             levelSelectList->addItem(item);
@@ -220,8 +203,16 @@ bool MenuModeLoad::updateDescription(const CEGUI::EventArgs&)
     CEGUI::ListboxItem* selItem = levelSelectList->getFirstSelectedItem();
     int id = selItem->getID();
 
-    std::string description = mDescriptionList[id];
-    descTxt->setText(description);
+    std::string filename = mFilesList[id];
+
+    LevelInfo levelInfo;
+    std::string mapDescription;
+    if(MapLoader::getMapInfo(filename, levelInfo))
+        mapDescription = levelInfo.mLevelDescription;
+    else
+        mapDescription = "invalid map";
+
+    descTxt->setText(mapDescription);
 
     return true;
 }

--- a/source/modes/MenuModeLoad.h
+++ b/source/modes/MenuModeLoad.h
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2011-2015  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MENUMODELOAD_H
+#define MENUMODELOAD_H
+
+#include "AbstractApplicationMode.h"
+
+class MenuModeLoad: public AbstractApplicationMode
+{
+public:
+    MenuModeLoad(ModeManager*);
+
+    //! \brief Called when the game mode is activated
+    //! Used to call the corresponding Gui Sheet.
+    void activate() final override;
+
+    bool launchSelectedButtonPressed(const CEGUI::EventArgs&);
+    bool deleteSelectedButtonPressed(const CEGUI::EventArgs&);
+    bool updateDescription(const CEGUI::EventArgs&);
+private:
+    std::vector<std::string> mFilesList;
+    std::vector<std::string> mDescriptionList;
+};
+
+#endif // MENUMODELOAD_H

--- a/source/modes/MenuModeLoad.h
+++ b/source/modes/MenuModeLoad.h
@@ -34,7 +34,6 @@ public:
     bool updateDescription(const CEGUI::EventArgs&);
 private:
     std::vector<std::string> mFilesList;
-    std::vector<std::string> mDescriptionList;
 };
 
 #endif // MENUMODELOAD_H

--- a/source/modes/MenuModeMultiplayerServer.cpp
+++ b/source/modes/MenuModeMultiplayerServer.cpp
@@ -127,11 +127,6 @@ void MenuModeMultiplayerServer::activate()
             item->setID(n);
             item->setSelectionBrushImage("OpenDungeonsSkin/SelectionBrush");
             levelSelectList->addItem(item);
-
-            // We reconstruct the filename to be relative to the levels/ folder
-            // because we'll need a relative reference for the clients.
-            std::string levelFile = LEVEL_PATH + boost::filesystem::path(mFilesList[n]).filename().string();
-            mFilesList[n] = levelFile;
         }
     }
 }
@@ -178,7 +173,7 @@ bool MenuModeMultiplayerServer::serverButtonPressed(const CEGUI::EventArgs&)
     CEGUI::ListboxItem* selItem = levelSelectList->getFirstSelectedItem();
     int id = selItem->getID();
 
-    std::string level = mFilesList[id];
+    const std::string& level = mFilesList[id];
 
     // We are a server
     if(!ODServer::getSingleton().startServer(level, ODServer::ServerMode::ModeGameMultiPlayer))

--- a/source/modes/MenuModeReplay.cpp
+++ b/source/modes/MenuModeReplay.cpp
@@ -106,7 +106,6 @@ void MenuModeReplay::activate()
         for (uint32_t n = 0; n < mFilesList.size(); ++n)
         {
             std::string filename = boost::filesystem::path(mFilesList[n]).filename().string();
-            mFilesList[n] = filename;
             CEGUI::ListboxTextItem* item = new CEGUI::ListboxTextItem(filename);
             item->setID(n);
             item->setSelectionBrushImage("OpenDungeonsSkin/SelectionBrush");
@@ -144,7 +143,7 @@ bool MenuModeReplay::launchSelectedButtonPressed(const CEGUI::EventArgs&)
         return true;
     }
 
-    std::string replayFile = ResourceManager::getSingleton().getReplayDataPath() + mFilesList[id];
+    const std::string& replayFile = mFilesList[id];
     if(!ODClient::getSingleton().replay(replayFile))
     {
         LogManager::getSingleton().logMessage("ERROR: Could not launch replay !!!");
@@ -172,7 +171,7 @@ bool MenuModeReplay::deleteSelectedButtonPressed(const CEGUI::EventArgs&)
     CEGUI::ListboxItem* selItem = replaySelectList->getFirstSelectedItem();
     int id = selItem->getID();
 
-    std::string replayFile = ResourceManager::getSingleton().getReplayDataPath() + mFilesList[id];
+    const std::string& replayFile = mFilesList[id];
     if(!boost::filesystem::remove(replayFile))
     {
         LogManager::getSingleton().logMessage("ERROR: Could not delete replay !!!");
@@ -212,9 +211,8 @@ bool MenuModeReplay::listReplaysClicked(const CEGUI::EventArgs&)
 
 bool MenuModeReplay::checkReplayValid(const std::string& replayFileName, std::string& mapDescription, std::string& errorMsg)
 {
-    std::string replayFile = ResourceManager::getSingleton().getReplayDataPath() + replayFileName;
     // We open the replay to get the level file name
-    std::ifstream is(replayFile, std::ios::in | std::ios::binary);
+    std::ifstream is(replayFileName, std::ios::in | std::ios::binary);
     ODPacket packet;
     ServerNotificationType type;
     do

--- a/source/modes/ModeManager.cpp
+++ b/source/modes/ModeManager.cpp
@@ -25,6 +25,7 @@
 #include "modes/MenuModeMultiplayerServer.h"
 #include "modes/MenuModeEditor.h"
 #include "modes/MenuModeReplay.h"
+#include "modes/MenuModeLoad.h"
 #include "modes/GameMode.h"
 #include "modes/EditorMode.h"
 #include "modes/ConsoleMode.h"
@@ -107,6 +108,9 @@ void ModeManager::addMode(ModeType mt)
         break;
     case FPP:
         mApplicationModes.emplace_back(new FppMode(this));
+        break;
+    case MENU_LOAD_SAVEDGAME:
+        mApplicationModes.emplace_back(new MenuModeLoad(this));
         break;
     default:
         break;

--- a/source/network/ClientNotification.cpp
+++ b/source/network/ClientNotification.cpp
@@ -72,8 +72,8 @@ std::string ClientNotification::typeString(ClientNotificationType type)
             return "askCastSpell";
         case ClientNotificationType::askSetResearchTree:
             return "askSetResearchTree";
-        case ClientNotificationType::editorAskSaveMap:
-            return "editorAskSaveMap";
+        case ClientNotificationType::askSaveMap:
+            return "askSaveMap";
         case ClientNotificationType::editorAskChangeTiles:
             return "editorAskChangeTiles";
         case ClientNotificationType::editorAskBuildRoom:

--- a/source/network/ClientNotification.h
+++ b/source/network/ClientNotification.h
@@ -52,8 +52,9 @@ enum class ClientNotificationType
     askCastSpell,
     askSetResearchTree,
 
+    askSaveMap,
+
     //  Editor
-    editorAskSaveMap,
     editorAskChangeTiles,
     editorAskBuildRoom,
     editorAskBuildTrap,

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -826,7 +826,7 @@ bool ODClient::processOneClientSocketMessage()
                 researches.push_back(research);
             }
 
-            getPlayer()->setResearchTree(researches);
+            getPlayer()->getSeat()->setResearchTree(researches);
             break;
         }
 
@@ -843,7 +843,7 @@ bool ODClient::processOneClientSocketMessage()
                 researches.push_back(research);
             }
 
-            getPlayer()->setResearchesDone(researches);
+            getPlayer()->getSeat()->setResearchesDone(researches);
             break;
         }
 

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -45,12 +45,14 @@
 #include "spell/Spell.h"
 #include "utils/ConfigManager.h"
 #include "utils/Helper.h"
+#include "utils/ResourceManager.h"
 
 #include <SFML/Network.hpp>
 #include <SFML/System.hpp>
 
 #include <boost/lexical_cast.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 const std::string ODServer::SERVER_INFORMATION = "SERVER_INFORMATION";
 
@@ -1505,32 +1507,50 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             break;
         }
 
-        case ClientNotificationType::editorAskSaveMap:
+        case ClientNotificationType::askSaveMap:
         {
-            OD_ASSERT_TRUE_MSG(mServerMode == ServerMode::ModeEditor, "Received editor command while wrong mode mode"
-                + Ogre::StringConverter::toString(static_cast<int>(mServerMode)));
             Player* player = clientSocket->getPlayer();
-            if(player->numObjectsInHand() == 0)
-            {
-                // If the file exists, we make a backup
-                const boost::filesystem::path levelPath(gameMap->getLevelFileName());
-                if (boost::filesystem::exists(levelPath))
-                    boost::filesystem::rename(gameMap->getLevelFileName(), gameMap->getLevelFileName() + ".bak");
-
-                std::string msg = "Map saved successfully";
-                MapLoader::writeGameMapToFile(gameMap->getLevelFileName(), *gameMap);
-                ServerNotification notif(ServerNotificationType::chatServer, player);
-                notif.mPacket << msg;
-                sendAsyncMsg(notif);
-            }
-            else
+            const boost::filesystem::path levelPath(gameMap->getLevelFileName());
+            std::string fileLevel = levelPath.filename().string();
+            // In editor mode, we don't allow a player to have creatures in hand while saving map
+            if((mServerMode == ServerMode::ModeEditor) &&
+                (player->numObjectsInHand() > 0))
             {
                 // We cannot save the map
                 std::string msg = "Map could not be saved because player hand is not empty";
                 ServerNotification notif(ServerNotificationType::chatServer, player);
                 notif.mPacket << msg;
                 sendAsyncMsg(notif);
+                break;
             }
+
+            boost::filesystem::path levelSave;
+            if(mServerMode == ServerMode::ModeEditor)
+            {
+                // In editor mode, we save in the original folder
+                levelSave = levelPath;
+            }
+            else
+            {
+                // We save in the saved game folder
+                static std::locale loc(std::wcout.getloc(), new boost::posix_time::time_facet("%Y-%m-%d_%H%M%S"));
+
+                std::ostringstream ss;
+                ss.imbue(loc);
+                ss << boost::posix_time::second_clock::local_time() << "-" << fileLevel;
+                std::string savePath = ResourceManager::getSingleton().getSaveGamePath() + ss.str();
+                levelSave = boost::filesystem::path(savePath);
+            }
+
+            // If the file exists, we make a backup
+            if (boost::filesystem::exists(levelSave))
+                boost::filesystem::rename(levelSave, levelSave.string() + ".bak");
+
+            std::string msg = "Map saved successfully";
+            MapLoader::writeGameMapToFile(levelSave.string(), *gameMap);
+            ServerNotification notif(ServerNotificationType::chatServer, player);
+            notif.mPacket << msg;
+            sendAsyncMsg(notif);
             break;
         }
 

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -986,7 +986,7 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             // We check if the room is available. It is not normal to receive a message
             // asking to build an unbuildable room since the client should only display
             // available rooms
-            if(!player->isRoomAvailableForPlayer(type))
+            if(!player->getSeat()->isRoomAvailable(type))
             {
                 LogManager::getSingleton().logMessage("WARNING: player " + player->getNick()
                     + " asked to cast a spell not available: " + Room::getRoomNameFromRoomType(type));
@@ -1258,7 +1258,7 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             // We check if the trap is available. It is not normal to receive a message
             // asking to build an unbuildable trap since the client should only display
             // available traps
-            if(!player->isTrapAvailableForPlayer(type))
+            if(!player->getSeat()->isTrapAvailable(type))
             {
                 LogManager::getSingleton().logMessage("WARNING: player " + player->getNick()
                     + " asked to cast a spell not available: " + Trap::getTrapNameFromTrapType(type));
@@ -1320,7 +1320,7 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             // We check if the spell is available. It is not normal to receive a message
             // asking to cast an uncastable spell since the client should only display
             // available spells
-            if(!player->isSpellAvailableForPlayer(spellType))
+            if(!player->getSeat()->isSpellAvailable(spellType))
             {
                 LogManager::getSingleton().logMessage("WARNING: player " + player->getNick()
                     + " asked to cast a spell not available: " + Spell::getSpellNameFromSpellType(spellType));
@@ -1872,7 +1872,7 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 researches.push_back(research);
             }
 
-            player->setResearchTree(researches);
+            player->getSeat()->setResearchTree(researches);
             break;
         }
 

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -345,8 +345,8 @@ void ODServer::serverThread()
                     if(seat->getPlayer() == nullptr)
                         continue;
 
-                    if(seat->getStartingGold() > 0)
-                        gameMap->addGoldToSeat(seat->getStartingGold(), seat->getId());
+                    if(seat->getGold() > 0)
+                        gameMap->addGoldToSeat(seat->getGold(), seat->getId());
                 }
             }
             else

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -1537,7 +1537,9 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
 
                 std::ostringstream ss;
                 ss.imbue(loc);
-                ss << boost::posix_time::second_clock::local_time() << "-" << fileLevel;
+                ss << boost::posix_time::second_clock::local_time() << "-";
+                ss << (mServerMode == ServerMode::ModeGameSinglePlayer ? "SK-" : "MP-");
+                ss << fileLevel;
                 std::string savePath = ResourceManager::getSingleton().getSaveGamePath() + ss.str();
                 levelSave = boost::filesystem::path(savePath);
             }

--- a/source/render/Gui.cpp
+++ b/source/render/Gui.cpp
@@ -82,6 +82,7 @@ Gui::Gui(SoundEffectsManager* soundEffectsManager, const std::string& ceguiLogFi
     mSheets[editorMenu] =  wmgr->loadLayoutFromFile("OpenDungeonsEditorMenu.layout");
     mSheets[configureSeats] =  wmgr->loadLayoutFromFile("OpenDungeonsMenuConfigureSeats.layout");
     mSheets[replayMenu] =  wmgr->loadLayoutFromFile("OpenDungeonsMenuReplay.layout");
+    mSheets[loadSavedGameMenu] =  wmgr->loadLayoutFromFile("OpenDungeonsMenuLoad.layout");
     mSheets[console] = wmgr->loadLayoutFromFile("OpenDungeonsConsole.layout");
 
     assignEventHandlers();
@@ -351,6 +352,7 @@ void Gui::assignEventHandlers()
     mSheets[multiplayerClientMenu]->getChild("VersionText")->setText(ODApplication::VERSION);
     mSheets[editorMenu]->getChild("VersionText")->setText(ODApplication::VERSION);
     mSheets[replayMenu]->getChild("VersionText")->setText(ODApplication::VERSION);
+    mSheets[loadSavedGameMenu]->getChild("VersionText")->setText(ODApplication::VERSION);
 }
 
 bool Gui::playButtonClickSound(const CEGUI::EventArgs&)
@@ -711,6 +713,7 @@ const std::string Gui::MM_BUTTON_START_SKIRMISH = "StartSkirmishButton";
 const std::string Gui::MM_BUTTON_START_REPLAY = "StartReplayButton";
 const std::string Gui::MM_BUTTON_START_MULTIPLAYER_CLIENT = "StartMultiplayerClientButton";
 const std::string Gui::MM_BUTTON_START_MULTIPLAYER_SERVER = "StartMultiplayerServerButton";
+const std::string Gui::MM_BUTTON_LOAD_GAME = "LoadGameButton";
 const std::string Gui::MM_BUTTON_MAPEDITOR = "MapEditorButton";
 const std::string Gui::MM_BUTTON_QUIT = "QuitButton";
 const std::string Gui::EXIT_CONFIRMATION_POPUP = "ConfirmExit";

--- a/source/render/Gui.h
+++ b/source/render/Gui.h
@@ -53,6 +53,7 @@ public:
         optionsMenu,
         inGameMenu,
         replayMenu,
+        loadSavedGameMenu,
         configureSeats,
         console
     };
@@ -110,6 +111,7 @@ public:
     static const std::string MM_BUTTON_START_REPLAY;
     static const std::string MM_BUTTON_START_MULTIPLAYER_CLIENT;
     static const std::string MM_BUTTON_START_MULTIPLAYER_SERVER;
+    static const std::string MM_BUTTON_LOAD_GAME;
     static const std::string MM_BUTTON_MAPEDITOR;
     static const std::string MM_BUTTON_QUIT;
     static const std::string EDITOR;

--- a/source/rooms/Room.cpp
+++ b/source/rooms/Room.cpp
@@ -164,7 +164,7 @@ Creature* Room::getCreatureUsingRoom(unsigned index)
     return mCreaturesUsingRoom[index];
 }
 
-std::string Room::getFormat()
+std::string Room::getRoomStreamFormat()
 {
     return "typeRoom\tseatId\tnumTiles\t\tSubsequent Lines: tileX\ttileY";
 }

--- a/source/rooms/Room.h
+++ b/source/rooms/Room.h
@@ -66,7 +66,7 @@ public:
 
     virtual void absorbRoom(Room* r);
 
-    static std::string getFormat();
+    static std::string getRoomStreamFormat();
 
     static Room* getRoomFromStream(GameMap* gameMap, std::istream& is);
     static Room* getRoomFromPacket(GameMap* gameMap, ODPacket& is);

--- a/source/rooms/RoomCrypt.cpp
+++ b/source/rooms/RoomCrypt.cpp
@@ -256,3 +256,17 @@ void RoomCrypt::notifyCarryingStateChanged(Creature* carrier, GameEntity* carrie
     // been erased between the time the carrier tried to come and the time it arrived.
     // In any case, nothing to do
 }
+
+void RoomCrypt::exportToStream(std::ostream& os) const
+{
+    Room::exportToStream(os);
+    os << mRottenPoints << "\n";
+    // We do not save rotten creatures. They will automatically be carried again by workers
+}
+
+void RoomCrypt::importFromStream(std::istream& is)
+{
+    Room::importFromStream(is);
+    OD_ASSERT_TRUE(is >> mRottenPoints);
+    // We do not save rotten creatures. They will automatically be carried again by workers
+}

--- a/source/rooms/RoomCrypt.h
+++ b/source/rooms/RoomCrypt.h
@@ -25,19 +25,22 @@ class RoomCrypt: public Room
 public:
     RoomCrypt(GameMap* gameMap);
 
-    virtual RoomType getType() const
+    virtual RoomType getType() const override
     { return RoomType::crypt; }
 
-    void absorbRoom(Room *r);
+    void absorbRoom(Room *r) override;
 
-    void doUpkeep();
+    void doUpkeep() override;
 
-    bool hasCarryEntitySpot(GameEntity* carriedEntity);
-    Tile* askSpotForCarriedEntity(GameEntity* carriedEntity);
-    void notifyCarryingStateChanged(Creature* carrier, GameEntity* carriedEntity);
+    bool hasCarryEntitySpot(GameEntity* carriedEntity) override;
+    Tile* askSpotForCarriedEntity(GameEntity* carriedEntity) override;
+    void notifyCarryingStateChanged(Creature* carrier, GameEntity* carriedEntity) override;
+
+    virtual void exportToStream(std::ostream& os) const override;
+    virtual void importFromStream(std::istream& is) override;
 protected:
-    virtual RenderedMovableEntity* notifyActiveSpotCreated(ActiveSpotPlace place, Tile* tile);
-    virtual void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile);
+    virtual RenderedMovableEntity* notifyActiveSpotCreated(ActiveSpotPlace place, Tile* tile) override;
+    virtual void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile) override;
 private:
     std::map<Tile*,std::pair<Creature*, int32_t> > mRottingCreatures;
     int32_t mRottenPoints;

--- a/source/rooms/RoomDormitory.h
+++ b/source/rooms/RoomDormitory.h
@@ -32,40 +32,26 @@ public:
         mOwningTile(tile)
     {}
 
-    double getX() const
-    {
-        return mX;
-    }
+    inline double getX() const
+    { return mX; }
 
-    double getY() const
-    {
-        return mY;
-    }
+    inline double getY() const
+    { return mY; }
 
-    double getRotation() const
-    {
-        return mRotation;
-    }
+    inline double getRotation() const
+    { return mRotation; }
 
-    Creature* getCreature()
-    {
-        return mCreature;
-    }
+    inline Creature* getCreature() const
+    { return mCreature; }
 
-    Tile* getOwningTile()
-    {
-        return mOwningTile;
-    }
+    inline Tile* getOwningTile() const
+    { return mOwningTile; }
 
-    const std::vector<Tile*>& getTilesTaken()
-    {
-        return mTilesTaken;
-    }
+    inline const std::vector<Tile*>& getTilesTaken() const
+    { return mTilesTaken; }
 
-    void addTileTaken(Tile* tile)
-    {
-        mTilesTaken.push_back(tile);
-    }
+    inline void addTileTaken(Tile* tile)
+    { mTilesTaken.push_back(tile); }
 
 private:
     //! \brief Building object position.
@@ -85,19 +71,56 @@ private:
     std::vector<Tile*> mTilesTaken;
 };
 
+/*! Class used at room loading to save the data needed to recreate the beds after map loading when
+ * restoreInitialEntityState is called
+ */
+class BedCreatureLoad
+{
+public:
+    BedCreatureLoad(const std::string& creatureName, int tileX, int tileY, double rotationAngle) :
+        mCreatureName(creatureName),
+        mTileX(tileX),
+        mTileY(tileY),
+        mRotationAngle(rotationAngle)
+    {}
+
+    inline int getTileX() const
+    { return mTileX; }
+
+    inline int getTileY() const
+    { return mTileY; }
+
+    inline const std::string& getCreatureName() const
+    { return mCreatureName; }
+
+    inline double getRotationAngle() const
+    { return mRotationAngle; }
+
+private:
+    std::string mCreatureName;
+    int mTileX;
+    int mTileY;
+    double mRotationAngle;
+};
+
 class RoomDormitory: public Room
 {
 public:
     RoomDormitory(GameMap* gameMap);
 
-    virtual RoomType getType() const
+    virtual RoomType getType() const override
     { return RoomType::dormitory; }
 
     // Functions overriding virtual functions in the Room base class.
-    void absorbRoom(Room *r);
-    void addCoveredTile(Tile* t, double nHP);
-    bool removeCoveredTile(Tile* t);
-    void clearCoveredTiles();
+    void absorbRoom(Room *r) override;
+    void addCoveredTile(Tile* t, double nHP) override;
+    bool removeCoveredTile(Tile* t) override;
+    void clearCoveredTiles() override;
+
+    virtual void exportToStream(std::ostream& os) const override;
+    virtual void importFromStream(std::istream& is) override;
+
+    virtual void restoreInitialEntityState() override;
 
     // Functions specific to this class.
     std::vector<Tile*> getOpenTiles();
@@ -109,11 +132,12 @@ protected:
     // Because dormitory do not use active spots, we don't want the default
     // behaviour (removing the active spot tile) as it could result in removing an
     // unwanted bed
-    void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile)
+    void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile) override
     {}
 
 private:
     bool tileCanAcceptBed(Tile *tile, int xDim, int yDim);
+    void createBed(Tile* t, double rotationAngle, Creature* c);
 
     //! \brief Keeps track of the tiles taken by a creature bed
     std::map<Tile*, Creature*> mCreatureSleepingInTile;
@@ -121,6 +145,9 @@ private:
     //! \brief Keeps track of info about the beds in order to be able
     //! to recreate them.
     std::vector<BedRoomObjectInfo> mBedRoomObjectsInfo;
+
+    //! Used at map load to store information about beds already in this room
+    std::vector<BedCreatureLoad> mBedCreatureLoad;
 };
 
 #endif // ROOMDORMITORY_H

--- a/source/rooms/RoomDungeonTemple.cpp
+++ b/source/rooms/RoomDungeonTemple.cpp
@@ -115,7 +115,7 @@ void RoomDungeonTemple::notifyCarryingStateChanged(Creature* carrier, GameEntity
 
     // We notify the player that the research is now available and we delete the researchEntity
     ResearchEntity* researchEntity = static_cast<ResearchEntity*>(carriedEntity);
-    getSeat()->getPlayer()->addResearch(researchEntity->getResearchType());
+    getSeat()->addResearch(researchEntity->getResearchType());
     researchEntity->removeFromGameMap();
     researchEntity->deleteYourself();
 }

--- a/source/rooms/RoomForge.cpp
+++ b/source/rooms/RoomForge.cpp
@@ -37,7 +37,6 @@ const Ogre::Real OFFSET_SPOT = 0.3;
 
 RoomForge::RoomForge(GameMap* gameMap) :
     Room(gameMap),
-    mNbTurnsNoChangeSpots(0),
     mPoints(0),
     mTrapType(TrapType::nullTrapType)
 {
@@ -438,4 +437,18 @@ void RoomForge::getCreatureWantedPos(Creature* creature, Tile* tileSpot,
     wantedX = static_cast<Ogre::Real>(tileSpot->getX());
     wantedY = static_cast<Ogre::Real>(tileSpot->getY());
     wantedY -= OFFSET_CREATURE;
+}
+
+void RoomForge::exportToStream(std::ostream& os) const
+{
+    Room::exportToStream(os);
+    os << mPoints << "\t";
+    os << mTrapType << "\n";
+}
+
+void RoomForge::importFromStream(std::istream& is)
+{
+    Room::importFromStream(is);
+    OD_ASSERT_TRUE(is >> mPoints);
+    OD_ASSERT_TRUE(is >> mTrapType);
 }

--- a/source/rooms/RoomForge.h
+++ b/source/rooms/RoomForge.h
@@ -27,25 +27,27 @@ class RoomForge: public Room
 public:
     RoomForge(GameMap* gameMap);
 
-    virtual RoomType getType() const
+    virtual RoomType getType() const override
     { return RoomType::forge; }
 
-    virtual void doUpkeep();
-    virtual bool hasOpenCreatureSpot(Creature* c);
-    virtual bool addCreatureUsingRoom(Creature* c);
-    virtual void removeCreatureUsingRoom(Creature* c);
-    virtual void absorbRoom(Room *r);
-    virtual void addCoveredTile(Tile* t, double nHP);
-    virtual bool removeCoveredTile(Tile* t);
+    virtual void doUpkeep() override;
+    virtual bool hasOpenCreatureSpot(Creature* c) override;
+    virtual bool addCreatureUsingRoom(Creature* c) override;
+    virtual void removeCreatureUsingRoom(Creature* c) override;
+    virtual void absorbRoom(Room *r) override;
+    virtual void addCoveredTile(Tile* t, double nHP) override;
+    virtual bool removeCoveredTile(Tile* t) override;
+
+    virtual void exportToStream(std::ostream& os) const override;
+    virtual void importFromStream(std::istream& is) override;
 
 protected:
-    virtual RenderedMovableEntity* notifyActiveSpotCreated(ActiveSpotPlace place, Tile* tile);
-    virtual void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile);
+    virtual RenderedMovableEntity* notifyActiveSpotCreated(ActiveSpotPlace place, Tile* tile) override;
+    virtual void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile) override;
 private:
     //!\brief checks if a tile is available in the forge to place a new crafted trap
     uint32_t countCraftedItemsOnRoom();
     Tile* checkIfAvailableSpot(const std::vector<Tile*>& activeSpots);
-    int32_t mNbTurnsNoChangeSpots;
     int32_t mPoints;
     TrapType mTrapType;
     void getCreatureWantedPos(Creature* creature, Tile* tileSpot,

--- a/source/rooms/RoomLibrary.cpp
+++ b/source/rooms/RoomLibrary.cpp
@@ -141,7 +141,7 @@ bool RoomLibrary::hasOpenCreatureSpot(Creature* c)
     if(getSeat()->getPlayer() == nullptr)
         return false;
 
-    if(!getSeat()->getPlayer()->isResearching())
+    if(!getSeat()->isResearching())
         return false;
 
     // We accept all creatures as soon as there are free active spots
@@ -208,7 +208,7 @@ void RoomLibrary::doUpkeep()
         return;
 
     // If there is nothing to do, we remove the working creatures if any
-    if(!getSeat()->getPlayer()->isResearching())
+    if(!getSeat()->isResearching())
     {
         if(mCreaturesSpots.empty())
             return;
@@ -274,7 +274,7 @@ void RoomLibrary::doUpkeep()
                     ConfigManager::getSingleton().getRoomConfigUInt32("LibraryCooldownWorkMax")));
 
                 // We check if we have enough points for the current research
-                const Research* researchDone = getSeat()->getPlayer()->addResearchPoints(pointsEarned);
+                const Research* researchDone = getSeat()->addResearchPoints(pointsEarned);
                 if(researchDone == nullptr)
                     continue;
 

--- a/source/rooms/RoomLibrary.h
+++ b/source/rooms/RoomLibrary.h
@@ -29,25 +29,24 @@ class RoomLibrary: public Room
 public:
     RoomLibrary(GameMap* gameMap);
 
-    virtual RoomType getType() const
+    virtual RoomType getType() const override
     { return RoomType::library; }
 
-    virtual void doUpkeep();
-    virtual bool hasOpenCreatureSpot(Creature* c);
-    virtual bool addCreatureUsingRoom(Creature* c);
-    virtual void removeCreatureUsingRoom(Creature* c);
-    virtual void absorbRoom(Room *r);
-    virtual void addCoveredTile(Tile* t, double nHP);
-    virtual bool removeCoveredTile(Tile* t);
+    virtual void doUpkeep() override;
+    virtual bool hasOpenCreatureSpot(Creature* c) override;
+    virtual bool addCreatureUsingRoom(Creature* c) override;
+    virtual void removeCreatureUsingRoom(Creature* c) override;
+    virtual void absorbRoom(Room *r) override;
+    virtual void addCoveredTile(Tile* t, double nHP) override;
+    virtual bool removeCoveredTile(Tile* t) override;
 
 protected:
-    virtual RenderedMovableEntity* notifyActiveSpotCreated(ActiveSpotPlace place, Tile* tile);
-    virtual void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile);
+    virtual RenderedMovableEntity* notifyActiveSpotCreated(ActiveSpotPlace place, Tile* tile) override;
+    virtual void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile) override;
 private:
     //!\brief checks how many items are on the library
     uint32_t countResearchItemsOnRoom();
     Tile* checkIfAvailableSpot(const std::vector<Tile*>& activeSpots);
-    int32_t mNbTurnsNoChangeSpots;
     void getCreatureWantedPos(Creature* creature, Tile* tileSpot,
         Ogre::Real& wantedX, Ogre::Real& wantedY);
     std::vector<Tile*> mUnusedSpots;

--- a/source/spell/Spell.cpp
+++ b/source/spell/Spell.cpp
@@ -274,9 +274,10 @@ void Spell::notifySeatsWithVision(const std::vector<Seat*>& seats)
     }
 }
 
-std::string Spell::getFormat()
+std::string Spell::getSpellStreamFormat()
 {
-    return "typeSpell\tseatId\tnumTiles\t\tSubsequent Lines: tileX\ttileY\tisActivated(0/1)\t\tSubsequent Lines: optional specific data";
+    return "typeSpell\t" + RenderedMovableEntity::getRenderedMovableEntityStreamFormat()
+        + "optionalData\t";
 }
 
 void Spell::exportHeadersToStream(std::ostream& os)
@@ -289,56 +290,6 @@ void Spell::exportHeadersToPacket(ODPacket& os)
 {
     RenderedMovableEntity::exportHeadersToPacket(os);
     os << getSpellType();
-}
-
-void Spell::exportToPacket(ODPacket& os) const
-{
-    int seatId = -1;
-    Seat* seat = getSeat();
-    if(seat != nullptr)
-        seatId = seat->getId();
-
-    os << seatId;
-    RenderedMovableEntity::exportToPacket(os);
-}
-
-void Spell::importFromPacket(ODPacket& is)
-{
-    int seatId;
-    OD_ASSERT_TRUE_MSG(is >> seatId, "name=" + getName());
-    if(seatId != -1)
-    {
-        Seat* seat = getGameMap()->getSeatById(seatId);
-        OD_ASSERT_TRUE_MSG(seat != nullptr, "name=" + getName() + ", seatId=" + Helper::toString(seatId));
-        if(seat != nullptr)
-            setSeat(seat);
-    }
-    RenderedMovableEntity::importFromPacket(is);
-}
-
-void Spell::exportToStream(std::ostream& os) const
-{
-    int seatId = -1;
-    Seat* seat = getSeat();
-    if(seat != nullptr)
-        seatId = seat->getId();
-
-    os << seatId;
-    RenderedMovableEntity::exportToStream(os);
-}
-
-void Spell::importFromStream(std::istream& is)
-{
-    int seatId;
-    OD_ASSERT_TRUE_MSG(is >> seatId, "name=" + getName());
-    if(seatId != -1)
-    {
-        Seat* seat = getGameMap()->getSeatById(seatId);
-        OD_ASSERT_TRUE_MSG(seat != nullptr, "name=" + getName() + ", seatId=" + Helper::toString(seatId));
-        if(seat != nullptr)
-            setSeat(seat);
-    }
-    RenderedMovableEntity::importFromStream(is);
 }
 
 std::istream& operator>>(std::istream& is, SpellType& tt)

--- a/source/spell/Spell.h
+++ b/source/spell/Spell.h
@@ -75,13 +75,8 @@ public:
      */
     virtual void exportHeadersToStream(std::ostream& os) override;
     virtual void exportHeadersToPacket(ODPacket& os) override;
-    //! \brief Exports the data of the Spell
-    virtual void exportToStream(std::ostream& os) const override;
-    virtual void importFromStream(std::istream& is) override;
-    virtual void exportToPacket(ODPacket& os) const override;
-    virtual void importFromPacket(ODPacket& is) override;
 
-    static std::string getFormat();
+    static std::string getSpellStreamFormat();
 
 private:
     //! \brief Number of turns the spell should be displayed before automatic deletion.

--- a/source/spell/SpellCallToWar.cpp
+++ b/source/spell/SpellCallToWar.cpp
@@ -63,7 +63,6 @@ void SpellCallToWar::slap()
 int SpellCallToWar::getSpellCallToWarCost(GameMap* gameMap, const std::vector<Tile*>& tiles, Player* player)
 {
     // Call to war can be cast on every tile where fullness = 0 (no matter type or vision)
-
     int32_t priceTotal = 0;
     int32_t pricePerTile = ConfigManager::getSingleton().getSpellConfigInt32("CallToWarPrice");
     for(Tile* tile : tiles)

--- a/source/spell/SpellCallToWar.h
+++ b/source/spell/SpellCallToWar.h
@@ -28,12 +28,12 @@ public:
     SpellCallToWar(GameMap* gameMap);
     virtual ~SpellCallToWar();
 
-    SpellType getSpellType() const
+    SpellType getSpellType() const override
     { return SpellType::callToWar; }
 
-    bool canSlap(Seat* seat);
+    bool canSlap(Seat* seat) override;
 
-    void slap();
+    void slap() override;
 
     static int getSpellCallToWarCost(GameMap* gameMap, const std::vector<Tile*>& tiles, Player* player);
 

--- a/source/traps/Trap.cpp
+++ b/source/traps/Trap.cpp
@@ -515,7 +515,7 @@ bool Trap::isAttackable(Tile* tile, Seat* seat) const
     return true;
 }
 
-std::string Trap::getFormat()
+std::string Trap::getTrapStreamFormat()
 {
     return "typeTrap\tseatId\tnumTiles\t\tSubsequent Lines: tileX\ttileY\tisActivated(0/1)\t\tSubsequent Lines: optional specific data";
 }

--- a/source/traps/Trap.h
+++ b/source/traps/Trap.h
@@ -189,7 +189,7 @@ public:
     virtual void exportToPacket(ODPacket& os) const override;
     virtual void importFromPacket(ODPacket& is) override;
 
-    static std::string getFormat();
+    static std::string getTrapStreamFormat();
 
 protected:
     virtual RenderedMovableEntity* notifyActiveSpotCreated(Tile* tile);

--- a/source/utils/Helper.cpp
+++ b/source/utils/Helper.cpp
@@ -96,7 +96,10 @@ namespace Helper
             if(!boost::filesystem::is_directory(itr->status()))
             {
                 if(itr->path().filename().extension().string() == fileExtension)
-                    listFiles.push_back(itr->path().string());
+                {
+                    boost::filesystem::path p = boost::filesystem::canonical(itr->path());
+                    listFiles.push_back(p.string());
+                }
             }
         }
         return true;

--- a/source/utils/Helper.h
+++ b/source/utils/Helper.h
@@ -79,8 +79,8 @@ namespace Helper
     int round(double d);
     int round(float d);
 
-    //! \brief Returns the filenames of the given directory.
-    //! \note The folder parameter given is part of the returned filenames.
+    //! \brief Fills listFiles with the absolute path of files in the given directory
+    //! matching fileExtension. Returns true on success, false otherwise
     bool fillFilesList(const std::string& path,
                        std::vector<std::string>& listFiles,
                        const std::string& fileExtension);

--- a/source/utils/ResourceManager.cpp
+++ b/source/utils/ResourceManager.cpp
@@ -255,6 +255,16 @@ void ResourceManager::setupUserDataFolders()
         exit(1);
     }
 
+    mSaveGamePath = mUserDataPath + "saves/";
+    try {
+      boost::filesystem::create_directories(mSaveGamePath);
+    }
+    catch (const boost::filesystem::filesystem_error& e) {
+        //TODO - Exit gracefully
+        std::cerr << "Fatal error creating replay folder: " << e.what() <<  std::endl;
+        exit(1);
+    }
+
     mOgreCfgFile = mUserConfigPath + CONFIGFILENAME;
     mOgreLogFile = mUserDataPath + LOGFILENAME;
     mCeguiLogFile = mUserDataPath + CEGUILOGFILENAME;

--- a/source/utils/ResourceManager.h
+++ b/source/utils/ResourceManager.h
@@ -73,6 +73,9 @@ public:
     inline const std::string& getReplayDataPath() const
     { return mReplayPath; }
 
+    inline const std::string& getSaveGamePath() const
+    { return mSaveGamePath; }
+
     inline const std::string& getUserConfigPath() const
     { return mUserConfigPath; }
 
@@ -141,6 +144,7 @@ private:
     std::string mScriptPath;
     std::string mLanguagePath;
     std::string mReplayPath;
+    std::string mSaveGamePath;
 
     static const std::string PLUGINSCFG;
     static const std::string RESOURCECFG;


### PR DESCRIPTION
For now, there are still some limitations:
- Room activity is not saved (points in library or forge)
- Carried entities will be at their original position after saving instead of being near the worker carrying them
- Beds are not saved (all the creatures will go to the dormitory to claim a new bed)
- Vision is not kept on persistent objects (traps/rooms)

Points 1,2 and 3 can easily be fixed.
Point 4 will not be easy to fix because the gamemap can be different for every player. Moreover, the server do not save the state for each client. For example, in a game with 2 players and feral traps, if player 1 sees a trap and looses vision while player 2 destroys the trap, player 1 should see it until he gets vision (and, on server side, the trap will be destroyed).

Of course, we can decide to keep all relevant information on server side. But concerning the map level, that would mean to save each tile state for each player...
