### PR TITLE
Make portals claimable + max creature number increases with portals + small fixes

### DIFF
--- a/config/global.cfg
+++ b/config/global.cfg
@@ -96,7 +96,10 @@
 [GameConfig]
     NetworkPort	31222
     CreatureDeathCounter	30
-    MaxCreaturesPerSeat	20
+# Maximum creature number. This is used for lagging purpose and a seat cannot control more creatures
+    MaxCreaturesPerSeatAbsolute	30
+# Maximum creature number a seat can control without portal
+    MaxCreaturesPerSeatDefault	10
     SlapDamagePercent	15
     TimePayDay	400
     NbTurnsFuriousMax	120

--- a/levels/multiplayer/GreedOrMight.level
+++ b/levels/multiplayer/GreedOrMight.level
@@ -2224,6 +2224,7 @@ MineNGold	50
 38	14
 38	15
 38	16
+9	5
 [/Room]
 [Room]
 1	DungeonTemple3	2	9
@@ -2248,6 +2249,7 @@ MineNGold	50
 60	46
 60	47
 60	48
+9	5
 [/Room]
 [Room]
 1	DungeonTemple5	3	9
@@ -2272,6 +2274,7 @@ MineNGold	50
 15	44
 15	45
 15	46
+9	5
 [/Room]
 [/Rooms]
 

--- a/levels/multiplayer/TestMultiplayer.level
+++ b/levels/multiplayer/TestMultiplayer.level
@@ -5838,6 +5838,7 @@ ProtectDungeonTemple	NULL
 187	213
 187	214
 187	215
+9	5
 [/Room]
 [Room]
 3	Treasury3	1	2
@@ -5883,6 +5884,7 @@ ProtectDungeonTemple	NULL
 256	221
 256	222
 256	223
+9	5
 [/Room]
 [Room]
 3	Treasury7	2	9
@@ -5955,6 +5957,7 @@ ProtectDungeonTemple	NULL
 157	105
 157	106
 157	107
+9	5
 [/Room]
 [Room]
 3	Treasury10	3	5
@@ -5998,6 +6001,7 @@ ProtectDungeonTemple	NULL
 273	91
 273	92
 273	93
+9	5
 [/Room]
 [Room]
 3	Treasury13	4	5

--- a/levels/multiplayer/TestMultiplayerSmall1v1.level
+++ b/levels/multiplayer/TestMultiplayerSmall1v1.level
@@ -486,6 +486,7 @@ ProtectDungeonTemple	NULL
 9	12
 9	13
 9	14
+9	5
 [/Room]
 [Room]
 3	Treasury3	1	3
@@ -532,6 +533,7 @@ ProtectDungeonTemple	NULL
 9	42
 9	43
 9	44
+9	5
 [/Room]
 [Room]
 3	Treasury6	2	3

--- a/levels/multiplayer/TestMultiplayerSmallAlliance.level
+++ b/levels/multiplayer/TestMultiplayerSmallAlliance.level
@@ -708,6 +708,7 @@ ProtectDungeonTemple	NULL
 9	12
 9	13
 9	14
+9	5
 [/Room]
 [Room]
 3	Treasury3	1	3
@@ -754,6 +755,7 @@ ProtectDungeonTemple	NULL
 9	42
 9	43
 9	44
+9	5
 [/Room]
 [Room]
 3	Treasury6	2	3
@@ -800,6 +802,7 @@ ProtectDungeonTemple	NULL
 39	12
 39	13
 39	14
+9	5
 [/Room]
 [Room]
 3	Treasury9	3	3
@@ -846,6 +849,7 @@ ProtectDungeonTemple	NULL
 39	42
 39	43
 39	44
+9	5
 [/Room]
 [Room]
 3	Treasury12	4	3

--- a/levels/multiplayer/TestMultiplayerSmallFreeForAll.level
+++ b/levels/multiplayer/TestMultiplayerSmallFreeForAll.level
@@ -708,6 +708,7 @@ ProtectDungeonTemple	NULL
 9	12
 9	13
 9	14
+9	5
 [/Room]
 [Room]
 3	Treasury3	1	3
@@ -754,6 +755,7 @@ ProtectDungeonTemple	NULL
 9	42
 9	43
 9	44
+9	5
 [/Room]
 [Room]
 3	Treasury6	2	3
@@ -800,6 +802,7 @@ ProtectDungeonTemple	NULL
 39	12
 39	13
 39	14
+9	5
 [/Room]
 [Room]
 3	Treasury9	3	3
@@ -846,6 +849,7 @@ ProtectDungeonTemple	NULL
 39	42
 39	43
 39	44
+9	5
 [/Room]
 [Room]
 3	Treasury12	4	3

--- a/levels/skirmish/GreedOrMight.level
+++ b/levels/skirmish/GreedOrMight.level
@@ -2224,6 +2224,7 @@ MineNGold	50
 38	14
 38	15
 38	16
