### PR TITLE
Clear up the message and chat widget at mode destruction.

### DIFF
--- a/levels/skirmish/FallingKeeper.level
+++ b/levels/skirmish/FallingKeeper.level
@@ -2138,7 +2138,7 @@ ProtectDungeonTemple	NULL
 SpawnTurnMin	0
 SpawnTurnMax	500
 [Creatures]
-DwarfWorker	2
+DwarfWorker	12
 Adventurer	2
 Adventurer	2
 Wizard	2
@@ -2149,10 +2149,10 @@ Knight	2
 SpawnTurnMin	700
 SpawnTurnMax	1500
 [Creatures]
-DwarfWorker	5
-Adventurer	5
-Adventurer	5
-Wizard	5
+DwarfWorker	15
+Adventurer	3
+Adventurer	3
+Wizard	4
 Knight	5
 Knight	5
 Knight	5
@@ -2163,13 +2163,13 @@ SpawnTurnMin	1000
 SpawnTurnMax	-1
 [Creatures]
 DwarfWorker	15
-Knight	15
-Knight	15
-Knight	15
-Wizard	15
-Wizard	15
-BigKnight	15
-BigKnight	15
+Knight	5
+Knight	5
+Knight	5
+Wizard	6
+Wizard	6
+BigKnight	7
+BigKnight	7
 [/Creatures]
 [/Wave]
 [Wave]
@@ -2177,15 +2177,15 @@ SpawnTurnMin	2500
 SpawnTurnMax	-1
 [Creatures]
 DwarfWorker	25
-Knight	25
-Knight	25
-Knight	25
-Wizard	25
-Wizard	25
-BigKnight	25
-BigKnight	25
-BigKnight	25
-BigKnight	25
+Knight	7
+Knight	7
+Knight	7
+Wizard	8
+Wizard	8
+BigKnight	10
+BigKnight	11
+BigKnight	12
+BigKnight	12
 [/Creatures]
 [/Wave]
 [/Waves]

--- a/source/modes/GameEditorModeBase.cpp
+++ b/source/modes/GameEditorModeBase.cpp
@@ -131,19 +131,18 @@ GameEditorModeBase::~GameEditorModeBase()
     // Delete the potential pending event messages
     for (EventMessage* message : mEventMessages)
         delete message;
+
+    // Clear up any events and chat messages.
+    mRootWindow->getChild("GameChatWindow/GameChatText")->setText("");
+    mRootWindow->getChild("GameEventText")->setText("");
 }
 
 void GameEditorModeBase::deactivate()
 {
-    // Clear up any events and chat messages.
-
     // Delete the potential pending event messages
     for (EventMessage* message : mEventMessages)
         delete message;
     mEventMessages.clear();
-
-    mRootWindow->getChild("GameChatWindow/GameChatText")->setText("");
-    mRootWindow->getChild("GameEventText")->setText("");
 }
 
 void GameEditorModeBase::connectGuiAction(const std::string& buttonName, AbstractApplicationMode::GuiAction action)


### PR DESCRIPTION
Following @oyvindln's advice.

This is fixing clearing the chat log for instance when opening/closing the console.

Not an ideal patch, but it's ok for the release.
