### PR TITLE
Finalized game saving + some more

### DIFF
--- a/levels/skirmish/TestSingleplayerSmall.level
+++ b/levels/skirmish/TestSingleplayerSmall.level
@@ -1202,6 +1202,7 @@ ProtectDungeonTemple	NULL
 0	Wyvern1	Wyvern	15	18	0	Wyvern	1	0	max	100	0	0	none	none
 2	DefaultWorker3	Kobold.mesh	12	9	0	DefaultWorker	1	0	max	100	0	0	none	none
 0	Wyvern2	Wyvern.mesh	18	32	0	Wyvern	1	0	max	100	0	0	none	none
+1	Tentacle16	Tentacle.mesh	11	5	0	Tentacle1	1	0	max	100	0	0	none	none
 [/Creatures]
 
 [Spells]

--- a/source/ai/KeeperAI.cpp
+++ b/source/ai/KeeperAI.cpp
@@ -782,13 +782,16 @@ bool KeeperAI::repairRooms()
         return false;
     }
 
-    mCooldownRepairRooms = Random::Int(3,10);
+    mCooldownRepairRooms = Random::Int(60,150);
 
     Seat* seat = mPlayer.getSeat();
     std::vector<Tile*> tilesToRepair;
     for(Room* room : mGameMap.getRooms())
     {
         if(room->getSeat() != seat)
+            continue;
+
+        if(!room->canBeRepaired())
             continue;
 
         const std::vector<Tile*>& tiles = room->getCoveredTilesDestroyed();

--- a/source/entities/Building.cpp
+++ b/source/entities/Building.cpp
@@ -76,6 +76,21 @@ void Building::removeBuildingObject(RenderedMovableEntity* obj)
     }
 }
 
+bool Building::canBuildingBeRemoved()
+{
+    if(mBuildingObjects.empty())
+        return true;
+
+    for (const std::pair<Tile* const, RenderedMovableEntity*>& p : mBuildingObjects)
+    {
+        RenderedMovableEntity* obj = p.second;
+        if(!obj->notifyRemoveAsked())
+            return false;
+    }
+
+    return true;
+}
+
 void Building::removeAllBuildingObjects()
 {
     if(mBuildingObjects.empty())

--- a/source/entities/Building.cpp
+++ b/source/entities/Building.cpp
@@ -81,13 +81,11 @@ void Building::removeAllBuildingObjects()
     if(mBuildingObjects.empty())
         return;
 
-    std::map<Tile*, RenderedMovableEntity*>::iterator itr = mBuildingObjects.begin();
-    while (itr != mBuildingObjects.end())
+    for (std::pair<Tile* const, RenderedMovableEntity*>& p : mBuildingObjects)
     {
-        RenderedMovableEntity* obj = itr->second;
+        RenderedMovableEntity* obj = p.second;
         obj->removeFromGameMap();
         obj->deleteYourself();
-        ++itr;
     }
     mBuildingObjects.clear();
 }
@@ -197,11 +195,6 @@ Tile* Building::getCoveredTile(int index)
         return nullptr;
 
     return mCoveredTiles[index];
-}
-
-uint32_t Building::numCoveredTiles()
-{
-    return mCoveredTiles.size();
 }
 
 void Building::clearCoveredTiles()

--- a/source/entities/Building.cpp
+++ b/source/entities/Building.cpp
@@ -322,22 +322,6 @@ bool Building::isAttackable(Tile* tile, Seat* seat) const
     return true;
 }
 
-void Building::notifySeatsVisionOnTile(const std::vector<Seat*>& seats, Tile* tile)
-{
-    // TODO: Allow tiles to have a list of old buildings so that they can be notified
-    // about vision
-    if(mTileData.count(tile) <= 0)
-    {
-        OD_ASSERT_TRUE_MSG(false, "building=" + getName() + ", tile=" + Tile::displayAsString(tile));
-        return;
-    }
-
-    // TODO: here, we should check if the tile is covered by this building. If yes, we update
-    // tileData->mSeatsVision. If not, we remove the seats from tileData->mSeatsVision
-    TileData* tileData = mTileData.at(tile);
-    tileData->mSeatsVision = seats;
-}
-
 void Building::exportToStream(std::ostream& os) const
 {
     const std::string& name = getName();

--- a/source/entities/Building.cpp
+++ b/source/entities/Building.cpp
@@ -287,8 +287,15 @@ double Building::getHP(Tile *tile) const
 
 double Building::takeDamage(GameEntity* attacker, double physicalDamage, double magicalDamage, Tile *tileTakingDamage)
 {
-    double damageDone = std::min(mTileData[tileTakingDamage]->mHP, physicalDamage + magicalDamage);
-    mTileData[tileTakingDamage]->mHP -= damageDone;
+    if(mTileData.count(tileTakingDamage) <= 0)
+    {
+        OD_ASSERT_TRUE_MSG(false, "building=" + getName() + ", tile=" + Tile::displayAsString(tileTakingDamage));
+        return 0.0;
+    }
+
+    TileData* tileData = mTileData.at(tileTakingDamage);
+    double damageDone = std::min(tileData->mHP, physicalDamage + magicalDamage);
+    tileData->mHP -= damageDone;
 
     GameMap* gameMap = getGameMap();
     if(!gameMap->isServerGameMap())

--- a/source/entities/Building.h
+++ b/source/entities/Building.h
@@ -75,7 +75,9 @@ public:
     virtual bool removeCoveredTile(Tile* t);
     std::vector<Tile*> getCoveredTiles();
     Tile* getCoveredTile(int index);
-    uint32_t numCoveredTiles();
+    uint32_t numCoveredTiles()
+    { return mCoveredTiles.size(); }
+
     virtual void clearCoveredTiles();
     double getHP(Tile *tile) const;
     double takeDamage(GameEntity* attacker, double physicalDamage, double magicalDamage, Tile *tileTakingDamage);

--- a/source/entities/Building.h
+++ b/source/entities/Building.h
@@ -41,8 +41,8 @@ public:
         mHP(0)
     {}
     double mHP;
-    //! Seats with vision at map loading (when loading saved game). Note that only
-    //! enemy seats are required since allied since will already have vision
+
+    //! Seats with vision at map loading (when loading saved game)
     std::vector<Seat*> mSeatsVision;
 };
 
@@ -103,15 +103,11 @@ public:
 
     //! \brief Tells whether the building tile should be displayed.
     virtual bool shouldDisplayBuildingTile()
-    {
-        return true;
-    }
+    { return true; }
 
     //! \brief Tells whether the ground tile below the building tile should be displayed.
     virtual bool shouldDisplayGroundTile()
-    {
-        return false;
-    }
+    { return false; }
 
     //! \brief Tells whether the building wants the given entity to be brought
     virtual bool hasCarryEntitySpot(GameEntity* carriedEntity)
@@ -136,9 +132,6 @@ public:
     virtual bool shouldSetCoveringTileDirty(Seat* seat, Tile* tile)
     { return true; }
 
-    //! Notify the seats that have vision on the given tile
-    virtual void notifySeatsVisionOnTile(const std::vector<Seat*>& seats, Tile* tile);
-
     inline const std::vector<Tile*>& getCoveredTilesDestroyed() const
     { return mCoveredTilesDestroyed; }
 
@@ -154,6 +147,9 @@ public:
     //! if added to covered tile vectors, set covering room
     virtual void importTileDataFromStream(std::istream& is, Tile* tile, TileData* tileData)
     {}
+
+    virtual bool isTileVisibleForSeat(Tile* tile, Seat* seat) const
+    { return true; }
 
 protected:
     //! This will be called when tiles will be added to the building. By overriding it,

--- a/source/entities/Building.h
+++ b/source/entities/Building.h
@@ -32,6 +32,18 @@ class Tile;
 class Room;
 class Trap;
 
+class TileData
+{
+public:
+    TileData(double hp) :
+        mHP(hp)
+    {}
+    double mHP;
+    //! Seats with vision at map loading (when loading saved game). Note that only
+    //! enemy seats are required since allied since will already have vision
+    std::vector<Seat*> mSeatsVision;
+};
+
 /*! \class Building
  *  \brief This class holds elements that are common to Building like Rooms or Traps
  *
@@ -50,6 +62,8 @@ public:
     const static double DEFAULT_TILE_HP;
 
     virtual ~Building() {}
+
+    virtual void doUpkeep() override;
 
     const Ogre::Vector3& getScale() const;
 
@@ -127,7 +141,22 @@ public:
     inline const std::vector<Tile*>& getCoveredTilesDestroyed() const
     { return mCoveredTilesDestroyed; }
 
+    virtual void exportToStream(std::ostream& os) const override;
+    virtual void importFromStream(std::istream& is) override;
+    //! Allows to export/import specific data for child classes. Note that every tile
+    //! should be exported on 1 line (thus, no line ending should be added here). Moreover
+    //! the building will only export the tile coords. Exporting other relevant data is
+    //! up to the subclass
+    virtual void exportTileToStream(std::ostream& os, Tile* tile) const
+    {}
+    virtual void importTileFromStream(std::istream& is, Tile* tile)
+    {}
+
 protected:
+    //! This will be called when tiles will be added to the building. By overriding it,
+    //! child classes can expand TileData and add the data they need
+    virtual TileData* createTileData(Tile* tile);
+
     void addBuildingObject(Tile* targetTile, RenderedMovableEntity* obj);
     void removeBuildingObject(Tile* tile);
     void removeBuildingObject(RenderedMovableEntity* obj);
@@ -141,7 +170,7 @@ protected:
     std::map<Tile*, RenderedMovableEntity*> mBuildingObjects;
     std::vector<Tile*> mCoveredTiles;
     std::vector<Tile*> mCoveredTilesDestroyed;
-    std::map<Tile*, double> mTileHP;
+    std::map<Tile*, TileData*> mTileData;
 };
 
 #endif // BUILDING_H_

--- a/source/entities/Building.h
+++ b/source/entities/Building.h
@@ -60,6 +60,9 @@ public:
     void receiveExp(double /*experience*/)
     {}
 
+    //! \brief Checks if the building objects allow the room to be deleted
+    bool canBuildingBeRemoved();
+
     void removeAllBuildingObjects();
     /*! \brief Creates a child RenderedMovableEntity mesh using the given mesh name and placing on the target tile,
      *  if the tile is nullptr the object appears in the building's center, the rotation angle is given in degrees.

--- a/source/entities/Building.h
+++ b/source/entities/Building.h
@@ -38,9 +38,20 @@ public:
     TileData() :
         mHP(0)
     {}
+
+    TileData(const TileData* tileData) :
+        mHP(tileData->mHP)
+    {}
+
+    virtual ~TileData()
+    {}
+
+    virtual TileData* cloneTileData() const
+    { return new TileData(this); }
+
     double mHP;
 
-    //! Seats with vision on the corresponding tile
+    //! Seats with vision on the corresponding tile. Note that seats with vision are not copied when cloning a TileData
     std::vector<Seat*> mSeatsVision;
 };
 

--- a/source/entities/Building.h
+++ b/source/entities/Building.h
@@ -26,8 +26,6 @@
 #include "entities/GameEntity.h"
 #include "game/Seat.h"
 
-#include <memory>
-
 class GameMap;
 class RenderedMovableEntity;
 class Tile;
@@ -42,7 +40,7 @@ public:
     {}
     double mHP;
 
-    //! Seats with vision at map loading (when loading saved game)
+    //! Seats with vision on the corresponding tile
     std::vector<Seat*> mSeatsVision;
 };
 
@@ -150,6 +148,8 @@ public:
 
     virtual bool isTileVisibleForSeat(Tile* tile, Seat* seat) const
     { return true; }
+
+    virtual void notifySeatVision(Tile* tile, Seat* seat);
 
 protected:
     //! This will be called when tiles will be added to the building. By overriding it,

--- a/source/entities/Building.h
+++ b/source/entities/Building.h
@@ -26,6 +26,8 @@
 #include "entities/GameEntity.h"
 #include "game/Seat.h"
 
+#include <memory>
+
 class GameMap;
 class RenderedMovableEntity;
 class Tile;
@@ -35,8 +37,8 @@ class Trap;
 class TileData
 {
 public:
-    TileData(double hp) :
-        mHP(hp)
+    TileData() :
+        mHP(0)
     {}
     double mHP;
     //! Seats with vision at map loading (when loading saved game). Note that only
@@ -59,9 +61,9 @@ public:
         GameEntity(gameMap)
     {}
 
-    const static double DEFAULT_TILE_HP;
+    virtual ~Building();
 
-    virtual ~Building() {}
+    const static double DEFAULT_TILE_HP;
 
     virtual void doUpkeep() override;
 
@@ -88,7 +90,6 @@ public:
     Tile* getCentralTile();
 
     virtual bool isAttackable(Tile* tile, Seat* seat) const;
-    virtual void addCoveredTile(Tile* t, double nHP);
     virtual bool removeCoveredTile(Tile* t);
     std::vector<Tile*> getCoveredTiles();
     Tile* getCoveredTile(int index);
@@ -147,9 +148,11 @@ public:
     //! should be exported on 1 line (thus, no line ending should be added here). Moreover
     //! the building will only export the tile coords. Exporting other relevant data is
     //! up to the subclass
-    virtual void exportTileToStream(std::ostream& os, Tile* tile) const
+    virtual void exportTileDataToStream(std::ostream& os, Tile* tile, TileData* tileData) const
     {}
-    virtual void importTileFromStream(std::istream& is, Tile* tile)
+    //! importTileDataFromStream should add the tile to covered or destroyed tiles vector and,
+    //! if added to covered tile vectors, set covering room
+    virtual void importTileDataFromStream(std::istream& is, Tile* tile, TileData* tileData)
     {}
 
 protected:

--- a/source/entities/Building.h
+++ b/source/entities/Building.h
@@ -102,11 +102,11 @@ public:
     std::string getNameTile(Tile* tile);
 
     //! \brief Tells whether the building tile should be displayed.
-    virtual bool shouldDisplayBuildingTile()
+    virtual bool shouldDisplayBuildingTile() const
     { return true; }
 
     //! \brief Tells whether the ground tile below the building tile should be displayed.
-    virtual bool shouldDisplayGroundTile()
+    virtual bool shouldDisplayGroundTile() const
     { return false; }
 
     //! \brief Tells whether the building wants the given entity to be brought

--- a/source/entities/ChickenEntity.cpp
+++ b/source/entities/ChickenEntity.cpp
@@ -212,7 +212,7 @@ void ChickenEntity::pickup()
 
 bool ChickenEntity::tryDrop(Seat* seat, Tile* tile)
 {
-    if (tile->getFullness() > 0.0)
+    if (tile->isFullTile())
         return false;
 
     // In editor mode, we allow to drop an object in dirt, claimed or gold tiles

--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -3521,16 +3521,8 @@ bool Creature::canGoThroughTile(const Tile* tile) const
 bool Creature::tryDrop(Seat* seat, Tile* tile)
 {
     // check whether the tile is a ground tile ...
-    switch(tile->getTileVisual())
-    {
-        case TileVisual::claimedFull:
-        case TileVisual::goldFull:
-        case TileVisual::dirtFull:
-        case TileVisual::rockFull:
-            return false;
-        default:
-            break;
-    }
+    if(tile->isFullTile())
+        return false;
 
     // In editor mode, we allow creatures to be dropped anywhere they can walk
     if(getGameMap()->isInEditorMode() && canGoThroughTile(tile))

--- a/source/entities/Creature.h
+++ b/source/entities/Creature.h
@@ -81,7 +81,7 @@ public:
     { return GameEntityType::creature; }
 
     virtual void addToGameMap();
-    virtual void removeFromGameMap();
+    virtual void removeFromGameMap() override;
 
     bool canDisplayStatsWindow(Seat* seat) override
     { return true; }

--- a/source/entities/GameEntity.cpp
+++ b/source/entities/GameEntity.cpp
@@ -264,13 +264,13 @@ void GameEntity::fireRemoveEntityToSeatsWithVision()
     mSeatsWithVisionNotified.clear();
 }
 
-void GameEntity::exportHeadersToStream(std::ostream& os)
+void GameEntity::exportHeadersToStream(std::ostream& os) const
 {
     // GameEntity are saved in the level file per type. For this reason, there is no
     // need to save the type
 }
 
-void GameEntity::exportHeadersToPacket(ODPacket& os)
+void GameEntity::exportHeadersToPacket(ODPacket& os) const
 {
     os << getObjectType();
 }

--- a/source/entities/GameEntity.h
+++ b/source/entities/GameEntity.h
@@ -255,7 +255,7 @@ class GameEntity
     virtual void removeSeatWithVision(Seat* seat);
 
     //! \brief Fires remove event to every seat with vision
-    void fireRemoveEntityToSeatsWithVision();
+    virtual void fireRemoveEntityToSeatsWithVision();
 
     //! \brief Returns true if the entity can be carried by a worker. False otherwise.
     virtual EntityCarryType getEntityCarryType()

--- a/source/entities/GameEntity.h
+++ b/source/entities/GameEntity.h
@@ -299,8 +299,8 @@ class GameEntity
      * export/import only the needed information for the clients while functions using the stream will export/import
      * every needed information to save/restore the entity from scratch.
      */