+9	5
 [/Room]
 [Room]
 1	DungeonTemple3	2	9
@@ -2248,6 +2249,7 @@ MineNGold	50
 60	46
 60	47
 60	48
+9	5
 [/Room]
 [Room]
 1	DungeonTemple5	3	9
@@ -2272,6 +2274,7 @@ MineNGold	50
 15	44
 15	45
 15	46
+9	5
 [/Room]
 [/Rooms]
 

--- a/levels/skirmish/ScreamInTheDark.level
+++ b/levels/skirmish/ScreamInTheDark.level
@@ -4712,6 +4712,7 @@ ProtectDungeonTemple	NULL
 4	20
 5	20
 6	20
+9	5
 [/Room]
 [Room]
 6	Dojo3	2	20
@@ -4804,6 +4805,7 @@ ProtectDungeonTemple	NULL
 89	15
 90	15
 91	15
+9	5
 [/Room]
 [Room]
 3	Treasury8	2	16
@@ -4969,6 +4971,7 @@ ProtectDungeonTemple	NULL
 11	95
 12	95
 13	95
+9	5
 [/Room]
 [Room]
 3	Treasury17	3	16
@@ -5141,6 +5144,7 @@ ProtectDungeonTemple	NULL
 87	93
 88	93
 89	93
+9	5
 [/Room]
 [Room]
 3	Treasury25	4	1
@@ -5376,6 +5380,7 @@ ProtectDungeonTemple	NULL
 42	55
 43	55
 44	55
+9	5
 [/Room]
 [Room]
 3	Treasury39	5	10

--- a/levels/skirmish/StonekeepSiege.level
+++ b/levels/skirmish/StonekeepSiege.level
@@ -3657,6 +3657,7 @@ ProtectDungeonTemple	NULL
 52	1
 52	2
 52	3
+9	5
 [/Room]
 [Room]
 3	Treasury3	1	9
@@ -3709,6 +3710,7 @@ ProtectDungeonTemple	NULL
 10	68
 10	69
 10	70
+9	5
 [/Room]
 [Room]
 3	Treasury6	2	9
@@ -3761,6 +3763,7 @@ ProtectDungeonTemple	NULL
 94	68
 94	69
 94	70
+9	5
 [/Room]
 [Room]
 3	Treasury9	3	10
@@ -3989,6 +3992,7 @@ ProtectDungeonTemple	NULL
 55	96
 55	97
 55	98
+9	5
 [/Room]
 [Room]
 4	Portal18	4	9
@@ -4001,6 +4005,7 @@ ProtectDungeonTemple	NULL
 45	96
 45	97
 45	98
+9	5
 [/Room]
 [Room]
 3	Treasury19	4	26

--- a/levels/skirmish/TestLegacy.level
+++ b/levels/skirmish/TestLegacy.level
@@ -6592,6 +6592,7 @@ ProtectDungeonTemple	NULL
 187	213
 187	214
 187	215
+9	5
 [/Room]
 [Room]
 3	Treasury6	1	1
@@ -6676,6 +6677,7 @@ ProtectDungeonTemple	NULL
 206	213
 206	214
 206	215
+9	5
 [/Room]
 [Room]
 3	Treasury12	2	9

--- a/levels/skirmish/TestSingleplayer.level
+++ b/levels/skirmish/TestSingleplayer.level
@@ -5838,6 +5838,7 @@ ProtectDungeonTemple	NULL
 187	213
 187	214
 187	215
+9	5
 [/Room]
 [Room]
 3	Treasury3	1	2
@@ -5883,6 +5884,7 @@ ProtectDungeonTemple	NULL
 256	221
 256	222
 256	223
+9	5
 [/Room]
 [Room]
 3	Treasury7	2	9
@@ -5955,6 +5957,7 @@ ProtectDungeonTemple	NULL
 157	105
 157	106
 157	107
+9	5
 [/Room]
 [Room]
 3	Treasury10	3	5
@@ -5998,6 +6001,7 @@ ProtectDungeonTemple	NULL
 273	91
 273	92
 273	93
+9	5
 [/Room]
 [Room]
 3	Treasury13	4	5

--- a/levels/skirmish/TestSingleplayerSmall.level
+++ b/levels/skirmish/TestSingleplayerSmall.level
@@ -863,7 +863,7 @@ ProtectDungeonTemple	NULL
 11	11
 [/Room]
 [Room]
-4	Portal2	1	9
+4	Portal2	0	9
 7	12
 7	13
 7	14
@@ -873,6 +873,7 @@ ProtectDungeonTemple	NULL
 9	12
 9	13
 9	14
+9	5
 [/Room]
 [Room]
 3	Treasury3	1	3