-    virtual void exportHeadersToStream(std::ostream& os);
-    virtual void exportHeadersToPacket(ODPacket& os);
+    virtual void exportHeadersToStream(std::ostream& os) const;
+    virtual void exportHeadersToPacket(ODPacket& os) const;
     //! \brief Exports the data of the GameEntity
     virtual void exportToStream(std::ostream& os) const;
     virtual void importFromStream(std::istream& is);

--- a/source/entities/MapLight.h
+++ b/source/entities/MapLight.h
@@ -61,7 +61,7 @@ public:
     static const std::string MAPLIGHT_NAME_PREFIX;
 
     virtual void addToGameMap();
-    virtual void removeFromGameMap();
+    virtual void removeFromGameMap() override;
 
     virtual void doUpkeep()
     {}

--- a/source/entities/MissileObject.cpp
+++ b/source/entities/MissileObject.cpp
@@ -179,13 +179,13 @@ bool MissileObject::computeDestination(const Ogre::Vector3& position, double mov
     return true;
 }
 
-void MissileObject::exportHeadersToStream(std::ostream& os)
+void MissileObject::exportHeadersToStream(std::ostream& os) const
 {
     RenderedMovableEntity::exportHeadersToStream(os);
     os << getMissileType() << "\t";
 }
 
-void MissileObject::exportHeadersToPacket(ODPacket& os)
+void MissileObject::exportHeadersToPacket(ODPacket& os) const
 {
     RenderedMovableEntity::exportHeadersToPacket(os);
     os << getMissileType();

--- a/source/entities/MissileObject.h
+++ b/source/entities/MissileObject.h
@@ -68,8 +68,8 @@ public:
 
     virtual MissileObjectType getMissileType() const = 0;
 
-    virtual void exportHeadersToStream(std::ostream& os) override;
-    virtual void exportHeadersToPacket(ODPacket& os) override;
+    virtual void exportHeadersToStream(std::ostream& os) const override;
+    virtual void exportHeadersToPacket(ODPacket& os) const override;
     void exportToStream(std::ostream& os) const override;
     void importFromStream(std::istream& is) override;
 

--- a/source/entities/PersistentObject.cpp
+++ b/source/entities/PersistentObject.cpp
@@ -54,7 +54,7 @@ PersistentObject* PersistentObject::getPersistentObjectFromPacket(GameMap* gameM
 
 void PersistentObject::notifySeatsWithVision(const std::vector<Seat*>& seats)
 {
-    // We notify seats that lost vision
+    // We process seats that lost vision
     for(std::vector<Seat*>::iterator it = mSeatsWithVisionNotified.begin(); it != mSeatsWithVisionNotified.end();)
     {
         Seat* seat = *it;
@@ -70,15 +70,26 @@ void PersistentObject::notifySeatsWithVision(const std::vector<Seat*>& seats)
         // We don't notify clients so that the objects stays visible
     }
 
-    // We notify seats that gain vision. If the PersistentObject is working, we notify
+    // We process seats that gain vision. If the PersistentObject is working, we notify
     // that it is there. If it is not working, we notify that it has been removed
     for(Seat* seat : seats)
     {
-        // If the seat was already in the list, nothing to do
-        if(std::find(mSeatsWithVisionNotified.begin(), mSeatsWithVisionNotified.end(), seat) != mSeatsWithVisionNotified.end())
-            continue;
+        auto it = std::find(mSeatsWithVisionNotified.begin(), mSeatsWithVisionNotified.end(), seat);
+        if(mIsWorking)
+        {
+            // If the seat was already in the list, nothing to do
+            if(it != mSeatsWithVisionNotified.end())
+                continue;
 
-        mSeatsWithVisionNotified.push_back(seat);
+            mSeatsWithVisionNotified.push_back(seat);
+        }
+        else
+        {
+            // If the seat is not already in the list, nothing to do
+            if(it != mSeatsWithVisionNotified.end())
+                mSeatsWithVisionNotified.erase(it);
+        }
+
 
         if(seat->getPlayer() == nullptr)
             continue;

--- a/source/entities/PersistentObject.cpp
+++ b/source/entities/PersistentObject.cpp
@@ -17,6 +17,7 @@
 
 #include "entities/PersistentObject.h"
 
+#include "entities/Building.h"
 #include "entities/Tile.h"
 
 #include "network/ODPacket.h"
@@ -32,7 +33,8 @@
 PersistentObject::PersistentObject(GameMap* gameMap, const std::string& buildingName, const std::string& meshName,
         Tile* tile, Ogre::Real rotationAngle, bool hideCoveredTile, float opacity) :
     RenderedMovableEntity(gameMap, buildingName, meshName, rotationAngle, hideCoveredTile, opacity),
-    mTile(tile)
+    mTile(tile),
+    mIsWorking(true)
 {
     mPosition.x = static_cast<Ogre::Real>(mTile->getX());
     mPosition.y = static_cast<Ogre::Real>(mTile->getY());
@@ -48,21 +50,6 @@ PersistentObject* PersistentObject::getPersistentObjectFromPacket(GameMap* gameM
 {
     PersistentObject* obj = new PersistentObject(gameMap);
     return obj;
-}
-
-void PersistentObject::addToGameMap()
-{
-    // We register on both client and server gamemaps
-    RenderedMovableEntity::addToGameMap();
-    // We register on the tile we are on
-    mTile->registerPersistentObject(this);
-}
-
-void PersistentObject::removeFromGameMap()
-{
-    RenderedMovableEntity::removeFromGameMap();
-    // Removes the PersistentObject. On client map, the persistent object will be removed when the associated tile is refreshed
-    mTile->removePersistentObject(this);
 }
 
 void PersistentObject::notifySeatsWithVision(const std::vector<Seat*>& seats)
@@ -83,7 +70,8 @@ void PersistentObject::notifySeatsWithVision(const std::vector<Seat*>& seats)
         // We don't notify clients so that the objects stays visible
     }
 
-    // We notify seats that gain vision
+    // We notify seats that gain vision. If the PersistentObject is working, we notify
+    // that it is there. If it is not working, we notify that it has been removed
     for(Seat* seat : seats)
     {
         // If the seat was already in the list, nothing to do
@@ -97,13 +85,39 @@ void PersistentObject::notifySeatsWithVision(const std::vector<Seat*>& seats)
         if(!seat->getPlayer()->getIsHuman())
             continue;
 
-        // If the object has already been notified once, we remove it and re-create it
-        if(std::find(mSeatsAlreadyNotifiedOnce.begin(), mSeatsAlreadyNotifiedOnce.end(), seat) == mSeatsAlreadyNotifiedOnce.end())
-            mSeatsAlreadyNotifiedOnce.push_back(seat);
-        else
-            fireRemoveEntity(seat);
+        // If the PersistentObject is working, we notify vision. If not, we notify it has been removed
+        if(mIsWorking)
+        {
+            // If the object has already been notified once, we remove it and re-create it
+            if(std::find(mSeatsAlreadyNotifiedOnce.begin(), mSeatsAlreadyNotifiedOnce.end(), seat) == mSeatsAlreadyNotifiedOnce.end())
+                mSeatsAlreadyNotifiedOnce.push_back(seat);
+            else
+                fireRemoveEntity(seat);
 
-        fireAddEntity(seat, false);
+            fireAddEntity(seat, false);
+        }
+        else
+        {
+            auto it = std::find(mSeatsAlreadyNotifiedOnce.begin(), mSeatsAlreadyNotifiedOnce.end(), seat);
+            if(it != mSeatsAlreadyNotifiedOnce.end())
+            {
+                mSeatsAlreadyNotifiedOnce.erase(it);
+                fireRemoveEntity(seat);
+            }
+        }
+    }
+}
+
+void PersistentObject::fireRemoveEntityToSeatsWithVision()
+{
+    for(Seat* seat : mSeatsAlreadyNotifiedOnce)
+    {
+        if(seat->getPlayer() == nullptr)
+            continue;
+        if(!seat->getPlayer()->getIsHuman())
+            continue;
+
+        fireRemoveEntity(seat);
     }
 }
 
@@ -120,4 +134,25 @@ void PersistentObject::importFromPacket(ODPacket& is)
 
     mTile = getGameMap()->tileFromPacket(is);
     OD_ASSERT_TRUE_MSG(mTile != nullptr, "name=" + getName());
+}
+
+bool PersistentObject::notifyRemoveAsked()
+{
+    mIsWorking = false;
+    // If at least 1 player has vision on this PersistentObject, we cannot remove it
+    // from gamemap.
+    // We check if there is at least 1 seat that have been notified previously and
+    // lost vision
+    for(Seat* seat : mSeatsAlreadyNotifiedOnce)
+    {
+        auto it = std::find(mSeatsWithVisionNotified.begin(), mSeatsWithVisionNotified.end(), seat);
+        if(it != mSeatsWithVisionNotified.end())
+            continue;
+
+        // There is at least 1 seat that have seen the PersistentObject but not currently
+        // have vision on it. We cannot remove it
+        return false;
+    }
+
+    return true;
 }

--- a/source/entities/PersistentObject.h
+++ b/source/entities/PersistentObject.h
@@ -61,6 +61,9 @@ public:
     virtual void importFromPacket(ODPacket& is) override;
     virtual bool notifyRemoveAsked() override;
 
+    const std::vector<Seat*>& getSeatsAlreadyNotifiedOnce() const
+    { return mSeatsAlreadyNotifiedOnce; }
+
     static PersistentObject* getPersistentObjectFromPacket(GameMap* gameMap, ODPacket& is);
 
 protected:

--- a/source/entities/PersistentObject.h
+++ b/source/entities/PersistentObject.h
@@ -27,16 +27,17 @@
 class Seat;
 class ODPacket;
 
-/*! PersistentObject is a RenderedMovableEntity that stays displayed when vision is lost (however, the object is not refreshed for clients
- *  without vision ie animation changes or remove from gamemap). When a PersistentObject is removed from the server gamemap, it will stay
- *  displayed on clients until they get vision on the associated tile.
- *  There are 2 problems with PersistentObject:
- *  - Their lifetime on client side can be higher than on client because he should be notified only when he gets vision on the associated
- *    tile. To make it work, on server side, we will send the list of PersistentObject on tiles when they get refreshed. This way, it will
- *    be easy to remove PersistentObject that got removed from server map.
- *  - Because they are displayed but not refreshed when a player looses vision, they might be in a different state on client side
- *    than on server side when a client gets vision again. To make it work, we will remove the PersistentObject from the client and
- *    recreate it when vision is gained again.
+/*! PersistentObject is a RenderedMovableEntity that stays displayed when vision is
+ *  lost (however, the object is not refreshed for clients without vision ie animation
+ *  changes). Note that Persistent objects will be removed from the clients if they are
+ *  removed from the server gamemap. That means that buildings that use them and want them
+ *  to be displayed until a client gains vision again should take this into account and
+ *  not add them to building objects as they would be removed if the room is destroyed.
+ *  Because PersistentObjects are displayed but not refreshed when a player looses vision,
+ *  they might be in a different state on client side than on server side when a client gets
+ *  vision again. To make sure they are synchronized, when a player re-gains vision on a
+ *  PersistentObject he had already seen, we will remove it from the player gamemap and
+ *  recreate it.
 */
 class PersistentObject: public RenderedMovableEntity
 {
@@ -53,16 +54,12 @@ public:
     virtual bool isVisibleForSeat(Seat* seat)
     { return true; }
 
-    virtual void addToGameMap();
-    virtual void removeFromGameMap();
-
-    void notifySeatsWithVision(const std::vector<Seat*>& seats);
-    //! We don't want to the remove entity event to be fired when the PersistentObject is removed from the server gamemap
-    void fireRemoveEntityToSeatsWithVision()
-    {}
+    virtual void notifySeatsWithVision(const std::vector<Seat*>& seats) override;
+    virtual void fireRemoveEntityToSeatsWithVision() override;
 
     virtual void exportToPacket(ODPacket& os) const override;
     virtual void importFromPacket(ODPacket& is) override;
+    virtual bool notifyRemoveAsked() override;
 
     static PersistentObject* getPersistentObjectFromPacket(GameMap* gameMap, ODPacket& is);
 
@@ -71,6 +68,13 @@ protected:
 
 private:
     Tile* mTile;
+
+    //! If true, the PersistentObject will notify the clients about vision
+    //! If false, the PersistentObject will only register clients that lost vision
+    //! and, once every client will have seen the PersistentObject been removed
+    //! it will be removed from gamemap and will allow its containing building to
+    //! get removed
+    bool mIsWorking;
 };
 
 #endif // PERSISTENTOBJECT_H

--- a/source/entities/RenderedMovableEntity.h
+++ b/source/entities/RenderedMovableEntity.h
@@ -42,7 +42,7 @@ public:
     static const std::string RENDEREDMOVABLEENTITY_PREFIX;
 
     virtual void addToGameMap();
-    virtual void removeFromGameMap();
+    virtual void removeFromGameMap() override;
 
     bool getHideCoveredTile() const
     { return mHideCoveredTile; }

--- a/source/entities/RenderedMovableEntity.h
+++ b/source/entities/RenderedMovableEntity.h
@@ -41,7 +41,7 @@ public:
 
     static const std::string RENDEREDMOVABLEENTITY_PREFIX;
 
-    virtual void addToGameMap();
+    virtual void addToGameMap() override;
     virtual void removeFromGameMap() override;
 
     bool getHideCoveredTile() const
@@ -76,6 +76,12 @@ public:
 
     virtual void pickup();
     virtual void drop(const Ogre::Vector3& v);
+
+    //! Notify the RenderedMovableEntity that it is asked to be removed. If it returns
+    //! true, it can be removed. Otherwise, that means that it should not. That allows
+    //! to use PersistentObjects that are visible even when vision is lost.
+    virtual bool notifyRemoveAsked()
+    { return true; }
 
     //! \brief Exports the data of the RenderedMovableEntity
     virtual void exportToStream(std::ostream& os) const override;

--- a/source/entities/Tile.cpp
+++ b/source/entities/Tile.cpp
@@ -306,41 +306,10 @@ void Tile::exportToStream(std::ostream& os) const
     os << "\t" << getSeat()->getId();
 }
 
-void Tile::exportTileToPacket(ODPacket& os, Seat* seat)
-{
-    Seat* tileSeat = getSeat();
-    int seatId = -1;
-    // We only pass the tile seat to the client if the tile is fully claimed
-    if((tileSeat != nullptr) && (mClaimedPercentage >= 1.0))
-        seatId = tileSeat->getId();
-
-    std::string meshName;
-
-    if((getCoveringBuilding() != nullptr) && (getCoveringBuilding()->shouldDisplayBuildingTile()))
-    {
-        meshName = getCoveringBuilding()->getMeshName() + ".mesh";
-        mScale = getCoveringBuilding()->getScale();
-        // Buildings are not colored with seat color
-    }
-    else
-    {
-        // We set an empty mesh so that the client can compute the tile itself
-        meshName.clear();
-        mScale = Ogre::Vector3::ZERO;
-    }
-
-    os << mIsBuilding;
-
-    os << seatId;
-    os << meshName;
-    os << mScale;
-    os << mTileVisual;
-}
-
 void Tile::exportToPacket(ODPacket& os) const
 {
-    //Check to make sure this function is not called. The function taking a
-    //seat argument should be used instead
+    //Check to make sure this function is not called. Seat argument should be used instead
+    OD_ASSERT_TRUE_MSG(false, "tile=" + displayAsString(this));
     throw std::runtime_error("ERROR: Wrong packet export function used for tile");
 }
 

--- a/source/entities/Tile.h
+++ b/source/entities/Tile.h
@@ -356,13 +356,6 @@ public:
     const std::vector<Seat*>& getSeatsWithVision()
     { return mSeatsWithVision; }
 
-    //! On client side, registers the PersistentObject on this tile so it can be removed when the tile is refreshed (and the object has been removed).
-    //! On Server side, registers the PersistentObject on this tile so that the PersistentObject still on this tile
-    //! can be sent to the clients when they got vision
-    bool registerPersistentObject(PersistentObject* obj);
-    //! Removes the PersistentObject from the tile.
-    bool removePersistentObject(PersistentObject* obj);
-
     void resetFloodFill();
 
     static inline uint32_t toUInt32(FloodFillType type)
@@ -425,9 +418,6 @@ private:
     std::vector<Player*> mPlayersMarkingTile;
     std::vector<std::pair<Seat*, bool>> mTileChangedForSeats;
     std::vector<Seat*> mSeatsWithVision;
-    std::vector<PersistentObject*> mPersistentObjectRegistered;
-    //! Used on client side to check if the PersistentObjects on this tile should be removed when the tile gets refreshed
-    std::vector<std::string> mPersistentObjectNamesOnTile;
 
     //! \brief List of the entities actually on this tile. Most of the creatures actions will rely on this list
     std::vector<GameEntity*> mEntitiesInTile;

--- a/source/entities/Tile.h
+++ b/source/entities/Tile.h
@@ -271,11 +271,6 @@ public:
     //! \brief Loads the tile data from a level line.
     static void loadFromLine(const std::string& line, Tile *t);
 
-    /*! \brief Exports the tile data to the packet so that the client associated to the seat have the needed information
-     *         to display the tile correctly
-     */
-    void exportTileToPacket(ODPacket& os, Seat* seat);
-
     //! \brief Override of packet export function from gameEntity. Should not be used
     void exportToPacket(ODPacket& os) const override;
 

--- a/source/entities/TreasuryObject.cpp
+++ b/source/entities/TreasuryObject.cpp
@@ -137,7 +137,7 @@ void TreasuryObject::pickup()
 
 bool TreasuryObject::tryDrop(Seat* seat, Tile* tile)
 {
-    if (tile->getFullness() > 0.0)
+    if (tile->isFullTile())
         return false;
 
     // In editor mode, we allow to drop an object in dirt, claimed or gold tiles

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -446,9 +446,6 @@ void Seat::initSeat()
                 serverNotification->mPacket << Ogre::Vector3::ZERO;
                 // tileVisual
                 serverNotification->mPacket << tileState.mTileVisual;
-                // persistent objects
-                uint32_t nbPersistentObject = 0;
-                serverNotification->mPacket << nbPersistentObject;
             }
             ODServer::getSingleton().queueServerNotification(serverNotification);
         }

--- a/source/game/Seat.h
+++ b/source/game/Seat.h
@@ -53,7 +53,7 @@ public:
     bool mMarkedForDigging;
     bool mVisionTurnLast;
     bool mVisionTurnCurrent;
-    const Building* mBuilding;
+    Building* mBuilding;
 };
 
 class Seat
@@ -298,7 +298,7 @@ public:
 
     //! Called when a tile is notified to the seat player. That allows to save the state
     //! Used on server side only
-    void tileNotifiedToPlayer(Tile* tile);
+    void updateTileStateForSeat(Tile* tile);
 
     //! Called when a tile is marked and notified to a player. That allows to save the state
     //! Note that the tile is marked depending on what the player knows about it, not
@@ -313,10 +313,9 @@ public:
 
     //! \brief Called for each seat when a building is removed from the gamemap. That allows
     //! the seats to clear the pointers to the building that they may have
-    void notifyBuildingRemovedFromGameMap(const Building* building, const Tile* tile);
+    void notifyBuildingRemovedFromGameMap(Building* building, Tile* tile);
 
-    bool haveVisionOnBuilding(const Building* building, const Tile* tile) const;
-    void setVisibleBuildingOnTile(const Building* building, const Tile* tile);
+    void setVisibleBuildingOnTile(Building* building, Tile* tile);
 
     /*! \brief Exports the tile data to the packet so that the client associated to the seat have the needed information
      *         to display the tile correctly

--- a/source/game/Seat.h
+++ b/source/game/Seat.h
@@ -318,6 +318,11 @@ public:
     bool haveVisionOnBuilding(const Building* building, const Tile* tile) const;
     void setVisibleBuildingOnTile(const Building* building, const Tile* tile);
 
+    /*! \brief Exports the tile data to the packet so that the client associated to the seat have the needed information
+     *         to display the tile correctly
+     */
+    void exportTileToPacket(ODPacket& os, Tile* tile) const;
+
     static bool sortForMapSave(Seat* s1, Seat* s2);
 
     static Seat* getRogueSeat(GameMap* gameMap);

--- a/source/game/Seat.h
+++ b/source/game/Seat.h
@@ -26,6 +26,7 @@
 #include <ostream>
 #include <istream>
 
+class Building;
 class Goal;
 class ODPacket;
 class GameMap;
@@ -52,6 +53,7 @@ public:
     bool mMarkedForDigging;
     bool mVisionTurnLast;
     bool mVisionTurnCurrent;
+    const Building* mBuilding;
 };
 
 class Seat
@@ -308,6 +310,13 @@ public:
     //! on the tile state the client knows, not on the real tile state
     //! Called on server side only
     bool isTileDiggableForClient(Tile* tile) const;
+
+    //! \brief Called for each seat when a building is removed from the gamemap. That allows
+    //! the seats to clear the pointers to the building that they may have
+    void notifyBuildingRemovedFromGameMap(const Building* building, const Tile* tile);
+
+    bool haveVisionOnBuilding(const Building* building, const Tile* tile) const;
+    void setVisibleBuildingOnTile(const Building* building, const Tile* tile);
 
     static bool sortForMapSave(Seat* s1, Seat* s2);
 

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -1122,26 +1122,7 @@ unsigned long int GameMap::doMiscUpkeep()
         ++activeObjectCount;
     }
 
-    // We add the queued active objects
-    while (!mActiveObjectsToAdd.empty())
-    {
-        GameEntity* ge = mActiveObjectsToAdd.front();
-        mActiveObjectsToAdd.pop_front();
-        mActiveObjects.push_back(ge);
-    }
-
-    // We remove the queued active objects
-    while (!mActiveObjectsToRemove.empty())
-    {
-        GameEntity* ge = mActiveObjectsToRemove.front();
-        mActiveObjectsToRemove.pop_front();
-        std::vector<GameEntity*>::iterator it = std::find(mActiveObjects.begin(), mActiveObjects.end(), ge);
-        OD_ASSERT_TRUE_MSG(it != mActiveObjects.end(), "name=" + ge->getName());
-        if(it != mActiveObjects.end())
-            mActiveObjects.erase(it);
-    }
-
-    // Carry out the upkeep round for each seat.  This means recomputing how much gold is
+    // Carry out the upkeep round for each seat. This means recomputing how much gold is
     // available in their treasuries, how much mana they gain/lose during this turn, etc.
     for (Seat* seat : mSeats)
     {
@@ -2346,6 +2327,28 @@ void GameMap::processDeletionQueues()
         GameEntity* entity = *mEntitiesToDelete.begin();
         mEntitiesToDelete.erase(mEntitiesToDelete.begin());
         delete entity;
+    }
+}
+
+void GameMap::processActiveObjectsChanges()
+{
+    // We add the queued active objects
+    while (!mActiveObjectsToAdd.empty())
+    {
+        GameEntity* ge = mActiveObjectsToAdd.front();
+        mActiveObjectsToAdd.pop_front();
+        mActiveObjects.push_back(ge);
+    }
+
+    // We remove the queued active objects
+    while (!mActiveObjectsToRemove.empty())
+    {
+        GameEntity* ge = mActiveObjectsToRemove.front();
+        mActiveObjectsToRemove.pop_front();
+        std::vector<GameEntity*>::iterator it = std::find(mActiveObjects.begin(), mActiveObjects.end(), ge);
+        OD_ASSERT_TRUE_MSG(it != mActiveObjects.end(), "name=" + ge->getName());
+        if(it != mActiveObjects.end())
+            mActiveObjects.erase(it);
     }
 }
 

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -932,6 +932,7 @@ void GameMap::createAllEntities()
     for (Room* room : mRooms)
     {
         room->createMesh();
+        room->updateActiveSpots();
         entities.push_back(room);
     }
 
@@ -939,6 +940,7 @@ void GameMap::createAllEntities()
     for (Trap* trap : mTraps)
     {
         trap->createMesh();
+        trap->updateActiveSpots();
         entities.push_back(trap);
     }
 
@@ -956,17 +958,6 @@ void GameMap::createAllEntities()
         entity->restoreInitialEntityState();
     }
 
-    // Then, we can create active spots
-    // Note that this have to be done after restoring entities states because some
-    // restored might be active spots
-    for (Room* room : mRooms)
-    {
-        room->updateActiveSpots();
-    }
-    for (Trap* trap : mTraps)
-    {
-        trap->updateActiveSpots();
-    }
     LogManager::getSingleton().logMessage("entities created");
 }
 

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -169,7 +169,7 @@ GameMap::~GameMap()
 bool GameMap::isInEditorMode() const
 {
     if (isServerGameMap())
-        return (ODServer::getSingleton().getServerMode() == ODServer::ServerMode::ModeEditor);
+        return (ODServer::getSingleton().getServerMode() == ServerMode::ModeEditor);
 
     return (ODFrameListener::getSingleton().getModeManager()->getCurrentModeTypeExceptConsole() == ModeManager::EDITOR);
 }

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -2469,7 +2469,7 @@ std::string GameMap::nextUniqueNameCreature(const std::string& className)
     {
         ++mUniqueNumberCreature;
         ret = className + Ogre::StringConverter::toString(mUniqueNumberCreature);
-    } while(getAnimatedObject(ret) != nullptr);
+    } while(getCreature(ret) != nullptr);
     return ret;
 }
 
@@ -2480,7 +2480,7 @@ std::string GameMap::nextUniqueNameRoom(const std::string& meshName)
     {
         ++mUniqueNumberRoom;
         ret = meshName + Ogre::StringConverter::toString(mUniqueNumberRoom);
-    } while(getAnimatedObject(ret) != nullptr);
+    } while(getRoomByName(ret) != nullptr);
     return ret;
 }
 
@@ -2491,7 +2491,7 @@ std::string GameMap::nextUniqueNameRenderedMovableEntity(const std::string& base
     {
         ++mUniqueNumberRenderedMovableEntity;
         ret = RenderedMovableEntity::RENDEREDMOVABLEENTITY_PREFIX + baseName + "_" + Ogre::StringConverter::toString(mUniqueNumberRenderedMovableEntity);
-    } while(getAnimatedObject(ret) != nullptr);
+    } while(getRenderedMovableEntity(ret) != nullptr);
     return ret;
 }
 
@@ -2502,7 +2502,7 @@ std::string GameMap::nextUniqueNameTrap(const std::string& meshName)
     {
         ++mUniqueNumberTrap;
         ret = meshName + "_" + Ogre::StringConverter::toString(mUniqueNumberTrap);
-    } while(getAnimatedObject(ret) != nullptr);
+    } while(getTrapByName(ret) != nullptr);
     return ret;
 }
 
@@ -2513,7 +2513,7 @@ std::string GameMap::nextUniqueNameMapLight()
     {
         ++mUniqueNumberMapLight;
         ret = MapLight::MAPLIGHT_NAME_PREFIX + Ogre::StringConverter::toString(mUniqueNumberMapLight);
-    } while(getAnimatedObject(ret) != nullptr);
+    } while(getMapLight(ret) != nullptr);
     return ret;
 }
 