@@ -947,6 +948,7 @@ ProtectDungeonTemple	NULL
 9	42
 9	43
 9	44
+9	5
 [/Room]
 [Room]
 3	Treasury6	2	3
@@ -1006,6 +1008,7 @@ ProtectDungeonTemple	NULL
 39	12
 39	13
 39	14
+9	5
 [/Room]
 [Room]
 3	Treasury10	3	3
@@ -1052,6 +1055,7 @@ ProtectDungeonTemple	NULL
 39	42
 39	43
 39	44
+9	5
 [/Room]
 [/Rooms]
 

--- a/levels/skirmish/TestSingleplayerSmallEmpty.level
+++ b/levels/skirmish/TestSingleplayerSmallEmpty.level
@@ -2588,7 +2588,7 @@ ProtectDungeonTemple	NULL
 11	11
 [/Room]
 [Room]
-4	Portal2	1	9
+4	Portal2	0	9
 7	12
 7	13
 7	14
@@ -2598,6 +2598,7 @@ ProtectDungeonTemple	NULL
 9	12
 9	13
 9	14
+9	10
 [/Room]
 [Room]
 3	Treasury3	1	3

--- a/levels/skirmish/TestSingleplayerSmallPassability.level
+++ b/levels/skirmish/TestSingleplayerSmallPassability.level
@@ -184,6 +184,7 @@ ProtectDungeonTemple	NULL
 3	4
 3	5
 3	6
+9	5
 [/Room]
 [Room]
 3	Treasury3	1	1

--- a/levels/skirmish/TheBridge.level
+++ b/levels/skirmish/TheBridge.level
@@ -4392,6 +4392,7 @@ ProtectDungeonTemple	NULL
 57	75
 57	76
 57	77
+9	5
 [/Room]
 [Room]
 4	Portal3	1	9
@@ -4404,6 +4405,7 @@ ProtectDungeonTemple	NULL
 45	75
 45	76
 45	77
+9	5
 [/Room]
 [Room]
 1	DungeonTemple4	2	9
@@ -4428,6 +4430,7 @@ ProtectDungeonTemple	NULL
 45	24
 45	25
 45	26
+9	5
 [/Room]
 [Room]
 4	Portal6	2	9
@@ -4440,6 +4443,7 @@ ProtectDungeonTemple	NULL
 57	24
 57	25
 57	26
+9	5
 [/Room]
 [/Rooms]
 