--- a/source/gamemap/GameMap.h
+++ b/source/gamemap/GameMap.h
@@ -484,6 +484,9 @@ public:
     //! RenderManager has finished to render every object inside.
     void processDeletionQueues();
 
+    //! \brief Adds and removes the active objects queued
+    void processActiveObjectsChanges();
+
     void fillBuildableTilesAndPriceForPlayerInArea(int x1, int y1, int x2, int y2,
         Player* player, RoomType type, std::vector<Tile*>& tiles, int& goldRequired);
 

--- a/source/gamemap/MapLoader.cpp
+++ b/source/gamemap/MapLoader.cpp
@@ -689,9 +689,9 @@ void writeGameMapToFile(const std::string& fileName, GameMap& gameMap)
     levelFile << "# " << Trap::getTrapStreamFormat() << "\n";
     for (Trap* trap : gameMap.getTraps())
     {
-        // Traps with 0 tiles are removed during upkeep. In editor mode, we don't use upkeep so there might be some traps with
+        // In editor mode, we don't use upkeep so there might be some traps with
         // 0 tiles (if a trap has been erased for example). For this reason, we don't save traps with 0 tiles
-        if(trap->numCoveredTiles() <= 0)
+        if(gameMap.isInEditorMode() && trap->numCoveredTiles() <= 0)
             continue;
 
         levelFile << "[Trap]" << std::endl;

--- a/source/gamemap/MapLoader.cpp
+++ b/source/gamemap/MapLoader.cpp
@@ -674,7 +674,7 @@ void writeGameMapToFile(const std::string& fileName, GameMap& gameMap)
     {
         // Rooms with 0 tiles are removed during upkeep. In editor mode, we don't use upkeep so there might be some rooms with
         // 0 tiles (if a room has been erased for example). For this reason, we don't save rooms with 0 tiles
-        if(room->numCoveredTiles() <= 0)
+        if((gameMap.isInEditorMode()) && (room->numCoveredTiles() <= 0))
             continue;
 
         levelFile << "[Room]" << std::endl;

--- a/source/gamemap/TileContainer.cpp
+++ b/source/gamemap/TileContainer.cpp
@@ -485,7 +485,12 @@ Tile* TileContainer::tileFromPacket(ODPacket& packet) const
     int32_t x;
     int32_t y;
     OD_ASSERT_TRUE(packet >> x >> y);
-    return getTile(x, y);
+    Tile* tile = getTile(x, y);
+    if(tile == nullptr)
+    {
+        OD_ASSERT_TRUE_MSG(false, "tile=" + Helper::toString(x) + "," + Helper::toString(y));
+    }
+    return tile;
 }
 
 unsigned int TileContainer::numTiles()

--- a/source/modes/MenuModeConfigureSeats.cpp
+++ b/source/modes/MenuModeConfigureSeats.cpp
@@ -115,7 +115,7 @@ void MenuModeConfigureSeats::activate()
     const CEGUI::Image* selImg = &CEGUI::ImageManager::getSingleton().get("OpenDungeonsSkin/SelectionBrush");
     const std::vector<Seat*>& seats = gameMap->getSeats();
 
-    ODServer::ServerMode serverMode = ODServer::getSingleton().getServerMode();
+    ServerMode serverMode = ODServer::getSingleton().getServerMode();
     int offset = 0;
     int bestSeatHumanSeatId = -1;
     // We start by searching for the most suitable seat for local player. If we find a seat
@@ -233,11 +233,19 @@ void MenuModeConfigureSeats::activate()
 
             // If we are not in multiplayer mode, we set all the players to AI except the best we could find
             // The unset players will be set when a player connects
-            if((serverMode != ODServer::ServerMode::ModeGameMultiPlayer) &&
-               (seat->getId() != bestSeatHumanSeatId))
+            // Note that when loading a game, this is useless because no seat with choice should be possible
+            switch(serverMode)
             {
-                combo->setItemSelectState(item, true);
-                combo->setText(item->getText());
+                case ServerMode::ModeGameMultiPlayer:
+                case ServerMode::ModeGameLoaded:
+                    break;
+                default:
+                    if(seat->getId() != bestSeatHumanSeatId)
+                    {
+                        combo->setItemSelectState(item, true);
+                        combo->setText(item->getText());
+                    }
+                    break;
             }
         }
         combo->subscribeEvent(CEGUI::Combobox::EventListSelectionAccepted, CEGUI::SubscriberSlot(&MenuModeConfigureSeats::comboChanged, this));

--- a/source/modes/MenuModeConfigureSeats.cpp
+++ b/source/modes/MenuModeConfigureSeats.cpp
@@ -71,16 +71,16 @@ MenuModeConfigureSeats::MenuModeConfigureSeats(ModeManager *modeManager):
 MenuModeConfigureSeats::~MenuModeConfigureSeats()
 {
     CEGUI::Window* tmpWin = getModeManager().getGui().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("ListPlayers");
-    for(Seat* seat : mSeats)
+    for(int seatId : mSeatIds)
     {
         std::string name;
-        name = TEXT_SEAT_ID_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        name = TEXT_SEAT_ID_PREFIX + Helper::toString(seatId);
         tmpWin->destroyChild(name);
-        name = COMBOBOX_PLAYER_FACTION_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        name = COMBOBOX_PLAYER_FACTION_PREFIX + Helper::toString(seatId);
         tmpWin->destroyChild(name);
-        name = COMBOBOX_PLAYER_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        name = COMBOBOX_PLAYER_PREFIX + Helper::toString(seatId);
         tmpWin->destroyChild(name);
-        name = COMBOBOX_TEAM_ID_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        name = COMBOBOX_TEAM_ID_PREFIX + Helper::toString(seatId);
         tmpWin->destroyChild(name);
     }
 }
@@ -142,7 +142,7 @@ void MenuModeConfigureSeats::activate()
         if(seat->isRogueSeat())
             continue;
 
-        mSeats.push_back(seat);
+        mSeatIds.push_back(seat->getId());
         std::string name;
         CEGUI::Combobox* combo;
 
@@ -334,9 +334,11 @@ bool MenuModeConfigureSeats::comboChanged(const CEGUI::EventArgs& ea)
        (selItem->getID() != 0) && // Can be several inactive players
        (selItem->getID() != 1)) // Can be several AI players
     {
+        GameMap* gameMap = ODFrameListener::getSingleton().getClientGameMap();
         CEGUI::Window* playersWin = getModeManager().getGui().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("ListPlayers");
-        for(Seat* seat : mSeats)
+        for(int seatId : mSeatIds)
         {
+            Seat* seat = gameMap->getSeatById(seatId);
             // We only add players to combos where a human player can play
             if((seat->getPlayerType().compare(Seat::PLAYER_TYPE_INACTIVE) == 0) ||
                (seat->getPlayerType().compare(Seat::PLAYER_TYPE_AI) == 0))
@@ -344,7 +346,7 @@ bool MenuModeConfigureSeats::comboChanged(const CEGUI::EventArgs& ea)
                 continue;
             }
 
-            std::string name = COMBOBOX_PLAYER_PREFIX + Ogre::StringConverter::toString(seat->getId());
+            std::string name = COMBOBOX_PLAYER_PREFIX + Helper::toString(seatId);
             CEGUI::Combobox* combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
             if(combo == comboSel)
                 continue;
@@ -372,9 +374,9 @@ void MenuModeConfigureSeats::addPlayer(const std::string& nick, int32_t id)
     bool isPlayerSet = false;
 
     mPlayers.push_back(std::pair<std::string, int32_t>(nick, id));
-    for(Seat* seat : mSeats)
+    for(int seatId : mSeatIds)
     {
-        std::string name = COMBOBOX_PLAYER_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        std::string name = COMBOBOX_PLAYER_PREFIX + Helper::toString(seatId);
         CEGUI::Combobox* combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
         CEGUI::ListboxTextItem* item = new CEGUI::ListboxTextItem(nick, id);
         item->setSelectionBrushImage(selImg);
@@ -407,9 +409,9 @@ void MenuModeConfigureSeats::removePlayer(int32_t id)
         }
 
         mPlayers.erase(it);
-        for(Seat* seat : mSeats)
+        for(int seatId : mSeatIds)
         {
-            std::string name = COMBOBOX_PLAYER_PREFIX + Ogre::StringConverter::toString(seat->getId());
+            std::string name = COMBOBOX_PLAYER_PREFIX + Helper::toString(seatId);
             CEGUI::Combobox* combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
             for(uint32_t i = 0; i < combo->getItemCount();)
             {
@@ -442,36 +444,36 @@ void MenuModeConfigureSeats::fireSeatConfigurationToServer(bool isFinal)
     if(isFinal)
     {
         // We start by checking that every seat is well configured.
-        for(Seat* seat : mSeats)
+        for(int seatId : mSeatIds)
         {
             std::string name;
-            name = COMBOBOX_PLAYER_FACTION_PREFIX + Ogre::StringConverter::toString(seat->getId());
+            name = COMBOBOX_PLAYER_FACTION_PREFIX + Helper::toString(seatId);
             combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
             selItem = combo->getSelectedItem();
             if(selItem == nullptr)
             {
                 CEGUI::Window* msgWin = getModeManager().getGui().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("LoadingText");
-                msgWin->setText("Faction is not well configured for seat " + Ogre::StringConverter::toString(seat->getId()));
+                msgWin->setText("Faction is not well configured for seat " + Helper::toString(seatId));
                 msgWin->setVisible(true);
                 return;
             }
-            name = COMBOBOX_PLAYER_PREFIX + Ogre::StringConverter::toString(seat->getId());
+            name = COMBOBOX_PLAYER_PREFIX + Helper::toString(seatId);
             combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
             selItem = combo->getSelectedItem();
             if(selItem == nullptr)
             {
                 CEGUI::Window* msgWin = getModeManager().getGui().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("LoadingText");
-                msgWin->setText("Player is not well configured for seat " + Ogre::StringConverter::toString(seat->getId()));
+                msgWin->setText("Player is not well configured for seat " + Helper::toString(seatId));
                 msgWin->setVisible(true);
                 return;
             }
-            name = COMBOBOX_TEAM_ID_PREFIX + Ogre::StringConverter::toString(seat->getId());
+            name = COMBOBOX_TEAM_ID_PREFIX + Helper::toString(seatId);
             combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
             selItem = combo->getSelectedItem();
             if(selItem == nullptr)
             {
                 CEGUI::Window* msgWin = getModeManager().getGui().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("LoadingText");
-                msgWin->setText("Player is not well configured for seat " + Ogre::StringConverter::toString(seat->getId()));
+                msgWin->setText("Player is not well configured for seat " + Helper::toString(seatId));
                 msgWin->setVisible(true);
                 return;
             }
@@ -484,11 +486,11 @@ void MenuModeConfigureSeats::fireSeatConfigurationToServer(bool isFinal)
     else
         notif = new ClientNotification(ClientNotificationType::seatConfigurationRefresh);
 
-    for(Seat* seat : mSeats)
+    for(int seatId : mSeatIds)
     {
         std::string name;
-        notif->mPacket << seat->getId();
-        name = COMBOBOX_PLAYER_FACTION_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        notif->mPacket << seatId;
+        name = COMBOBOX_PLAYER_FACTION_PREFIX + Helper::toString(seatId);
         combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
         selItem = combo->getSelectedItem();
         if(selItem != nullptr)
@@ -501,7 +503,7 @@ void MenuModeConfigureSeats::fireSeatConfigurationToServer(bool isFinal)
             notif->mPacket << false;
         }
 
-        name = COMBOBOX_PLAYER_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        name = COMBOBOX_PLAYER_PREFIX + Helper::toString(seatId);
         combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
         selItem = combo->getSelectedItem();
         if(selItem != nullptr)
@@ -514,7 +516,7 @@ void MenuModeConfigureSeats::fireSeatConfigurationToServer(bool isFinal)
             notif->mPacket << false;
         }
 
-        name = COMBOBOX_TEAM_ID_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        name = COMBOBOX_TEAM_ID_PREFIX + Helper::toString(seatId);
         combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
         selItem = combo->getSelectedItem();
         if(selItem != nullptr)
@@ -539,13 +541,13 @@ void MenuModeConfigureSeats::refreshSeatConfiguration(ODPacket& packet)
     CEGUI::Window* playersWin = getModeManager().getGui().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("ListPlayers");
     CEGUI::Combobox* combo;
     bool isSelected;
-    for(Seat* seat : mSeats)
+    for(int seatId : mSeatIds)
     {
-        int seatId;
-        OD_ASSERT_TRUE(packet >> seatId);
-        OD_ASSERT_TRUE(seat->getId() == seatId);
+        int seatIdPacket;
+        OD_ASSERT_TRUE(packet >> seatIdPacket);
+        OD_ASSERT_TRUE(seatId == seatIdPacket);
         std::string name;
-        name = COMBOBOX_PLAYER_FACTION_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        name = COMBOBOX_PLAYER_FACTION_PREFIX + Helper::toString(seatId);
         combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
         OD_ASSERT_TRUE(packet >> isSelected);
         uint32_t factionIndex = 0;
@@ -565,7 +567,7 @@ void MenuModeConfigureSeats::refreshSeatConfiguration(ODPacket& packet)
                 combo->setItemSelectState(selItem, false);
         }
 
-        name = COMBOBOX_PLAYER_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        name = COMBOBOX_PLAYER_PREFIX + Helper::toString(seatId);
         combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
         OD_ASSERT_TRUE(packet >> isSelected);
         int32_t playerId = 0;
@@ -585,7 +587,7 @@ void MenuModeConfigureSeats::refreshSeatConfiguration(ODPacket& packet)
                 combo->setItemSelectState(selItem, false);
         }
 
-        name = COMBOBOX_TEAM_ID_PREFIX + Ogre::StringConverter::toString(seat->getId());
+        name = COMBOBOX_TEAM_ID_PREFIX + Helper::toString(seatId);
         combo = static_cast<CEGUI::Combobox*>(playersWin->getChild(name));
         OD_ASSERT_TRUE(packet >> isSelected);
         int32_t teamId = 0;

--- a/source/modes/MenuModeConfigureSeats.h
+++ b/source/modes/MenuModeConfigureSeats.h
@@ -52,7 +52,7 @@ public:
     void refreshSeatConfiguration(ODPacket& packet);
 
 private:
-    std::vector<Seat*> mSeats;
+    std::vector<int> mSeatIds;
     std::vector<std::pair<std::string, int32_t> > mPlayers;
 
     void fireSeatConfigurationToServer(bool isFinal);

--- a/source/modes/MenuModeEditor.cpp
+++ b/source/modes/MenuModeEditor.cpp
@@ -185,7 +185,7 @@ bool MenuModeEditor::launchSelectedButtonPressed(const CEGUI::EventArgs&)
     const std::string& level = mFilesList[id];
 
     // In single player mode, we act as a server
-    if(!ODServer::getSingleton().startServer(level, ODServer::ServerMode::ModeEditor))
+    if(!ODServer::getSingleton().startServer(level, ServerMode::ModeEditor))
     {
         LogManager::getSingleton().logMessage("ERROR: Could not start server for editor !!!");
         tmpWin = getModeManager().getGui().getGuiSheet(Gui::editorMenu)->getChild(Gui::EDM_TEXT_LOADING);

--- a/source/modes/MenuModeLoad.cpp
+++ b/source/modes/MenuModeLoad.cpp
@@ -136,7 +136,7 @@ bool MenuModeLoad::launchSelectedButtonPressed(const CEGUI::EventArgs&)
 
     const std::string& level = mFilesList[id];
     // In single player mode, we act as a server
-    if(!ODServer::getSingleton().startServer(level, ODServer::ServerMode::ModeGameMultiPlayer))
+    if(!ODServer::getSingleton().startServer(level, ServerMode::ModeGameLoaded))
     {
         LogManager::getSingleton().logMessage("ERROR: Could not start server for single player game !!!");
         tmpWin = getModeManager().getGui().getGuiSheet(Gui::loadSavedGameMenu)->getChild("LoadingText");

--- a/source/modes/MenuModeMultiplayerServer.cpp
+++ b/source/modes/MenuModeMultiplayerServer.cpp
@@ -176,7 +176,7 @@ bool MenuModeMultiplayerServer::serverButtonPressed(const CEGUI::EventArgs&)
     const std::string& level = mFilesList[id];
 
     // We are a server
-    if(!ODServer::getSingleton().startServer(level, ODServer::ServerMode::ModeGameMultiPlayer))
+    if(!ODServer::getSingleton().startServer(level, ServerMode::ModeGameMultiPlayer))
     {
         LogManager::getSingleton().logMessage("ERROR: Could not start server for multi player game !!!");
         tmpWin = getModeManager().getGui().getGuiSheet(Gui::multiplayerServerMenu)->getChild(Gui::MPM_TEXT_LOADING);

--- a/source/modes/MenuModeSkirmish.cpp
+++ b/source/modes/MenuModeSkirmish.cpp
@@ -147,7 +147,7 @@ bool MenuModeSkirmish::launchSelectedButtonPressed(const CEGUI::EventArgs&)
 
     const std::string& level = mFilesList[id];
     // In single player mode, we act as a server
-    if(!ODServer::getSingleton().startServer(level, ODServer::ServerMode::ModeGameSinglePlayer))
+    if(!ODServer::getSingleton().startServer(level, ServerMode::ModeGameSinglePlayer))
     {
         LogManager::getSingleton().logMessage("ERROR: Could not start server for single player game !!!");
         tmpWin = getModeManager().getGui().getGuiSheet(Gui::skirmishMenu)->getChild(Gui::SKM_TEXT_LOADING);

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -502,7 +502,6 @@ bool ODClient::processOneClientSocketMessage()
                 break;
 
             Tile* tile = gameMap->tileFromPacket(packetReceived);
-            OD_ASSERT_TRUE(tile != nullptr);
             if(tile == nullptr)
                 break;
 
@@ -668,7 +667,6 @@ bool ODClient::processOneClientSocketMessage()
             {
                 --nbTiles;
                 Tile* tile = gameMap->tileFromPacket(packetReceived);
-                OD_ASSERT_TRUE(tile != nullptr);
                 if(tile == nullptr)
                     continue;
 
@@ -701,7 +699,6 @@ bool ODClient::processOneClientSocketMessage()
             {
                 --nbTiles;
                 Tile* tile = gameMap->tileFromPacket(packetReceived);
-                OD_ASSERT_TRUE(tile != nullptr);
                 if(tile == nullptr)
                     continue;
 
@@ -720,7 +717,6 @@ bool ODClient::processOneClientSocketMessage()
             {
                 --nbTiles;
                 Tile* tile = gameMap->tileFromPacket(packetReceived);
-                OD_ASSERT_TRUE(tile != nullptr);
                 if(tile == nullptr)
                     continue;
 
@@ -733,7 +729,6 @@ bool ODClient::processOneClientSocketMessage()
             {
                 --nbTiles;
                 Tile* tile = gameMap->tileFromPacket(packetReceived);
-                OD_ASSERT_TRUE(tile != nullptr);
                 if(tile == nullptr)
                     continue;
 
@@ -767,7 +762,6 @@ bool ODClient::processOneClientSocketMessage()
             {
                 --nbTiles;
                 Tile* gameTile = gameMap->tileFromPacket(packetReceived);
-                OD_ASSERT_TRUE(gameTile != nullptr);
                 if(gameTile == nullptr)
                     continue;
 
@@ -791,7 +785,6 @@ bool ODClient::processOneClientSocketMessage()
             {
                 --nbTiles;
                 Tile* tile = gameMap->tileFromPacket(packetReceived);
-                OD_ASSERT_TRUE(tile != nullptr);
                 if(tile == nullptr)
                     continue;
 

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -192,7 +192,7 @@ bool ODClient::processOneClientSocketMessage()
 
         case ServerNotificationType::pickNick:
         {
-            ODServer::ServerMode serverMode;
+            ServerMode serverMode;
             OD_ASSERT_TRUE(packetReceived >> serverMode);
 
             ODPacket packSend;
@@ -203,11 +203,12 @@ bool ODClient::processOneClientSocketMessage()
             // We can proceed to configure seat level
             switch(serverMode)
             {
-                case ODServer::ServerMode::ModeGameSinglePlayer:
-                case ODServer::ServerMode::ModeGameMultiPlayer:
+                case ServerMode::ModeGameSinglePlayer:
+                case ServerMode::ModeGameMultiPlayer:
+                case ServerMode::ModeGameLoaded:
                     frameListener->getModeManager()->requestConfigureSeatsMode(true);
                     break;
-                case ODServer::ServerMode::ModeEditor:
+                case ServerMode::ModeEditor:
                     break;
                 default:
                     OD_ASSERT_TRUE_MSG(false,"Unknown server mode=" + Ogre::StringConverter::toString(static_cast<int32_t>(serverMode)));
@@ -327,17 +328,18 @@ bool ODClient::processOneClientSocketMessage()
                 }
             }
 
-            ODServer::ServerMode serverMode;
+            ServerMode serverMode;
             OD_ASSERT_TRUE(packetReceived >> serverMode);
 
             // Now that the we have received all needed information, we can launch the requested mode
             switch(serverMode)
             {
-                case ODServer::ServerMode::ModeGameSinglePlayer:
-                case ODServer::ServerMode::ModeGameMultiPlayer:
+                case ServerMode::ModeGameSinglePlayer:
+                case ServerMode::ModeGameMultiPlayer:
+                case ServerMode::ModeGameLoaded:
                     frameListener->getModeManager()->requestGameMode(true);
                     break;
-                case ODServer::ServerMode::ModeEditor:
+                case ServerMode::ModeEditor:
                     frameListener->getModeManager()->requestEditorMode(true);
                     break;
                 default:

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -1127,8 +1127,8 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 for(Tile* tile : p.second)
                 {
                     gameMap->tileToPacket(serverNotification.mPacket, tile);
-                    tile->exportTileToPacket(serverNotification.mPacket, p.first);
                     p.first->tileNotifiedToPlayer(tile);
+                    p.first->exportTileToPacket(serverNotification.mPacket, tile);
                 }
                 sendAsyncMsg(serverNotification);
             }
@@ -1198,8 +1198,8 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 for(Tile* tile : p.second)
                 {
                     gameMap->tileToPacket(serverNotification.mPacket, tile);
-                    tile->exportTileToPacket(serverNotification.mPacket, p.first);
                     p.first->tileNotifiedToPlayer(tile);
+                    p.first->exportTileToPacket(serverNotification.mPacket, tile);
                 }
                 sendAsyncMsg(serverNotification);
             }
@@ -1268,8 +1268,8 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 for(Tile* tile : p.second)
                 {
                     gameMap->tileToPacket(serverNotification.mPacket, tile);
-                    tile->exportTileToPacket(serverNotification.mPacket, p.first);
                     p.first->tileNotifiedToPlayer(tile);
+                    p.first->exportTileToPacket(serverNotification.mPacket, tile);
                 }
                 sendAsyncMsg(serverNotification);
             }
@@ -1435,8 +1435,8 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 for(Tile* tile : p.second)
                 {
                     gameMap->tileToPacket(serverNotification.mPacket, tile);
-                    tile->exportTileToPacket(serverNotification.mPacket, p.first);
                     p.first->tileNotifiedToPlayer(tile);
+                    p.first->exportTileToPacket(serverNotification.mPacket, tile);
                 }
                 sendAsyncMsg(serverNotification);
             }
@@ -1504,8 +1504,8 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 for(Tile* tile : p.second)
                 {
                     gameMap->tileToPacket(serverNotification.mPacket, tile);
-                    tile->exportTileToPacket(serverNotification.mPacket, p.first);
                     p.first->tileNotifiedToPlayer(tile);
+                    p.first->exportTileToPacket(serverNotification.mPacket, tile);
                 }
                 sendAsyncMsg(serverNotification);
             }
@@ -1643,8 +1643,8 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                     for(Tile* tile : affectedTiles)
                     {
                         gameMap->tileToPacket(notif.mPacket, tile);
-                        tile->exportTileToPacket(notif.mPacket, seat);
                         seat->tileNotifiedToPlayer(tile);
+                        seat->exportTileToPacket(notif.mPacket, tile);
                     }
                     sendAsyncMsg(notif);
                 }
@@ -1779,8 +1779,8 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 for(Tile* tile : p.second)
                 {
                     gameMap->tileToPacket(serverNotification.mPacket, tile);
-                    tile->exportTileToPacket(serverNotification.mPacket, p.first);
                     p.first->tileNotifiedToPlayer(tile);
+                    p.first->exportTileToPacket(serverNotification.mPacket, tile);
                 }
                 sendAsyncMsg(serverNotification);
             }

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -1130,7 +1130,7 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 for(Tile* tile : p.second)
                 {
                     gameMap->tileToPacket(serverNotification.mPacket, tile);
-                    p.first->tileNotifiedToPlayer(tile);
+                    p.first->updateTileStateForSeat(tile);
                     p.first->exportTileToPacket(serverNotification.mPacket, tile);
                 }
                 sendAsyncMsg(serverNotification);
@@ -1201,7 +1201,7 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 for(Tile* tile : p.second)
                 {
                     gameMap->tileToPacket(serverNotification.mPacket, tile);
-                    p.first->tileNotifiedToPlayer(tile);
+                    p.first->updateTileStateForSeat(tile);
                     p.first->exportTileToPacket(serverNotification.mPacket, tile);
                 }
                 sendAsyncMsg(serverNotification);
@@ -1271,7 +1271,7 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 for(Tile* tile : p.second)
                 {
                     gameMap->tileToPacket(serverNotification.mPacket, tile);
-                    p.first->tileNotifiedToPlayer(tile);
+                    p.first->updateTileStateForSeat(tile);
                     p.first->exportTileToPacket(serverNotification.mPacket, tile);
                 }
                 sendAsyncMsg(serverNotification);
@@ -1438,7 +1438,7 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 for(Tile* tile : p.second)
                 {
                     gameMap->tileToPacket(serverNotification.mPacket, tile);
-                    p.first->tileNotifiedToPlayer(tile);
+                    p.first->updateTileStateForSeat(tile);
                     p.first->exportTileToPacket(serverNotification.mPacket, tile);
                 }
                 sendAsyncMsg(serverNotification);
@@ -1507,7 +1507,7 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 for(Tile* tile : p.second)
                 {
                     gameMap->tileToPacket(serverNotification.mPacket, tile);
-                    p.first->tileNotifiedToPlayer(tile);
+                    p.first->updateTileStateForSeat(tile);
                     p.first->exportTileToPacket(serverNotification.mPacket, tile);
                 }
                 sendAsyncMsg(serverNotification);
@@ -1700,7 +1700,7 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                     for(Tile* tile : affectedTiles)
                     {
                         gameMap->tileToPacket(notif.mPacket, tile);
-                        seat->tileNotifiedToPlayer(tile);
+                        seat->updateTileStateForSeat(tile);
                         seat->exportTileToPacket(notif.mPacket, tile);
                     }
                     sendAsyncMsg(notif);
@@ -1836,7 +1836,7 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 for(Tile* tile : p.second)
                 {
                     gameMap->tileToPacket(serverNotification.mPacket, tile);
-                    p.first->tileNotifiedToPlayer(tile);
+                    p.first->updateTileStateForSeat(tile);
                     p.first->exportTileToPacket(serverNotification.mPacket, tile);
                 }
                 sendAsyncMsg(serverNotification);

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -622,9 +622,10 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
             packetSend << nbPlayers;
             const std::string& nick = clientSocket->getPlayer()->getNick();
             int32_t id = clientSocket->getPlayer()->getId();
-            int seatId = seat->getId();
+            int32_t seatId = seat->getId();
+            int32_t teamId = 0;
             seat->setMapSize(gameMap->getMapSizeX(), gameMap->getMapSizeY());
-            packetSend << nick << id << seatId;
+            packetSend << nick << id << seatId << teamId;
             sendMsgToClient(clientSocket, packetSend);
 
             packetSend.clear();

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -269,6 +269,7 @@ void ODServer::startNewTurn(double timeSinceLastFrame)
     }
 
     gameMap->updateVisibleEntities();
+    gameMap->processActiveObjectsChanges();
     gameMap->processDeletionQueues();
 }
 

--- a/source/network/ODServer.h
+++ b/source/network/ODServer.h
@@ -26,6 +26,18 @@ class ServerNotification;
 class GameMap;
 class ServerConsoleCommand;
 
+enum class ServerMode
+{
+    ModeNone,
+    ModeGameSinglePlayer,
+    ModeGameMultiPlayer,
+    ModeGameLoaded,
+    ModeEditor
+};
+
+ODPacket& operator<<(ODPacket& os, const ServerMode& sm);
+ODPacket& operator>>(ODPacket& is, ServerMode& sm);
+
 /**
  * When playing single player or multiplayer, there is always one reference gamemap. It is
  * the one on ODServer. There is also a client gamemap in ODFrameListener which is supposed to be
@@ -43,18 +55,10 @@ class ServerConsoleCommand;
  * Note that this rule is not followed when dealing with client connexions or chat because there
  * is no need to synchronize such messages with the gamemap.
  */
-
 class ODServer: public Ogre::Singleton<ODServer>,
     public ODSocketServer
 {
  public:
-     enum ServerMode
-     {
-         ModeNone,
-         ModeGameSinglePlayer,
-         ModeGameMultiPlayer,
-         ModeEditor
-     };
      enum ServerState
      {
          StateNone,
@@ -85,8 +89,6 @@ class ODServer: public Ogre::Singleton<ODServer>,
     void notifyExit();
 
     static const std::string SERVER_INFORMATION;
-    friend ODPacket& operator<<(ODPacket& os, const ODServer::ServerMode& sm);
-    friend ODPacket& operator>>(ODPacket& is, ODServer::ServerMode& sm);
 
 protected:
     bool notifyNewConnection(ODSocketClient *sock);

--- a/source/rooms/Room.cpp
+++ b/source/rooms/Room.cpp
@@ -727,12 +727,12 @@ void Room::notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile)
     removeBuildingObject(tile);
 }
 
-void Room::exportHeadersToStream(std::ostream& os)
+void Room::exportHeadersToStream(std::ostream& os) const
 {
     os << getType() << "\t";
 }
 
-void Room::exportHeadersToPacket(ODPacket& os)
+void Room::exportHeadersToPacket(ODPacket& os) const
 {
     os << getType();
 }

--- a/source/rooms/Room.cpp
+++ b/source/rooms/Room.cpp
@@ -731,12 +731,9 @@ void Room::exportTileDataToStream(std::ostream& os, Tile* tile, TileData* tileDa
 
     // We only save enemy seats that have vision on the building
     std::vector<Seat*> seatsToSave;
-    for(Seat* seat : getGameMap()->getSeats())
+    for(Seat* seat : tileData->mSeatsVision)
     {
         if(getSeat()->isAlliedSeat(seat))
-            continue;
-
-        if(!seat->haveVisionOnBuilding(this, tile))
             continue;
 
         seatsToSave.push_back(seat);
@@ -802,10 +799,6 @@ void Room::restoreInitialEntityState()
             seat->setVisibleBuildingOnTile(this, p.first);
             tiles[seat].push_back(p.first);
         }
-
-        // We empty the list of seats with vision to make sure we don't do it again
-        // if there is an active spots update
-        p.second->mSeatsVision.clear();
     }
 
     // We notify the clients

--- a/source/rooms/Room.h
+++ b/source/rooms/Room.h
@@ -62,7 +62,7 @@ public:
     { return GameEntityType::room; }
 
     virtual void addToGameMap();
-    virtual void removeFromGameMap();
+    virtual void removeFromGameMap() override;
 
     virtual void absorbRoom(Room* r);
 
@@ -74,8 +74,8 @@ public:
     /*! \brief Exports the headers needed to recreate the Room. It allows to extend Room as much as wanted.
      * The content of the Room will be exported by exportToPacket.
      */
-    virtual void exportHeadersToStream(std::ostream& os) override;
-    virtual void exportHeadersToPacket(ODPacket& os) override;
+    virtual void exportHeadersToStream(std::ostream& os) const override;
+    virtual void exportHeadersToPacket(ODPacket& os) const override;
     //! \brief Exports the data of the Room
     virtual void exportToStream(std::ostream& os) const override;
     virtual void importFromStream(std::istream& is) override;

--- a/source/rooms/Room.h
+++ b/source/rooms/Room.h
@@ -136,8 +136,8 @@ protected:
     virtual RenderedMovableEntity* notifyActiveSpotCreated(ActiveSpotPlace place, Tile* tile);
     virtual void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile);
 
-    //! \brief This function will be called when a new room is created if another room has been absorbed.
-    virtual void reorderRoomAfterAbsorbtion();
+    //! \brief This function will be called when reordering room is needed (for example if another room has been absorbed)
+    static void reorderRoomTiles(std::vector<Tile*>& tiles);
 private :
     void activeSpotCheckChange(ActiveSpotPlace place, const std::vector<Tile*>& originalSpotTiles,
         const std::vector<Tile*>& newSpotTiles);

--- a/source/rooms/Room.h
+++ b/source/rooms/Room.h
@@ -75,12 +75,8 @@ public:
      * The content of the Room will be exported by exportToPacket.
      */
     virtual void exportHeadersToStream(std::ostream& os) const override;
-    virtual void exportHeadersToPacket(ODPacket& os) const override;
-    //! \brief Exports the data of the Room
-    virtual void exportToStream(std::ostream& os) const override;
-    virtual void importFromStream(std::istream& is) override;
-    virtual void exportToPacket(ODPacket& os) const override;
-    virtual void importFromPacket(ODPacket& is) override;
+    void exportTileToStream(std::ostream& os, Tile* tile) const;
+    void importTileFromStream(std::istream& is, Tile* tile);
 
     virtual RoomType getType() const = 0;
 
@@ -90,11 +86,6 @@ public:
     static int costPerTile(RoomType t);
 
     static bool compareTile(Tile* tile1, Tile* tile2);
-
-    //! \brief Carry out per turn upkeep on the room.
-    //! Do any generic upkeep here (i.e. any upkeep that all room types should do).
-    //! All derived classes of room should call this function first during their doUpkeep() routine.
-    virtual void doUpkeep();
 
     //! \brief Adds a creature using the room. If the creature is allowed, true is returned
     virtual bool addCreatureUsingRoom(Creature* c);

--- a/source/rooms/Room.h
+++ b/source/rooms/Room.h
@@ -108,6 +108,8 @@ public:
 
     bool canBeRepaired() const;
 
+    virtual void restoreInitialEntityState() override;
+
     static bool sortForMapSave(Room* r1, Room* r2);
 
 protected:

--- a/source/rooms/Room.h
+++ b/source/rooms/Room.h
@@ -115,6 +115,8 @@ public:
     //! if so, it aborbs them
     void checkForRoomAbsorbtion();
 
+    bool canBeRepaired() const;
+
     static bool sortForMapSave(Room* r1, Room* r2);
 
 protected:

--- a/source/rooms/Room.h
+++ b/source/rooms/Room.h
@@ -75,8 +75,8 @@ public:
      * The content of the Room will be exported by exportToPacket.
      */
     virtual void exportHeadersToStream(std::ostream& os) const override;
-    void exportTileToStream(std::ostream& os, Tile* tile) const;
-    void importTileFromStream(std::istream& is, Tile* tile);
+    void exportTileDataToStream(std::ostream& os, Tile* tile, TileData* tileData) const;
+    void importTileDataFromStream(std::istream& is, Tile* tile, TileData* tileData);
 
     virtual RoomType getType() const = 0;
 

--- a/source/rooms/RoomDormitory.h
+++ b/source/rooms/RoomDormitory.h
@@ -20,6 +20,17 @@
 
 #include "rooms/Room.h"
 
+class RoomDormitoryTileData : public TileData
+{
+public:
+    RoomDormitoryTileData() :
+        TileData(),
+        mCreature(nullptr)
+    {}
+
+    Creature* mCreature;
+};
+
 //! \brief A class containing info on the bed room objects.
 class BedRoomObjectInfo
 {
@@ -113,9 +124,7 @@ public:
 
     // Functions overriding virtual functions in the Room base class.
     void absorbRoom(Room *r) override;
-    void addCoveredTile(Tile* t, double nHP) override;
     bool removeCoveredTile(Tile* t) override;
-    void clearCoveredTiles() override;
 
     virtual void exportToStream(std::ostream& os) const override;
     virtual void importFromStream(std::istream& is) override;
@@ -129,6 +138,7 @@ public:
     Tile* getLocationForBed(int xDim, int yDim);
 
 protected:
+    RoomDormitoryTileData* createTileData(Tile* tile);
     // Because dormitory do not use active spots, we don't want the default
     // behaviour (removing the active spot tile) as it could result in removing an
     // unwanted bed
@@ -138,9 +148,6 @@ protected:
 private:
     bool tileCanAcceptBed(Tile *tile, int xDim, int yDim);
     void createBed(Tile* t, double rotationAngle, Creature* c);
-
-    //! \brief Keeps track of the tiles taken by a creature bed
-    std::map<Tile*, Creature*> mCreatureSleepingInTile;
 
     //! \brief Keeps track of info about the beds in order to be able
     //! to recreate them.

--- a/source/rooms/RoomDormitory.h
+++ b/source/rooms/RoomDormitory.h
@@ -28,6 +28,17 @@ public:
         mCreature(nullptr)
     {}
 
+    RoomDormitoryTileData(const RoomDormitoryTileData* roomDormitoryTileData) :
+        TileData(roomDormitoryTileData),
+        mCreature(roomDormitoryTileData->mCreature)
+    {}
+
+    virtual ~RoomDormitoryTileData()
+    {}
+
+    virtual RoomDormitoryTileData* cloneTileData() const override
+    { return new RoomDormitoryTileData(this); }
+
     Creature* mCreature;
 };
 

--- a/source/rooms/RoomDungeonTemple.cpp
+++ b/source/rooms/RoomDungeonTemple.cpp
@@ -24,6 +24,7 @@
 #include "entities/CreatureSound.h"
 #include "entities/PersistentObject.h"
 #include "entities/ResearchEntity.h"
+#include "entities/Tile.h"
 #include "game/Player.h"
 #include "network/ODServer.h"
 #include "network/ServerNotification.h"
@@ -135,4 +136,33 @@ void RoomDungeonTemple::notifyCarryingStateChanged(Creature* carrier, GameEntity
     getSeat()->addResearch(researchEntity->getResearchType());
     researchEntity->removeFromGameMap();
     researchEntity->deleteYourself();
+}
+
+void RoomDungeonTemple::restoreInitialEntityState()
+{
+    // We need to use seats with vision before calling Room::restoreInitialEntityState
+    // because it will empty the list
+    if(mTempleObject == nullptr)
+    {
+        OD_ASSERT_TRUE_MSG(false, "roomDungeonTemple=" + getName());
+        return;
+    }
+
+    Tile* tileTempleObject = mTempleObject->getPositionTile();
+    if(tileTempleObject == nullptr)
+    {
+        OD_ASSERT_TRUE_MSG(false, "roomDungeonTemple=" + getName() + ", mTempleObject=" + mTempleObject->getName());
+        return;
+    }
+    TileData* tileData = mTileData[tileTempleObject];
+    if(tileData == nullptr)
+    {
+        OD_ASSERT_TRUE_MSG(false, "roomDungeonTemple=" + getName() + ", tile=" + Tile::displayAsString(tileTempleObject));
+        return;
+    }
+
+    if(!tileData->mSeatsVision.empty())
+        mTempleObject->notifySeatsWithVision(tileData->mSeatsVision);
+
+    Room::restoreInitialEntityState();
 }

--- a/source/rooms/RoomDungeonTemple.cpp
+++ b/source/rooms/RoomDungeonTemple.cpp
@@ -164,5 +164,9 @@ void RoomDungeonTemple::restoreInitialEntityState()
     if(!tileData->mSeatsVision.empty())
         mTempleObject->notifySeatsWithVision(tileData->mSeatsVision);
 
+    // If there are no covered tile, the temple object is not working
+    if(numCoveredTiles() == 0)
+        mTempleObject->notifyRemoveAsked();
+
     Room::restoreInitialEntityState();
 }

--- a/source/rooms/RoomDungeonTemple.cpp
+++ b/source/rooms/RoomDungeonTemple.cpp
@@ -44,6 +44,30 @@ void RoomDungeonTemple::updateActiveSpots()
     // We don't update the active spots the same way as only the central tile is needed.
     if (getGameMap()->isInEditorMode())
         updateTemplePosition();
+    else
+    {
+        if(mTempleObject == nullptr)
+        {
+            // We check if the temple already exists (that can happen if it has
+            // been restored after restoring a saved game)
+            if(mBuildingObjects.empty())
+                updateTemplePosition();
+            else
+            {
+                for(std::pair<Tile* const, RenderedMovableEntity*>& p : mBuildingObjects)
+                {
+                    if(p.second == nullptr)
+                        continue;
+
+                    // We take the first RenderedMovableEntity. Note that we cannot use
+                    // the central tile because after saving a game, the central tile may
+                    // not be the same if some tiles have been destroyed
+                    mTempleObject = p.second;
+                    break;
+                }
+            }
+        }
+    }
 }
 
 void RoomDungeonTemple::updateTemplePosition()
@@ -62,12 +86,6 @@ void RoomDungeonTemple::updateTemplePosition()
 
     mTempleObject = new PersistentObject(getGameMap(), getName(), "DungeonTempleObject", centralTile, 0.0, false);
     addBuildingObject(centralTile, mTempleObject);
-}
-
-void RoomDungeonTemple::createMeshLocal()
-{
-    Room::createMeshLocal();
-    updateTemplePosition();
 }
 
 void RoomDungeonTemple::destroyMeshLocal()

--- a/source/rooms/RoomDungeonTemple.h
+++ b/source/rooms/RoomDungeonTemple.h
@@ -35,6 +35,8 @@ public:
     Tile* askSpotForCarriedEntity(GameEntity* carriedEntity);
     void notifyCarryingStateChanged(Creature* carrier, GameEntity* carriedEntity);
 
+    virtual void restoreInitialEntityState() override;
+
 protected:
     virtual void destroyMeshLocal();
 

--- a/source/rooms/RoomDungeonTemple.h
+++ b/source/rooms/RoomDungeonTemple.h
@@ -36,7 +36,6 @@ public:
     void notifyCarryingStateChanged(Creature* carrier, GameEntity* carriedEntity);
 
 protected:
-    virtual void createMeshLocal();
     virtual void destroyMeshLocal();
 
     void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile)