--- a/source/entities/Building.cpp
+++ b/source/entities/Building.cpp
@@ -57,12 +57,6 @@ void Building::doUpkeep()
     std::vector<Tile*> tilesToRemove;
     for (Tile* tile : mCoveredTiles)
     {
-        if(!getSeat()->isAlliedSeat(tile->getSeat()))
-        {
-            tilesToRemove.push_back(tile);
-            continue;
-        }
-
         if (mTileData[tile]->mHP <= 0.0)
         {
             tilesToRemove.push_back(tile);
@@ -336,6 +330,14 @@ std::string Building::getNameTile(Tile* tile)
 bool Building::isAttackable(Tile* tile, Seat* seat) const
 {
     if(getHP(tile) <= 0.0)
+        return false;
+
+    return true;
+}
+
+bool Building::canSeatSellBuilding(Seat* seat) const
+{
+    if(!getSeat()->canBuildingBeDestroyedBy(seat))
         return false;
 
     return true;

--- a/source/entities/Building.cpp
+++ b/source/entities/Building.cpp
@@ -205,7 +205,13 @@ Tile* Building::getCentralTile()
 
     std::vector<Tile*> allTiles;
     allTiles.insert(allTiles.end(), mCoveredTiles.begin(), mCoveredTiles.end());
-    allTiles.insert(allTiles.end(), mCoveredTilesDestroyed.begin(), mCoveredTilesDestroyed.end());
+
+    // In editor mode, we do not consider destroyed tiles while computing the central tile
+    if(!getGameMap()->isInEditorMode())
+        allTiles.insert(allTiles.end(), mCoveredTilesDestroyed.begin(), mCoveredTilesDestroyed.end());
+
+    if(allTiles.empty())
+        return nullptr;
 
     int minX, maxX, minY, maxY;
     minX = maxX = allTiles[0]->getX();

--- a/source/entities/Building.h
+++ b/source/entities/Building.h
@@ -98,6 +98,14 @@ public:
         Tile* targetTile, double x, double y, double rotationAngle, bool hideCoveredTile, float opacity = 1.0f);
     Tile* getCentralTile();
 
+    virtual bool isClaimable(Seat* seat) const
+    { return false; }
+
+    virtual void claimForSeat(Seat* seat, Tile* tile, double danceRate)
+    {}
+
+    virtual bool canSeatSellBuilding(Seat* seat) const;
+
     virtual bool isAttackable(Tile* tile, Seat* seat) const;
     virtual bool removeCoveredTile(Tile* t);
     std::vector<Tile*> getCoveredTiles();

--- a/source/entities/Tile.cpp
+++ b/source/entities/Tile.cpp
@@ -205,8 +205,11 @@ bool Tile::isGroundClaimable(Seat* seat) const
     if(mType != TileType::dirt && mType != TileType::gold)
         return false;
 
-    if(getCoveringRoom() != nullptr)
+    if((getCoveringBuilding() != nullptr) &&
+       (!getCoveringBuilding()->isClaimable(seat)))
+    {
         return false;
+    }
 
     if(isClaimedForSeat(seat))
         return false;
@@ -696,6 +699,14 @@ void Tile::addNeighbor(Tile *n)
 
 void Tile::claimForSeat(Seat* seat, double nDanceRate)
 {
+    // If there is a claimable building, we claim it
+    if((getCoveringBuilding() != nullptr) &&
+       (getCoveringBuilding()->isClaimable(seat)))
+    {
+        getCoveringBuilding()->claimForSeat(seat, this, nDanceRate);
+        return;
+    }
+
     // If the seat is allied, we add to it. If it is an enemy seat, we subtract from it.
     if (getSeat() != nullptr && getSeat()->isAlliedSeat(seat))
     {

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -63,6 +63,7 @@ Seat::Seat(GameMap* gameMap) :
     mStartingY(0),
     mGoldMined(0),
     mNumCreaturesFighters(0),
+    mNumCreaturesFightersMax(0),
     mDefaultWorkerClass(nullptr),
     mNumClaimedTiles(0),
     mHasGoalsChanged(true),
@@ -794,7 +795,8 @@ ODPacket& operator<<(ODPacket& os, Seat *s)
     os << s->mId << s->mTeamId << s->mPlayerType << s->mFaction << s->mStartingX
        << s->mStartingY;
     os << s->mColorId;
-    os << s->mGold << s->mMana << s->mManaDelta << s->mNumClaimedTiles << s->mNumCreaturesFighters;
+    os << s->mGold << s->mMana << s->mManaDelta << s->mNumClaimedTiles;
+    os << s->mNumCreaturesFighters << s->mNumCreaturesFightersMax;
     os << s->mHasGoalsChanged;
     os << s->mNbTreasuries;
     uint32_t nb = s->mAvailableTeamIds.size();
@@ -810,7 +812,8 @@ ODPacket& operator>>(ODPacket& is, Seat *s)
     is >> s->mId >> s->mTeamId >> s->mPlayerType;
     is >> s->mFaction >> s->mStartingX >> s->mStartingY;
     is >> s->mColorId;
-    is >> s->mGold >> s->mMana >> s->mManaDelta >> s->mNumClaimedTiles >> s->mNumCreaturesFighters;
+    is >> s->mGold >> s->mMana >> s->mManaDelta >> s->mNumClaimedTiles;
+    is >> s->mNumCreaturesFighters >> s->mNumCreaturesFightersMax;
     is >> s->mHasGoalsChanged;
     is >> s->mNbTreasuries;
     s->mColorValue = ConfigManager::getSingleton().getColorFromId(s->mColorId);
@@ -861,6 +864,7 @@ void Seat::refreshFromSeat(Seat* s)
     mManaDelta = s->mManaDelta;
     mNumClaimedTiles = s->mNumClaimedTiles;
     mNumCreaturesFighters = s->mNumCreaturesFighters;
+    mNumCreaturesFightersMax = s->mNumCreaturesFightersMax;
     mHasGoalsChanged = s->mHasGoalsChanged;
     mNbTreasuries = s->mNbTreasuries;
 }

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -326,15 +326,7 @@ bool Seat::canOwnedCreatureUseRoomFrom(const Seat* seat) const
     return false;
 }
 
-bool Seat::canRoomBeDestroyedBy(const Seat* seat) const
-{
-    if(this == seat)
-        return true;
-
-    return false;
-}
-
-bool Seat::canTrapBeDestroyedBy(const Seat* seat) const
+bool Seat::canBuildingBeDestroyedBy(const Seat* seat) const
 {
     if(this == seat)
         return true;

--- a/source/game/Seat.h
+++ b/source/game/Seat.h
@@ -170,6 +170,9 @@ public:
     inline int getNumCreaturesFighters() const
     { return mNumCreaturesFighters; }
 
+    inline int getNumCreaturesFightersMax() const
+    { return mNumCreaturesFightersMax; }
+
     bool takeMana(double mana);
 
     inline Ogre::Vector3 getStartingPosition() const
@@ -376,6 +379,7 @@ private:
 
     //! \brief The number of living creatures fighters under this seat's control
     int mNumCreaturesFighters;
+    int mNumCreaturesFightersMax;
 
     //! \brief The actual color that this color index translates into.
     std::string mColorId;

--- a/source/game/Seat.h
+++ b/source/game/Seat.h
@@ -212,8 +212,7 @@ public:
     bool canOwnedCreatureBePickedUpBy(const Seat* seat) const;
     bool canOwnedTileBeClaimedBy(const Seat* seat) const;
     bool canOwnedCreatureUseRoomFrom(const Seat* seat) const;
-    bool canRoomBeDestroyedBy(const Seat* seat) const;
-    bool canTrapBeDestroyedBy(const Seat* seat) const;
+    bool canBuildingBeDestroyedBy(const Seat* seat) const;
 
     void clearTilesWithVision();
     void notifyVisionOnTile(Tile* tile);

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -49,6 +49,7 @@
 
 #include "rooms/Room.h"
 #include "rooms/RoomDungeonTemple.h"
+#include "rooms/RoomPortal.h"
 #include "rooms/RoomTreasury.h"
 
 #include "spell/Spell.h"
@@ -1064,6 +1065,8 @@ unsigned long int GameMap::doMiscUpkeep()
         if (seat->checkAllGoals() == 0
                 && seat->numFailedGoals() == 0)
             addWinningSeat(seat);
+
+        seat->mNumCreaturesFightersMax = getMaxNumberCreatures(seat);
 
         // Set the creatures count to 0. It will be reset by the next count in doTurn()
         seat->mNumCreaturesFighters = 0;
@@ -2963,4 +2966,18 @@ const TileSetValue& GameMap::getMeshForTile(const Tile* tile) const
     }
 
     return mTileSet->getTileValues(tile->getTileVisual()).at(index);
+}
+
+uint32_t GameMap::getMaxNumberCreatures(Seat* seat) const
+{
+    uint32_t nbCreatures = ConfigManager::getSingleton().getMaxCreaturesPerSeatDefault();
+
+    std::vector<const Room*> portals = getRoomsByTypeAndSeat(RoomType::portal, seat);
+    for(const Room* room : portals)
+    {
+        const RoomPortal* roomPortal = static_cast<const RoomPortal*>(room);
+        nbCreatures += roomPortal->getNbCreatureMaxIncrease();
+    }
+
+    return std::min(nbCreatures, ConfigManager::getSingleton().getMaxCreaturesPerSeatAbsolute());
 }

--- a/source/gamemap/GameMap.h
+++ b/source/gamemap/GameMap.h
@@ -443,6 +443,8 @@ public:
     //! \brief Returns the closest tile from origin where a GameEntity in listObjects is
     GameEntity* getClosestTileWhereGameEntityFromList(std::vector<GameEntity*> listObjects, Tile* origin, Tile*& attackedTile);
 
+    uint32_t getMaxNumberCreatures(Seat* seat) const;
+
     void logFloodFileTiles();
     void consoleSetCreatureDestination(const std::string& creatureName, int x, int y);
     void consoleDisplayCreatureVisualDebug(const std::string& creatureName, bool enable);

--- a/source/gamemap/TileContainer.cpp
+++ b/source/gamemap/TileContainer.cpp
@@ -686,48 +686,25 @@ std::vector<Tile*> TileContainer::tilesBorderedByRegion(const std::vector<Tile*>
 {
     std::vector<Tile*> returnList;
 
-    // If there are too many tiles, we use an algorithm that do not use std::find (too slow) but
-    // that is more memory consuming.
-    if(region.size() > 40)
+    std::vector<std::vector<bool>> tilesToRefresh(getMapSizeX(), std::vector<bool>(getMapSizeY(), false));
+    for (Tile* t1 : region)
     {
-        std::vector<std::vector<bool>> tilesToRefresh(getMapSizeX(), std::vector<bool>(getMapSizeY(), false));
-        for (Tile* t1 : region)
+        if(!tilesToRefresh[t1->getX()][t1->getY()])
         {
-            if(!tilesToRefresh[t1->getX()][t1->getY()])
-            {
-                tilesToRefresh[t1->getX()][t1->getY()] = true;
-                returnList.push_back(t1);
-            }
+            tilesToRefresh[t1->getX()][t1->getY()] = true;
+            returnList.push_back(t1);
+        }
 
-            // Get the tiles bordering the current tile and loop over them.
-            for (Tile* t2 : t1->getAllNeighbors())
-            {
-                if(tilesToRefresh[t2->getX()][t2->getY()])
-                    continue;
+        // Get the tiles bordering the current tile and loop over them.
+        for (Tile* t2 : t1->getAllNeighbors())
+        {
+            if(tilesToRefresh[t2->getX()][t2->getY()])
+                continue;
 
-                tilesToRefresh[t2->getX()][t2->getY()] = true;
-                returnList.push_back(t2);
-            }
+            tilesToRefresh[t2->getX()][t2->getY()] = true;
+            returnList.push_back(t2);
         }
     }
-    else
-    {
-        // Loop over all the tiles in the specified region.
-        for (Tile* t1 : region)
-        {
-            // Get the tiles bordering the current tile and loop over them.
-            for (Tile* t2 : t1->getAllNeighbors())
-            {
-                // We add the tile in the return list if it is not already there or in the region
-                if((std::find(region.begin(), region.end(), t2) == region.end()) &&
-                   (std::find(returnList.begin(), returnList.end(), t2) == returnList.end()))
-                {
-                    returnList.push_back(t2);
-                }
-            }
-        }
-    }
-
 
     return returnList;
 }

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -394,11 +394,14 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
 
                 for(Tile* tile : tiles)
                 {
+                    // FIXME: the client is not notified about rooms/traps. Thus,
+                    // the funding cannot be computed. To do that, the easiest will
+                    // be to create a variable in the tile mGoldIfSold for each client
                     if(tile->getCoveringRoom() == nullptr)
                         continue;
 
                     Room* room = tile->getCoveringRoom();
-                    if(!room->getSeat()->canRoomBeDestroyedBy(player->getSeat()))
+                    if(!room->getSeat()->canBuildingBeDestroyedBy(player->getSeat()))
                         continue;
 
                     goldRetrieved += Room::costPerTile(room->getType()) / 2;
@@ -426,11 +429,13 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
 
                 for(Tile* tile : tiles)
                 {
+                    // FIXME: the client is not notified about rooms/traps. Thus,
+                    // the funding cannot be computed
                     if(tile->getCoveringTrap() == nullptr)
                         continue;
 
                     Trap* trap = tile->getCoveringTrap();
-                    if(!trap->getSeat()->canTrapBeDestroyedBy(player->getSeat()))
+                    if(!trap->getSeat()->canBuildingBeDestroyedBy(player->getSeat()))
                         continue;
 
                     goldRetrieved += Trap::costPerTile(trap->getType()) / 2;

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -1162,7 +1162,7 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                     continue;
 
                 Room* room = tile->getCoveringRoom();
-                if(!room->getSeat()->canRoomBeDestroyedBy(player->getSeat()))
+                if(!room->canSeatSellBuilding(player->getSeat()))
                     continue;
 
                 roomsImpacted.insert(room);
@@ -1399,7 +1399,7 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                     continue;
 
                 Trap* trap = tile->getCoveringTrap();
-                if(!trap->getSeat()->canTrapBeDestroyedBy(player->getSeat()))
+                if(!trap->canSeatSellBuilding(player->getSeat()))
                     continue;
 
                 trapsImpacted.insert(trap);

--- a/source/render/ODFrameListener.cpp
+++ b/source/render/ODFrameListener.cpp
@@ -283,7 +283,7 @@ void ODFrameListener::refreshPlayerDisplay(const std::string& goalsDisplayString
 
     tempWindow = mGui->getGuiSheet(Gui::inGameMenu)->getChild(Gui::DISPLAY_CREATURES);
     tempSS.str("");
-    tempSS << mySeat->getNumCreaturesFighters() << "/" << ConfigManager::getSingleton().getMaxCreaturesPerSeat();
+    tempSS << mySeat->getNumCreaturesFighters() << "/" << mySeat->getNumCreaturesFightersMax();
     tempWindow->setText(tempSS.str());
 
     tempWindow = mGui->getGuiSheet(Gui::inGameMenu)->getChild(Gui::DISPLAY_GOLD);

--- a/source/rooms/Room.h
+++ b/source/rooms/Room.h
@@ -100,7 +100,7 @@ public:
     { return mNumActiveSpots; }
 
     //! \brief Sets the name, seat and associates the given tiles with the room
-    void setupRoom(const std::string& name, Seat* seat, const std::vector<Tile*>& tiles);
+    virtual void setupRoom(const std::string& name, Seat* seat, const std::vector<Tile*>& tiles);
 
     //! \brief Checks on the neighboor tiles of the room if there are other rooms of the same type/same seat.
     //! if so, it aborbs them

--- a/source/rooms/RoomCrypt.cpp
+++ b/source/rooms/RoomCrypt.cpp
@@ -141,7 +141,7 @@ void RoomCrypt::doUpkeep()
         p.second.first = nullptr;
         p.second.second = -1;
 
-        int32_t maxCreatures = ConfigManager::getSingleton().getMaxCreaturesPerSeat();
+        int32_t maxCreatures = ConfigManager::getSingleton().getMaxCreaturesPerSeatAbsolute();
         int32_t numCreatures = getGameMap()->getCreaturesBySeat(getSeat()).size();
         int32_t cryptPointsForSpawn = ConfigManager::getSingleton().getRoomConfigInt32("CryptPointsForSpawn");
         if((numCreatures < maxCreatures) &&

--- a/source/rooms/RoomPortal.cpp
+++ b/source/rooms/RoomPortal.cpp
@@ -39,7 +39,8 @@ RoomPortal::RoomPortal(GameMap* gameMap) :
         Room(gameMap),
         mSpawnCreatureCountdown(0),
         mPortalObject(nullptr),
-        mClaimedValue(0)
+        mClaimedValue(0),
+        mNbCreatureMaxIncrease(0)
 {
    setMeshName("Portal");
 }
@@ -141,9 +142,12 @@ void RoomPortal::doUpkeep()
     }
 
     // Randomly choose to spawn a creature.
-    const double maxCreatures = ConfigManager::getSingleton().getMaxCreaturesPerSeat();
+    const double maxCreatures = getSeat()->getNumCreaturesFightersMax();
     // Count how many creatures are controlled by this seat
     double numCreatures = getGameMap()->getNbFightersForSeat(getSeat());
+    if(numCreatures >= maxCreatures)
+        return;
+
     double targetProbability = powl((maxCreatures - numCreatures) / maxCreatures, 1.5);
     if (Random::Double(0.0, 1.0) <= targetProbability)
         spawnCreature();
@@ -191,20 +195,23 @@ void RoomPortal::setupRoom(const std::string& name, Seat* seat, const std::vecto
 {
     Room::setupRoom(name, seat, tiles);
     mClaimedValue = static_cast<double>(numCoveredTiles());
+    // By default, we allow some more creatures per portal
+    mNbCreatureMaxIncrease = 5;
 }
 
 void RoomPortal::exportToStream(std::ostream& os) const
 {
     Room::exportToStream(os);
 
-    os << mClaimedValue << "\n";
+    os << mClaimedValue << "\t" << mNbCreatureMaxIncrease << "\n";
 }
 
 void RoomPortal::importFromStream(std::istream& is)
 {
     Room::importFromStream(is);
 
-    OD_ASSERT_TRUE_MSG(is >> mClaimedValue, "roomPortal=" + getName());
+    OD_ASSERT_TRUE(is >> mClaimedValue);
+    OD_ASSERT_TRUE(is >> mNbCreatureMaxIncrease);
 }
 
 void RoomPortal::restoreInitialEntityState()

--- a/source/rooms/RoomPortal.h
+++ b/source/rooms/RoomPortal.h
@@ -29,28 +29,45 @@ class RoomPortal: public Room
 public:
     RoomPortal(GameMap* gameMap);
 
-    virtual RoomType getType() const
+    virtual RoomType getType() const override
     { return RoomType::portal; }
 
+    //! Room portal is claimable by enemy seats
+    virtual bool isClaimable(Seat* seat) const override;
+    virtual void claimForSeat(Seat* seat, Tile* tile, double danceRate) override;
+
+    //! Room portal cannot be destroyed
+    virtual bool isAttackable(Tile* tile, Seat* seat) const override
+    { return false; }
+
+    //! No seat can sell Room portals
+    virtual bool canSeatSellBuilding(Seat* seat) const override
+    { return false; }
+
     //! \brief In addition to the standard upkeep, check to see if a new creature should be spawned.
-    void doUpkeep();
+    void doUpkeep() override;
 
     //! \brief Creates a new creature whose class is probabalistic and adds it to the game map at the center of the portal.
     void spawnCreature();
 
     //! \brief Portals only display claimed tiles on their ground.
-    virtual bool shouldDisplayBuildingTile() const
+    virtual bool shouldDisplayBuildingTile() const override
     { return false; }
 
     //! \brief Updates the portal position when in editor mode.
-    void updateActiveSpots();
+    void updateActiveSpots() override;
+
+    virtual void setupRoom(const std::string& name, Seat* seat, const std::vector<Tile*>& tiles) override;
+
+    virtual void exportToStream(std::ostream& os) const override;
+    virtual void importFromStream(std::istream& is) override;
 
     virtual void restoreInitialEntityState() override;
 
 protected:
-    void destroyMeshLocal();
+    void destroyMeshLocal() override;
 
-    void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile)
+    void notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile) override
     {
         // This Room keeps its building object until it is destroyed (it will be released when
         // the room is destroyed)
@@ -59,8 +76,9 @@ protected:
 private:
     //! \brief Stores the number of turns before spawning the next creature.
     int mSpawnCreatureCountdown;
-
     RenderedMovableEntity* mPortalObject;
+
+    double mClaimedValue;
 
     //! \brief Updates the portal mesh position.
     void updatePortalPosition();

--- a/source/rooms/RoomPortal.h
+++ b/source/rooms/RoomPortal.h
@@ -29,6 +29,9 @@ class RoomPortal: public Room
 public:
     RoomPortal(GameMap* gameMap);
 
+    inline uint32_t getNbCreatureMaxIncrease() const
+    { return mNbCreatureMaxIncrease; }
+
     virtual RoomType getType() const override
     { return RoomType::portal; }
 
@@ -79,6 +82,8 @@ private:
     RenderedMovableEntity* mPortalObject;
 
     double mClaimedValue;
+
+    uint32_t mNbCreatureMaxIncrease;
 
     //! \brief Updates the portal mesh position.
     void updatePortalPosition();

--- a/source/traps/Trap.h
+++ b/source/traps/Trap.h
@@ -55,6 +55,7 @@ class TrapTileData : public TileData
 public:
     TrapTileData() :
         TileData(),
+        mClaimedValue(1.0),
         mIsActivated(false),
         mReloadTime(0),
         mCraftedTrap(nullptr),
@@ -147,6 +148,8 @@ public:
     inline void setRemoveTrap(bool removeTrap)
     { mRemoveTrap = removeTrap; }
 
+    double mClaimedValue;
+
 private:
     bool mIsActivated;
     uint32_t mReloadTime;
@@ -182,6 +185,10 @@ public:
 
     static int costPerTile(TrapType t);
 
+    //! Traps can be claimed by enemy seats
+    virtual bool isClaimable(Seat* seat) const override;
+    virtual void claimForSeat(Seat* seat, Tile* tile, double danceRate) override;
+
     virtual void doUpkeep() override;
 
     virtual bool shoot(Tile* tile)
@@ -191,7 +198,7 @@ public:
     bool isActivated(Tile* tile) const;
 
     //! \brief Sets the name, seat and associates the given tiles with the trap
-    void setupTrap(const std::string& name, Seat* seat, const std::vector<Tile*>& tiles);
+    virtual void setupTrap(const std::string& name, Seat* seat, const std::vector<Tile*>& tiles);
 
     virtual bool removeCoveredTile(Tile* t);
     virtual void updateActiveSpots();

--- a/source/utils/ConfigManager.cpp
+++ b/source/utils/ConfigManager.cpp
@@ -46,7 +46,8 @@ ConfigManager::ConfigManager() :
     mNetworkPort(0),
     mBaseSpawnPoint(10),
     mCreatureDeathCounter(10),
-    mMaxCreaturesPerSeat(15),
+    mMaxCreaturesPerSeatAbsolute(30),
+    mMaxCreaturesPerSeatDefault(10),
     mCreatureBaseMood(1000),
     mCreatureMoodHappy(1200),
     mCreatureMoodUpset(0),
@@ -462,10 +463,17 @@ bool ConfigManager::loadGlobalGameConfig(std::stringstream& configFile)
             // Not mandatory
         }
 
-        if(nextParam == "MaxCreaturesPerSeat")
+        if(nextParam == "MaxCreaturesPerSeatAbsolute")
         {
             configFile >> nextParam;
-            mMaxCreaturesPerSeat = Helper::toUInt32(nextParam);
+            mMaxCreaturesPerSeatAbsolute = Helper::toUInt32(nextParam);
+            // Not mandatory
+        }
+
+        if(nextParam == "MaxCreaturesPerSeatDefault")
+        {
+            configFile >> nextParam;
+            mMaxCreaturesPerSeatDefault = Helper::toUInt32(nextParam);
             // Not mandatory
         }
 

--- a/source/utils/ConfigManager.h
+++ b/source/utils/ConfigManager.h
@@ -57,8 +57,11 @@ public:
     inline uint32_t getCreatureDeathCounter() const
     { return mCreatureDeathCounter; }
 
-    inline uint32_t getMaxCreaturesPerSeat() const
-    { return mMaxCreaturesPerSeat; }
+    inline uint32_t getMaxCreaturesPerSeatAbsolute() const
+    { return mMaxCreaturesPerSeatAbsolute; }
+
+    inline uint32_t getMaxCreaturesPerSeatDefault() const
+    { return mMaxCreaturesPerSeatDefault; }
 
     inline double getSlapDamagePercent() const
     { return mSlapDamagePercent; }
@@ -154,7 +157,8 @@ private:
     uint32_t mNetworkPort;
     uint32_t mBaseSpawnPoint;
     uint32_t mCreatureDeathCounter;
-    uint32_t mMaxCreaturesPerSeat;
+    uint32_t mMaxCreaturesPerSeatAbsolute;
+    uint32_t mMaxCreaturesPerSeatDefault;
     int32_t mCreatureBaseMood;
     int32_t mCreatureMoodHappy;
     int32_t mCreatureMoodUpset;


### PR DESCRIPTION
To test, the skirmish small test map (2v2 and empty) now start for seat 1 with 1 rogue portal that needs to be claimed. Note that the max creature number should increase when the portal is claimed (5 in 2v2 map and 10 in empty map).
I've not tested with 2 portals but it should work ^^