--- a/source/rooms/RoomLibrary.cpp
+++ b/source/rooms/RoomLibrary.cpp
@@ -260,9 +260,12 @@ void RoomLibrary::doUpkeep()
                     continue;
 
                 // We check if there is an empty tile to release the researchEntity
-                Tile* spanwTile = checkIfAvailableSpot();
-                OD_ASSERT_TRUE_MSG(spanwTile != nullptr, "room=" + getName());
+                Tile* spawnTile = checkIfAvailableSpot();
+                if(spawnTile == nullptr)
+                {
+                    OD_ASSERT_TRUE_MSG(false, "room=" + getName());
                     return;
+                }
 
                 ResearchEntity* researchEntity = new ResearchEntity(getGameMap(), getName(), researchDone->getType());
                 researchEntity->setSeat(getSeat());

--- a/source/rooms/RoomLibrary.h
+++ b/source/rooms/RoomLibrary.h
@@ -32,6 +32,17 @@ public:
         mCanHaveResearchEntity(true)
     {}
 
+    RoomLibraryTileData(const RoomLibraryTileData* roomLibraryTileData) :
+        TileData(roomLibraryTileData),
+        mCanHaveResearchEntity(roomLibraryTileData->mCanHaveResearchEntity)
+    {}
+
+    virtual ~RoomLibraryTileData()
+    {}
+
+    virtual RoomLibraryTileData* cloneTileData() const override
+    { return new RoomLibraryTileData(this); }
+
     bool mCanHaveResearchEntity;
 };
 

--- a/source/rooms/RoomLibrary.h
+++ b/source/rooms/RoomLibrary.h
@@ -24,6 +24,17 @@ class Tile;
 
 enum class ResearchType;
 
+class RoomLibraryTileData : public TileData
+{
+public:
+    RoomLibraryTileData() :
+        TileData(),
+        mCanHaveResearchEntity(true)
+    {}
+
+    bool mCanHaveResearchEntity;
+};
+
 class RoomLibrary: public Room
 {
 public:
@@ -37,20 +48,18 @@ public:
     virtual bool addCreatureUsingRoom(Creature* c) override;
     virtual void removeCreatureUsingRoom(Creature* c) override;
     virtual void absorbRoom(Room *r) override;
-    virtual void addCoveredTile(Tile* t, double nHP) override;
-    virtual bool removeCoveredTile(Tile* t) override;
 
 protected:
+    RoomLibraryTileData* createTileData(Tile* tile) override;
     virtual RenderedMovableEntity* notifyActiveSpotCreated(ActiveSpotPlace place, Tile* tile) override;
     virtual void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile) override;
 private:
     //!\brief checks how many items are on the library
     uint32_t countResearchItemsOnRoom();
-    Tile* checkIfAvailableSpot(const std::vector<Tile*>& activeSpots);
+    Tile* checkIfAvailableSpot();
     void getCreatureWantedPos(Creature* creature, Tile* tileSpot,
         Ogre::Real& wantedX, Ogre::Real& wantedY);
     std::vector<Tile*> mUnusedSpots;
-    std::vector<Tile*> mAllowedSpotsForResearchItems;
     std::map<Creature*,Tile*> mCreaturesSpots;
 };
 

--- a/source/rooms/RoomPortal.cpp
+++ b/source/rooms/RoomPortal.cpp
@@ -162,3 +162,32 @@ void RoomPortal::spawnCreature()
 
     mSpawnCreatureCountdown = Random::Uint(15, 30);
 }
+
+void RoomPortal::restoreInitialEntityState()
+{
+    // We need to use seats with vision before calling Room::restoreInitialEntityState
+    // because it will empty the list
+    if(mPortalObject == nullptr)
+    {
+        OD_ASSERT_TRUE_MSG(false, "roomPortal=" + getName());
+        return;
+    }
+
+    Tile* tilePortalObject = mPortalObject->getPositionTile();
+    if(tilePortalObject == nullptr)
+    {
+        OD_ASSERT_TRUE_MSG(false, "roomPortal=" + getName() + ", mPortalObject=" + mPortalObject->getName());
+        return;
+    }
+    TileData* tileData = mTileData[tilePortalObject];
+    if(tileData == nullptr)
+    {
+        OD_ASSERT_TRUE_MSG(false, "roomPortal=" + getName() + ", tile=" + Tile::displayAsString(tilePortalObject));
+        return;
+    }
+
+    if(!tileData->mSeatsVision.empty())
+        mPortalObject->notifySeatsWithVision(tileData->mSeatsVision);
+
+    Room::restoreInitialEntityState();
+}

--- a/source/rooms/RoomPortal.cpp
+++ b/source/rooms/RoomPortal.cpp
@@ -49,6 +49,30 @@ void RoomPortal::updateActiveSpots()
     // We don't update the active spots the same way as only the central tile is needed.
     if (getGameMap()->isInEditorMode())
         updatePortalPosition();
+    else
+    {
+        if(mPortalObject == nullptr)
+        {
+            // We check if the portal already exists (that can happen if it has
+            // been restored after restoring a saved game)
+            if(mBuildingObjects.empty())
+                updatePortalPosition();
+            else
+            {
+                for(std::pair<Tile* const, RenderedMovableEntity*>& p : mBuildingObjects)
+                {
+                    if(p.second == nullptr)
+                        continue;
+
+                    // We take the first RenderedMovableEntity. Note that we cannot use
+                    // the central tile because after saving a game, the central tile may
+                    // not be the same if some tiles have been destroyed
+                    mPortalObject = p.second;
+                    break;
+                }
+            }
+        }
+    }
 }
 
 void RoomPortal::updatePortalPosition()
@@ -69,12 +93,6 @@ void RoomPortal::updatePortalPosition()
     addBuildingObject(centralTile, mPortalObject);
 
     mPortalObject->setAnimationState("Idle");
-}
-
-void RoomPortal::createMeshLocal()
-{
-    Room::createMeshLocal();
-    updatePortalPosition();
 }
 
 void RoomPortal::destroyMeshLocal()

--- a/source/rooms/RoomPortal.cpp
+++ b/source/rooms/RoomPortal.cpp
@@ -189,5 +189,9 @@ void RoomPortal::restoreInitialEntityState()
     if(!tileData->mSeatsVision.empty())
         mPortalObject->notifySeatsWithVision(tileData->mSeatsVision);
 
+    // If there are no covered tile, the temple object is not working
+    if(numCoveredTiles() == 0)
+        mPortalObject->notifyRemoveAsked();
+
     Room::restoreInitialEntityState();
 }

--- a/source/rooms/RoomPortal.h
+++ b/source/rooms/RoomPortal.h
@@ -39,13 +39,13 @@ public:
     void spawnCreature();
 
     //! \brief Portals only display claimed tiles on their ground.
-    virtual bool shouldDisplayBuildingTile()
-    {
-        return false;
-    }
+    virtual bool shouldDisplayBuildingTile() const
+    { return false; }
 
     //! \brief Updates the portal position when in editor mode.
     void updateActiveSpots();
+
+    virtual void restoreInitialEntityState() override;
 
 protected:
     void destroyMeshLocal();

--- a/source/rooms/RoomPortal.h
+++ b/source/rooms/RoomPortal.h
@@ -48,7 +48,6 @@ public:
     void updateActiveSpots();
 
 protected:
-    void createMeshLocal();
     void destroyMeshLocal();
 
     void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile)

--- a/source/rooms/RoomTrainingHall.cpp
+++ b/source/rooms/RoomTrainingHall.cpp
@@ -118,9 +118,14 @@ void RoomTrainingHall::notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile
     }
 
     std::vector<Tile*>::iterator it = std::find(mUnusedDummies.begin(), mUnusedDummies.end(), tile);
-    OD_ASSERT_TRUE_MSG(it != mUnusedDummies.end(), "name=" + getName() + ", tile=" + Tile::displayAsString(tile));
-    if(it != mUnusedDummies.end())
-        mUnusedDummies.erase(it);
+    if(it == mUnusedDummies.end())
+    {
+        // Dummies are on center tiles only
+        OD_ASSERT_TRUE_MSG(place != ActiveSpotPlace::activeSpotCenter, "name=" + getName() + ", tile=" + Tile::displayAsString(tile));
+        return;
+    }
+
+    mUnusedDummies.erase(it);
 }
 
 void RoomTrainingHall::refreshCreaturesDummies()

--- a/source/rooms/RoomTreasury.h
+++ b/source/rooms/RoomTreasury.h
@@ -21,6 +21,18 @@
 #include "entities/TreasuryObject.h"
 #include "rooms/Room.h"
 
+class RoomTreasuryTileData : public TileData
+{
+public:
+    RoomTreasuryTileData() :
+        TileData(),
+        mGoldInTile(0)
+    {}
+
+    int mGoldInTile;
+    std::string mMeshOfTile;
+};
+
 class RoomTreasury: public Room
 {
     friend class ODClient;
@@ -31,8 +43,6 @@ public:
     { return RoomType::treasury; }
 
     // Functions overriding virtual functions in the Room base class.
-    void absorbRoom(Room *r);
-    void addCoveredTile(Tile* t, double nHP);
     bool removeCoveredTile(Tile* t);
 
     // Functions specific to this class.
@@ -47,6 +57,7 @@ public:
     void notifyCarryingStateChanged(Creature* carrier, GameEntity* carriedEntity);
 
 protected:
+    RoomTreasuryTileData* createTileData(Tile* tile) override;
     // Because treasury do not use active spots, we don't want the default
     // behaviour (removing the active spot tile) as it could result in removing an
     // unwanted treasury
@@ -54,10 +65,7 @@ protected:
     {}
 
 private:
-    void updateMeshesForTile(Tile *t);
-
-    std::map<Tile*, int> mGoldInTile;
-    std::map<Tile*, std::string> mMeshOfTile;
+    void updateMeshesForTile(Tile* tile, RoomTreasuryTileData* roomTreasuryTileData);
     bool mGoldChanged;
 };
 

--- a/source/rooms/RoomTreasury.h
+++ b/source/rooms/RoomTreasury.h
@@ -29,6 +29,18 @@ public:
         mGoldInTile(0)
     {}
 
+    RoomTreasuryTileData(const RoomTreasuryTileData* roomTreasuryTileData) :
+        TileData(roomTreasuryTileData),
+        mGoldInTile(roomTreasuryTileData->mGoldInTile),
+        mMeshOfTile(roomTreasuryTileData->mMeshOfTile)
+    {}
+
+    virtual ~RoomTreasuryTileData()
+    {}
+
+    virtual RoomTreasuryTileData* cloneTileData() const override
+    { return new RoomTreasuryTileData(this); }
+
     int mGoldInTile;
     std::string mMeshOfTile;
 };

--- a/source/rooms/RoomWorkshop.h
+++ b/source/rooms/RoomWorkshop.h
@@ -30,6 +30,17 @@ public:
         mCanHaveCraftedTrap(true)
     {}
 
+    RoomWorkshopTileData(const RoomWorkshopTileData* roomWorkshopTileData) :
+        TileData(roomWorkshopTileData),
+        mCanHaveCraftedTrap(roomWorkshopTileData->mCanHaveCraftedTrap)
+    {}
+
+    virtual ~RoomWorkshopTileData()
+    {}
+
+    virtual RoomWorkshopTileData* cloneTileData() const override
+    { return new RoomWorkshopTileData(this); }
+
     bool mCanHaveCraftedTrap;
 };
 

--- a/source/rooms/RoomWorkshop.h
+++ b/source/rooms/RoomWorkshop.h
@@ -22,8 +22,18 @@
 
 enum class TrapType;
 
-class RoomWorkshop: public Room
+class RoomWorkshopTileData : public TileData
 {
+public:
+    RoomWorkshopTileData() :
+        TileData(),
+        mCanHaveCraftedTrap(true)
+    {}
+
+    bool mCanHaveCraftedTrap;
+};
+
+class RoomWorkshop: public Room{
 public:
     RoomWorkshop(GameMap* gameMap);
 
@@ -35,25 +45,23 @@ public:
     virtual bool addCreatureUsingRoom(Creature* c) override;
     virtual void removeCreatureUsingRoom(Creature* c) override;
     virtual void absorbRoom(Room *r) override;
-    virtual void addCoveredTile(Tile* t, double nHP) override;
-    virtual bool removeCoveredTile(Tile* t) override;
 
     virtual void exportToStream(std::ostream& os) const override;
     virtual void importFromStream(std::istream& is) override;
 
 protected:
+    RoomWorkshopTileData* createTileData(Tile* tile) override;
     virtual RenderedMovableEntity* notifyActiveSpotCreated(ActiveSpotPlace place, Tile* tile) override;
     virtual void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile) override;
 private:
     //!\brief checks if a tile is available in the workshop to place a new crafted trap
     uint32_t countCraftedItemsOnRoom();
-    Tile* checkIfAvailableSpot(const std::vector<Tile*>& activeSpots);
+    Tile* checkIfAvailableSpot();
     int32_t mPoints;
     TrapType mTrapType;
     void getCreatureWantedPos(Creature* creature, Tile* tileSpot,
         Ogre::Real& wantedX, Ogre::Real& wantedY);
     std::vector<Tile*> mUnusedSpots;
-    std::vector<Tile*> mAllowedSpotsForCraftedItems;
     std::map<Creature*,Tile*> mCreaturesSpots;
 };
 

--- a/source/spell/Spell.cpp
+++ b/source/spell/Spell.cpp
@@ -280,13 +280,13 @@ std::string Spell::getSpellStreamFormat()
         + "optionalData\t";
 }
 
-void Spell::exportHeadersToStream(std::ostream& os)
+void Spell::exportHeadersToStream(std::ostream& os) const
 {
     RenderedMovableEntity::exportHeadersToStream(os);
     os << getSpellType() << "\t";
 }
 
-void Spell::exportHeadersToPacket(ODPacket& os)
+void Spell::exportHeadersToPacket(ODPacket& os) const
 {
     RenderedMovableEntity::exportHeadersToPacket(os);
     os << getSpellType();

--- a/source/spell/Spell.h
+++ b/source/spell/Spell.h
@@ -54,8 +54,8 @@ public:
 
     virtual SpellType getSpellType() const = 0;
 
-    virtual void addToGameMap();
-    virtual void removeFromGameMap();
+    virtual void addToGameMap() override;
+    virtual void removeFromGameMap() override;
 
     static std::string getSpellNameFromSpellType(SpellType t);
 
@@ -73,8 +73,8 @@ public:
     /*! \brief Exports the headers needed to recreate the Spell. It allows to extend Spells as much as wanted.
      * The content of the Spell will be exported by exportToPacket.
      */
-    virtual void exportHeadersToStream(std::ostream& os) override;
-    virtual void exportHeadersToPacket(ODPacket& os) override;
+    virtual void exportHeadersToStream(std::ostream& os) const override;
+    virtual void exportHeadersToPacket(ODPacket& os) const override;
 
     static std::string getSpellStreamFormat();
 

--- a/source/traps/Trap.cpp
+++ b/source/traps/Trap.cpp
@@ -527,6 +527,9 @@ void Trap::restoreInitialEntityState()
         if(trapTileData->mSeatsVision.empty())
             continue;
 
+        for(Seat* seat : p.second->mSeatsVision)
+            seat->setVisibleBuildingOnTile(this, p.first);
+
         TrapEntity* trapEntity = trapTileData->getTrapEntity();
         if(trapEntity == nullptr)
         {
@@ -538,10 +541,6 @@ void Trap::restoreInitialEntityState()
         trapEntity->notifySeatsWithVision(trapTileData->mSeatsVision);
         for(Seat* seat : trapEntity->getSeatsNotHidden())
             seat->setVisibleBuildingOnTile(this, p.first);
-
-        // We empty the list of seats with vision to make sure we don't do it again
-        // if there is an active spots update
-        trapTileData->mSeatsVision.clear();
     }
 }
 
@@ -568,12 +567,9 @@ void Trap::exportTileDataToStream(std::ostream& os, Tile* tile, TileData* tileDa
 
     // We only save enemy seats that have vision on the building
     std::vector<Seat*> seatsToSave;
-    for(Seat* seat : getGameMap()->getSeats())
+    for(Seat* seat : trapTileData->mSeatsVision)
     {
         if(getSeat()->isAlliedSeat(seat))
-            continue;
-
-        if(!seat->haveVisionOnBuilding(this, tile))
             continue;
 
         seatsToSave.push_back(seat);

--- a/source/traps/Trap.cpp
+++ b/source/traps/Trap.cpp
@@ -300,31 +300,6 @@ void Trap::updateActiveSpots()
             continue;
         }
     }
-
-    // We restore the vision if we need to
-    for(std::pair<Tile* const, TileData*>& p : mTileData)
-    {
-        TrapTileData* trapTileData = static_cast<TrapTileData*>(p.second);
-        if(trapTileData->mSeatsVision.empty())
-            continue;
-
-        TrapEntity* trapEntity = trapTileData->getTrapEntity();
-        if(trapEntity == nullptr)
-        {
-            OD_ASSERT_TRUE_MSG(false, "tile=" + Tile::displayAsString(p.first));
-            continue;
-        }
-
-        trapEntity->seatsSawTriggering(trapTileData->mSeatsVision);
-        trapEntity->notifySeatsWithVision(trapTileData->mSeatsVision);
-        for(Seat* seat : trapEntity->getSeatsNotHidden())
-            seat->setVisibleBuildingOnTile(this, p.first);
-
-        // We empty the list of seats with vision to make sure we don't do it again
-        // if there is an active spots update
-        trapTileData->mSeatsVision.clear();
-
-    }
 }
 
 RenderedMovableEntity* Trap::notifyActiveSpotCreated(Tile* tile)
@@ -541,6 +516,33 @@ bool Trap::isAttackable(Tile* tile, Seat* seat) const
         return false;
 
     return true;
+}
+
+void Trap::restoreInitialEntityState()
+{
+    // We restore the vision if we need to
+    for(std::pair<Tile* const, TileData*>& p : mTileData)
+    {
+        TrapTileData* trapTileData = static_cast<TrapTileData*>(p.second);
+        if(trapTileData->mSeatsVision.empty())
+            continue;
+
+        TrapEntity* trapEntity = trapTileData->getTrapEntity();
+        if(trapEntity == nullptr)
+        {
+            OD_ASSERT_TRUE_MSG(false, "tile=" + Tile::displayAsString(p.first));
+            continue;
+        }
+
+        trapEntity->seatsSawTriggering(trapTileData->mSeatsVision);
+        trapEntity->notifySeatsWithVision(trapTileData->mSeatsVision);
+        for(Seat* seat : trapEntity->getSeatsNotHidden())
+            seat->setVisibleBuildingOnTile(this, p.first);
+
+        // We empty the list of seats with vision to make sure we don't do it again
+        // if there is an active spots update
+        trapTileData->mSeatsVision.clear();
+    }
 }
 
 std::string Trap::getTrapStreamFormat()

--- a/source/traps/Trap.cpp
+++ b/source/traps/Trap.cpp
@@ -743,7 +743,11 @@ void Trap::importFromStream(std::istream& is)
         int32_t nbSeatsVision;
         OD_ASSERT_TRUE(ss >> tileHealth >> reloadTime);
         OD_ASSERT_TRUE(ss >> nbShootsBeforeDeactivation >> nbSeatsVision);
-        addCoveredTile(tempTile, tileHealth);
+        if(tileHealth > 0.0)
+            addCoveredTile(tempTile, tileHealth);
+        else
+            mCoveredTilesDestroyed.push_back(tempTile);
+
         tempTile->setSeat(getSeat());
         if(tempActiv != 0)
             activate(tempTile);

--- a/source/traps/Trap.cpp
+++ b/source/traps/Trap.cpp
@@ -520,12 +520,12 @@ std::string Trap::getTrapStreamFormat()
     return "typeTrap\tname\tseatId\tnumTiles\t\tSubsequent Lines: tileX\ttileY\tisActivated(0/1)\t\tSubsequent Lines: optional specific data";
 }
 
-void Trap::exportHeadersToStream(std::ostream& os)
+void Trap::exportHeadersToStream(std::ostream& os) const
 {
     os << getType() << "\t";
 }
 
-void Trap::exportHeadersToPacket(ODPacket& os)
+void Trap::exportHeadersToPacket(ODPacket& os) const
 {
     os << getType();
 }

--- a/source/traps/Trap.h
+++ b/source/traps/Trap.h
@@ -64,6 +64,23 @@ public:
         mRemoveTrap(false)
     {}
 
+    TrapTileData(const TrapTileData* trapTileData) :
+        TileData(trapTileData),
+        mIsActivated(trapTileData->mIsActivated),
+        mReloadTime(trapTileData->mReloadTime),
+        mCraftedTrap(trapTileData->mCraftedTrap),
+        mNbShootsBeforeDeactivation(trapTileData->mNbShootsBeforeDeactivation),
+        mTrapEntity(trapTileData->mTrapEntity),
+        mIsWorking(trapTileData->mIsWorking),
+        mRemoveTrap(trapTileData->mRemoveTrap)
+    {}
+
+    virtual ~TrapTileData()
+    {}
+
+    virtual TrapTileData* cloneTileData() const override
+    { return new TrapTileData(this); }
+
     inline void setTrapEntity(TrapEntity* trapEntity)
     { mTrapEntity = trapEntity; }
 

--- a/source/traps/Trap.h
+++ b/source/traps/Trap.h
@@ -53,8 +53,8 @@ ODPacket& operator<<(ODPacket& os, const TrapType& tt);
 class TrapTileData : public TileData
 {
 public:
-    TrapTileData(double hp) :
-        TileData(hp),
+    TrapTileData() :
+        TileData(),
         mIsActivated(false),
         mReloadTime(0),
         mCraftedTrap(nullptr),
@@ -176,7 +176,6 @@ public:
     //! \brief Sets the name, seat and associates the given tiles with the trap
     void setupTrap(const std::string& name, Seat* seat, const std::vector<Tile*>& tiles);
 
-    virtual void addCoveredTile(Tile* t, double nHP);
     virtual bool removeCoveredTile(Tile* t);
     virtual void updateActiveSpots();
 
@@ -193,13 +192,13 @@ public:
     { return false; }
 
     virtual void exportHeadersToStream(std::ostream& os) const override;
-    virtual void exportTileToStream(std::ostream& os, Tile* tile) const override;
-    virtual void importTileFromStream(std::istream& is, Tile* tile) override;
+    virtual void exportTileDataToStream(std::ostream& os, Tile* tile, TileData* tileData) const override;
+    virtual void importTileDataFromStream(std::istream& is, Tile* tile, TileData* tileData) override;
 
     static std::string getTrapStreamFormat();
 
 protected:
-    virtual TileData* createTileData(Tile* tile) override;
+    virtual TrapTileData* createTileData(Tile* tile) override;
 
     virtual RenderedMovableEntity* notifyActiveSpotCreated(Tile* tile);
     virtual TrapEntity* getTrapEntity(Tile* tile) = 0;

--- a/source/traps/Trap.h
+++ b/source/traps/Trap.h
@@ -58,7 +58,8 @@ public:
         mReloadTime(0),
         mCraftedTrap(nullptr),
         mNbShootsBeforeDeactivation(0),
-        mTrapEntity(nullptr)
+        mTrapEntity(nullptr),
+        mIsWorking(false)
     {}
 
     TrapTileInfo(uint32_t reloadTime, bool activated):
@@ -66,7 +67,8 @@ public:
         mReloadTime(reloadTime),
         mCraftedTrap(nullptr),
         mNbShootsBeforeDeactivation(0),
-        mTrapEntity(nullptr)
+        mTrapEntity(nullptr),
+        mIsWorking(false)
     {}
 
     inline void setTrapEntity(TrapEntity* trapEntity)
@@ -87,7 +89,7 @@ public:
         return false;
     }
 
-    void setActivated(bool activated)
+    inline void setActivated(bool activated)
     { mIsActivated = activated; }
 
     bool decreaseShoot()
@@ -102,20 +104,35 @@ public:
         return false;
     }
 
-    bool isActivated() const
+    inline bool isActivated() const
     { return mIsActivated; }
 
-    void setReloadTime(uint32_t reloadTime)
+    inline uint32_t getReloadTime() const
+    { return mReloadTime; }
+
+    inline void setReloadTime(uint32_t reloadTime)
     { mReloadTime = reloadTime; }
 
-    void setNbShootsBeforeDeactivation(int32_t nbShoot)
+    inline void setNbShootsBeforeDeactivation(int32_t nbShoot)
     { mNbShootsBeforeDeactivation = nbShoot; }
 
-    void setCarriedCraftedTrap(CraftedTrap* craftedTrap)
+    inline int32_t getNbShootsBeforeDeactivation() const
+    { return mNbShootsBeforeDeactivation; }
+
+    inline void setCarriedCraftedTrap(CraftedTrap* craftedTrap)
     { mCraftedTrap = craftedTrap; }
 
-    CraftedTrap* getCarriedCraftedTrap() const
+    inline CraftedTrap* getCarriedCraftedTrap() const
     { return mCraftedTrap; }
+
+    inline std::vector<int>& getSeatsVision()
+    { return mSeatsVision; }
+
+    inline bool getIsWorking() const
+    { return mIsWorking; }
+
+    inline void setIsWorking(bool isWorking)
+    { mIsWorking = isWorking; }
 
 private:
     bool mIsActivated;
@@ -123,6 +140,10 @@ private:
     CraftedTrap* mCraftedTrap;
     int32_t mNbShootsBeforeDeactivation;
     TrapEntity* mTrapEntity;
+    //! Seats with vision at map loading (when loading saved game). Note that only
+    //! enemy seats are required since allied since will already have vision
+    std::vector<int> mSeatsVision;
+    bool mIsWorking;
 };
 
 /*! \class Trap Trap.h

--- a/source/traps/Trap.h
+++ b/source/traps/Trap.h
@@ -191,6 +191,8 @@ public:
     virtual bool shouldSetCoveringTileDirty(Seat* seat, Tile* tile)
     { return false; }
 
+    virtual bool isTileVisibleForSeat(Tile* tile, Seat* seat) const override;
+
     virtual void exportHeadersToStream(std::ostream& os) const override;
     virtual void exportTileDataToStream(std::ostream& os, Tile* tile, TileData* tileData) const override;
     virtual void importTileDataFromStream(std::istream& is, Tile* tile, TileData* tileData) override;

--- a/source/traps/Trap.h
+++ b/source/traps/Trap.h
@@ -209,6 +209,9 @@ protected:
 
     //! \brief Tells the current reloading time left for each tiles and whether it is activated.
     std::map<Tile*, TrapTileInfo> mTrapTiles;
+    //! List of traps destroyed but with at least 1 player having vision. They will
+    //! get removed when vision is gained by every player having seen it before destruction
+    std::vector<RenderedMovableEntity*> mTrapEntitiesWaitingRemove;
 };
 
 #endif // TRAP_H

--- a/source/traps/Trap.h
+++ b/source/traps/Trap.h
@@ -191,6 +191,8 @@ public:
     virtual bool shouldSetCoveringTileDirty(Seat* seat, Tile* tile)
     { return false; }
 
+    virtual void restoreInitialEntityState() override;
+
     virtual bool isTileVisibleForSeat(Tile* tile, Seat* seat) const override;
 
     virtual void exportHeadersToStream(std::ostream& os) const override;

--- a/source/traps/Trap.h
+++ b/source/traps/Trap.h
@@ -138,8 +138,8 @@ public:
     virtual GameEntityType getObjectType() const
     { return GameEntityType::trap; }
 
-    virtual void addToGameMap();
-    virtual void removeFromGameMap();
+    virtual void addToGameMap() override;
+    virtual void removeFromGameMap() override;
 
     static Trap* getTrapFromStream(GameMap* gameMap, std::istream &is);
     static Trap* getTrapFromPacket(GameMap* gameMap, ODPacket &is);
@@ -181,8 +181,8 @@ public:
     /*! \brief Exports the headers needed to recreate the Trap. It allows to extend Traps as much as wanted.
      * The content of the Trap will be exported by exportToPacket.
      */
-    virtual void exportHeadersToStream(std::ostream& os) override;
-    virtual void exportHeadersToPacket(ODPacket& os) override;
+    virtual void exportHeadersToStream(std::ostream& os) const override;
+    virtual void exportHeadersToPacket(ODPacket& os) const override;
     //! \brief Exports the data of the Trap
     virtual void exportToStream(std::ostream& os) const override;
     virtual void importFromStream(std::istream& is) override;

--- a/source/traps/TrapBoulder.h
+++ b/source/traps/TrapBoulder.h
@@ -40,16 +40,12 @@ public:
     }
 
     //! \brief There is no building tile for this trap.
-    virtual bool shouldDisplayBuildingTile()
-    {
-        return false;
-    }
+    virtual bool shouldDisplayBuildingTile() const
+    { return false; }
 
     //! \brief The boulder trap should let the ground tile visible.
-    virtual bool shouldDisplayGroundTile()
-    {
-        return true;
-    }
+    virtual bool shouldDisplayGroundTile() const
+    { return true; }
 
     virtual TrapEntity* getTrapEntity(Tile* tile);
 };

--- a/source/traps/TrapCannon.h
+++ b/source/traps/TrapCannon.h
@@ -38,16 +38,12 @@ public:
     virtual bool shoot(Tile* tile);
 
     //! \brief There is no building tile for this trap.
-    virtual bool shouldDisplayBuildingTile()
-    {
-        return false;
-    }
+    virtual bool shouldDisplayBuildingTile() const
+    { return false; }
 
     //! \brief The cannon should show the ground tile under.
-    virtual bool shouldDisplayGroundTile()
-    {
-        return true;
-    }
+    virtual bool shouldDisplayGroundTile() const
+    { return true; }
 
     virtual TrapEntity* getTrapEntity(Tile* tile);
 private:

--- a/source/traps/TrapSpike.h
+++ b/source/traps/TrapSpike.h
@@ -40,17 +40,13 @@ public:
     }
 
     //! \brief There is no building tile for this trap
-    virtual bool shouldDisplayBuildingTile()
-    {
-        return false;
-    }
+    virtual bool shouldDisplayBuildingTile() const
+    { return false; }
 
     //! \brief The trap object covers the whole tile under
     //! but while it built, the ground tile still must be shown.
-    virtual bool shouldDisplayGroundTile()
-    {
-        return true;
-    }
+    virtual bool shouldDisplayGroundTile() const
+    { return true; }
 
     virtual TrapEntity* getTrapEntity(Tile* tile);
 };


### PR DESCRIPTION
Sorry for this big (game breaker) PR but I had to mess with saving and repairing rooms (because they both need to know deleted tiles from building, they were tied).
Concerning game saving, basically, the server now reminds tile states for each human player (including building).
Moreover, buildings are removed from gamemap only when not used anymore (if a player sees an enemy building, looses vision and the building gets destroyed by someone else, the building will be removed from the gamemap only when the player will get vision again - and see it has been destroyed).

Building tiles are displayed at map load. Traps and just like persistent objects (dungeon temple and portal).

@oyvindln I've played a bit with memory. I tried to pay attention but if you could have a look with valgrind, it would be nice.

@akien-mga If nobody sees any obvious regression/problem with this PR, I propose we use my repo as it is right now for the next testing version

fixes #560 
fixes #531 
