### PR TITLE
Handle inputs in a generic way in gamemode/editormode + small fix on worker behaviour + used macro for logs

### DIFF
--- a/config/spells.cfg
+++ b/config/spells.cfg
@@ -28,7 +28,7 @@
     CallToWarPrice	6000
     CallToWarNbTurnsMax	50
     CallToWarCooldown	15
-    CreatureHealPrice	5000
+    CreatureHealPrice	4500
     CreatureHealDuration	5
     CreatureHealValue	5
     CreatureHealCooldown	5

--- a/levels/skirmish/TestModelsFair.level
+++ b/levels/skirmish/TestModelsFair.level
@@ -622,6 +622,8 @@ ProtectDungeonTemple	NULL
 24	5	1	25
 24	6	1	25
 24	7	1	25
+24	9	1	0	1
+24	10	1	0	1
 24	12	1	0	1
 24	13	1	0	1
 24	15	1	0	1
@@ -639,6 +641,8 @@ ProtectDungeonTemple	NULL
 25	5	1	25
 25	6	1	25
 25	7	1	25
+25	9	1	0	1
+25	10	1	0	1
 25	12	1	0	1
 25	13	1	0	1
 25	15	1	0	1
@@ -1017,19 +1021,19 @@ Spider12	16	13	0
 [/Trap]
 [Trap]
 4	DoorWooden_1	1	1
-9	14	0	10	0	0	1	0
+9	14	0
 [/Trap]
 [Trap]
 4	DoorWooden_2	1	1
-12	9	0	10	0	0	1	0
+12	9	0
 [/Trap]
 [Trap]
 4	DoorWooden_3	1	1
-6	9	0	10	0	0	1	0
+6	9	0
 [/Trap]
 [Trap]
 4	DoorWooden_4	1	1
-9	6	0	10	0	0	1	0
+9	6	0
 [/Trap]
 [/Traps]
 
@@ -1070,6 +1074,7 @@ Spider12	16	13	0
 1	RunelordDwarf27	RunelordDwarf.mesh	27	7	0	RunelordDwarf	1	0	max	100	0	0	none	Roundshield	0	none	0
 1	BigKnight28	Knight.mesh	27	4	0	BigKnight	1	0	max	100	0	0	RustyShield	RustySword	0	none	0
 1	Defender29	Defender.mesh	27	1	0	Defender	1	0	max	100	0	0	none	none	0	none	0
+0	Adventurer1	Adventurer.mesh	24	10	0	Adventurer	1	0	max	100	0	0	none	none	0	none	0
 [/Creatures]
 
 [Spells]

--- a/source/ODApplication.h
+++ b/source/ODApplication.h
@@ -46,9 +46,6 @@ public:
     //! \brief Initializes the Application along with the ResourceManager
     void startGame(boost::program_options::variables_map& options);
 
-    //! \brief Display a GUI error message
-    static void displayErrorMessage(const std::string& message, LogManager& logger);
-
     static double turnsPerSecond;
     static const std::string VERSION;
     static const std::string VERSIONSTRING;

--- a/source/ai/AIManager.cpp
+++ b/source/ai/AIManager.cpp
@@ -40,7 +40,7 @@ bool AIManager::assignAI(Player& player, const std::string& type, const std::str
 
     if(ai == nullptr)
     {
-        LogManager::getSingleton().logMessage("Couldn't find requested AI type=" + type);
+        OD_LOG_INF("Couldn't find requested AI type=" + type);
         return false;
     }
 

--- a/source/ai/KeeperAI.cpp
+++ b/source/ai/KeeperAI.cpp
@@ -313,7 +313,7 @@ bool KeeperAI::handleRooms()
     mRoomPosY = bestY;
 
     Tile* tileDest = mGameMap.getTile(mRoomPosX, mRoomPosY);
-    if(tileDest != nullptr)
+    if(tileDest == nullptr)
     {
         OD_LOG_ERR("tileDest=" + Tile::displayAsString(tileDest) + ", mRoomPosX=" + Helper::toString(mRoomPosX) + ", mRoomPosY=" + Helper::toString(mRoomPosY));
         return false;

--- a/source/ai/KeeperAI.cpp
+++ b/source/ai/KeeperAI.cpp
@@ -142,7 +142,7 @@ bool KeeperAI::checkTreasury()
 
                     if(!RoomTreasury::buildRoomOnTiles(&mGameMap, &mPlayer, tiles))
                     {
-                        OD_ASSERT_TRUE_MSG(false, "seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
+                        OD_LOG_ERR("seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
                         return false;
                     }
                     return true;
@@ -258,7 +258,7 @@ bool KeeperAI::checkTreasury()
 
     if(!RoomTreasury::buildRoomOnTiles(&mGameMap, &mPlayer, tiles))
     {
-        OD_ASSERT_TRUE_MSG(false, "seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
+        OD_LOG_ERR("seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
         return false;
     }
 
@@ -279,9 +279,9 @@ bool KeeperAI::handleRooms()
     if(mRoomSize != -1)
     {
         Tile* tile = mGameMap.getTile(mRoomPosX, mRoomPosY);
-        OD_ASSERT_TRUE(tile != nullptr);
         if(tile == nullptr)
         {
+            OD_LOG_ERR("mRoomPosX=" + Helper::toString(mRoomPosX) + ", mRoomPosY=" + Helper::toString(mRoomPosY));
             mRoomSize = -1;
             return false;
         }
@@ -313,7 +313,11 @@ bool KeeperAI::handleRooms()
     mRoomPosY = bestY;
 
     Tile* tileDest = mGameMap.getTile(mRoomPosX, mRoomPosY);
-    OD_ASSERT_TRUE_MSG(tileDest != nullptr, "tileDest=" + Tile::displayAsString(tileDest));
+    if(tileDest != nullptr)
+    {
+        OD_LOG_ERR("tileDest=" + Tile::displayAsString(tileDest) + ", mRoomPosX=" + Helper::toString(mRoomPosX) + ", mRoomPosY=" + Helper::toString(mRoomPosY));
+        return false;
+    }
     if(!digWayToTile(central, tileDest))
         return false;
 
@@ -322,9 +326,11 @@ bool KeeperAI::handleRooms()
         for(int yy = 0; yy < mRoomSize; ++yy)
         {
             Tile* tile = mGameMap.getTile(mRoomPosX + xx, mRoomPosY + yy);
-            OD_ASSERT_TRUE(tile != nullptr);
             if(tile == nullptr)
+            {
+                OD_LOG_ERR("xx=" + Helper::toString(mRoomPosX + xx) + ", yy=" + Helper::toString(mRoomPosY + yy));
                 continue;
+            }
 
             tile->setMarkedForDigging(true, &mPlayer);
         }
@@ -511,7 +517,7 @@ bool KeeperAI::buildMostNeededRoom()
 
             if(!RoomDormitory::buildRoomOnTiles(&mGameMap, &mPlayer, tiles))
             {
-                OD_ASSERT_TRUE_MSG(false, "seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
+                OD_LOG_ERR("seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
                 return false;
             }
             return true;
@@ -545,7 +551,7 @@ bool KeeperAI::buildMostNeededRoom()
 
             if(!RoomTreasury::buildRoomOnTiles(&mGameMap, &mPlayer, tiles))
             {
-                OD_ASSERT_TRUE_MSG(false, "seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
+                OD_LOG_ERR("seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
                 return false;
             }
             return true;
@@ -569,7 +575,7 @@ bool KeeperAI::buildMostNeededRoom()
 
             if(!RoomHatchery::buildRoomOnTiles(&mGameMap, &mPlayer, tiles))
             {
-                OD_ASSERT_TRUE_MSG(false, "seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
+                OD_LOG_ERR("seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
                 return false;
             }
             return true;
@@ -593,7 +599,7 @@ bool KeeperAI::buildMostNeededRoom()
 
             if(!RoomTrainingHall::buildRoomOnTiles(&mGameMap, &mPlayer, tiles))
             {
-                OD_ASSERT_TRUE_MSG(false, "seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
+                OD_LOG_ERR("seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
                 return false;
             }
             return true;
@@ -617,7 +623,7 @@ bool KeeperAI::buildMostNeededRoom()
 
             if(!RoomWorkshop::buildRoomOnTiles(&mGameMap, &mPlayer, tiles))
             {
-                OD_ASSERT_TRUE_MSG(false, "seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
+                OD_LOG_ERR("seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
                 return false;
             }
             return true;
@@ -641,7 +647,7 @@ bool KeeperAI::buildMostNeededRoom()
 
             if(!RoomLibrary::buildRoomOnTiles(&mGameMap, &mPlayer, tiles))
             {
-                OD_ASSERT_TRUE_MSG(false, "seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
+                OD_LOG_ERR("seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
                 return false;
             }
             return true;
@@ -665,7 +671,7 @@ bool KeeperAI::buildMostNeededRoom()
 
             if(!RoomCrypt::buildRoomOnTiles(&mGameMap, &mPlayer, tiles))
             {
-                OD_ASSERT_TRUE_MSG(false, "seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
+                OD_LOG_ERR("seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
                 return false;
             }
             return true;
@@ -687,7 +693,7 @@ bool KeeperAI::buildMostNeededRoom()
 
         if(!RoomDormitory::buildRoomOnTiles(&mGameMap, &mPlayer, tiles))
         {
-            OD_ASSERT_TRUE_MSG(false, "seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
+            OD_LOG_ERR("seatId=" + Helper::toString(mPlayer.getSeat()->getId()));
             return false;
         }
         return true;
@@ -699,7 +705,11 @@ bool KeeperAI::buildMostNeededRoom()
 void KeeperAI::saveWoundedCreatures()
 {
     Tile* dungeonTempleTile = getDungeonTemple()->getCentralTile();
-    OD_ASSERT_TRUE(dungeonTempleTile != nullptr);
+    if(dungeonTempleTile == nullptr)
+    {
+        OD_LOG_ERR("keeperAi=" + mPlayer.getNick());
+        return;
+    }
 
     Seat* seat = mPlayer.getSeat();
     std::vector<Creature*> creatures = mGameMap.getCreaturesBySeat(seat);
@@ -724,8 +734,7 @@ void KeeperAI::saveWoundedCreatures()
 
         mPlayer.pickUpEntity(creature);
 
-        OD_ASSERT_TRUE_MSG(mPlayer.dropHand(dungeonTempleTile) == creature, "dungeonTempleTile=" + dungeonTempleTile->getName()
-            + ", creature=" + creature->getName());
+        mPlayer.dropHand(dungeonTempleTile);
     }
 }
 
@@ -736,9 +745,6 @@ void KeeperAI::handleDefense()
         --mCooldownDefense;
         return;
     }
-
-    Tile* dungeonTempleTile = getDungeonTemple()->getCentralTile();
-    OD_ASSERT_TRUE(dungeonTempleTile != nullptr);
 
     Seat* seat = mPlayer.getSeat();
     // We drop creatures nearby owned or allied attacked creatures
@@ -765,7 +771,7 @@ void KeeperAI::handleDefense()
             if(creatureToDrop->tryDrop(seat, neigh))
             {
                 mPlayer.pickUpEntity(creatureToDrop);
-                OD_ASSERT_TRUE(mPlayer.dropHand(neigh) == creatureToDrop);
+                mPlayer.dropHand(neigh);
                 mCooldownDefense = Random::Int(0,5);
                 return;
             }

--- a/source/ai/KeeperAI.cpp
+++ b/source/ai/KeeperAI.cpp
@@ -251,7 +251,7 @@ bool KeeperAI::checkTreasury()
 
     std::vector<Tile*> tiles;
     tiles.push_back(firstAvailableTile);
-    int goldRequired = static_cast<int>(tiles.size()) * RoomManager::costPerTile(RoomType::treasury);
+    int32_t goldRequired = RoomTreasury::getRoomCostForPlayer(&mGameMap, &mPlayer, tiles);
 
     if(!mGameMap.withdrawFromTreasuries(goldRequired, mPlayer.getSeat()))
         return false;

--- a/source/camera/CameraManager.cpp
+++ b/source/camera/CameraManager.cpp
@@ -84,7 +84,7 @@ CameraManager::CameraManager(Ogre::SceneManager* sceneManager, TileContainer* gm
     setActiveCamera("RTS");
     setActiveCameraNode("RTS");
 
-    LogManager::getSingleton().logMessage("Created camera manager");
+    OD_LOG_INF("Created camera manager");
 }
 
 void CameraManager::createCamera(const Ogre::String& ss, double nearClip, double farClip)
@@ -99,7 +99,7 @@ void CameraManager::createCamera(const Ogre::String& ss, double nearClip, double
                                                   static_cast<Ogre::Real>(0)));
 
     mRegisteredCameraNames.insert(ss);
-    LogManager::getSingleton().logMessage("Creating " + ss + " camera...");
+    OD_LOG_INF("Creating " + ss + " camera...");
 }
 
 void CameraManager::createCameraNode(const Ogre::String& ss, Ogre::Vector3 xyz,
@@ -114,7 +114,7 @@ void CameraManager::createCameraNode(const Ogre::String& ss, Ogre::Vector3 xyz,
     node->setPosition(Ogre::Vector3(0,0,2) +  node->getPosition());
     mRegisteredCameraNodeNames.insert(ss);
 
-    LogManager::getSingleton().logMessage("Creating " + ss + "_node camera node...");
+    OD_LOG_INF("Creating " + ss + "_node camera node...");
 }
 
 void CameraManager::setNextDefaultView()
@@ -168,8 +168,7 @@ void CameraManager::createViewport(Ogre::RenderWindow* renderWindow)
 //    for(set<string>::iterator m_itr = mRegisteredCameraNames.begin(); m_itr != mRegisteredCameraNames.end() ; ++m_itr){
 //        Ogre::Camera* tmpCamera = getCamera(*m_itr);
 //    }
-    LogManager* logManager = LogManager::getSingletonPtr();
-    logManager->logMessage("Creating viewport...");
+    OD_LOG_INF("Creating viewport...");
 }
 
 Ogre::SceneNode* CameraManager::getActiveCameraNode()
@@ -179,8 +178,7 @@ Ogre::SceneNode* CameraManager::getActiveCameraNode()
 
 Ogre::SceneNode* CameraManager::setActiveCameraNode(const Ogre::String& ss)
 {
-    LogManager* logManager = LogManager::getSingletonPtr();
-    logManager->logMessage("Setting active camera node to " + ss + "_node ...");
+    OD_LOG_INF("Setting active camera node to " + ss + "_node ...");
 
     return mActiveCameraNode = mSceneManager->getSceneNode(ss + "_node");
 }
@@ -196,8 +194,7 @@ void CameraManager::setActiveCamera(const Ogre::String& ss)
     mViewport->setCamera(mActiveCamera);
     mActiveCamera->setAspectRatio(Ogre::Real(mViewport->getActualWidth()) / Ogre::Real(mViewport->getActualHeight()));
 
-    LogManager* logManager = LogManager::getSingletonPtr();
-    logManager->logMessage("Setting Active Camera to " + ss + " ...");
+    OD_LOG_INF("Setting Active Camera to " + ss + " ...");
 }
 
 void CameraManager::updateCameraFrameTime(const Ogre::Real frameTime)

--- a/source/creatureeffect/CreatureEffect.cpp
+++ b/source/creatureeffect/CreatureEffect.cpp
@@ -42,7 +42,7 @@ CreatureEffect* CreatureEffect::load(std::istream& is)
         case CreatureEffectType::explosion:
             return CreatureEffectExplosion::load(is);
         default:
-            OD_ASSERT_TRUE_MSG(false, "Unallowed enum value=" + Helper::toString(static_cast<int32_t>(effectType)));
+            OD_LOG_ERR("Unallowed enum value=" + Helper::toString(static_cast<int32_t>(effectType)));
             return nullptr;
     }
 }

--- a/source/creatureeffect/CreatureEffect.h
+++ b/source/creatureeffect/CreatureEffect.h
@@ -18,6 +18,7 @@
 #ifndef CREATUREEFFECT_H
 #define CREATUREEFFECT_H
 
+#include <cstdint>
 #include <istream>
 
 class Creature;

--- a/source/creaturemood/CreatureMood.cpp
+++ b/source/creaturemood/CreatureMood.cpp
@@ -45,7 +45,7 @@ std::string CreatureMood::toString(CreatureMoodLevel moodLevel)
         case CreatureMoodLevel::Furious:
             return "Furious";
         default:
-            OD_ASSERT_TRUE_MSG(false, "moodLevel=" + Helper::toString(static_cast<int>(moodLevel)));
+            OD_LOG_ERR("moodLevel=" + Helper::toString(static_cast<int>(moodLevel)));
             return "";
     }
 }
@@ -65,7 +65,7 @@ CreatureMood* CreatureMood::load(std::istream& defFile)
         if(def != nullptr)
         {
             // The previous line was a valid def so we should have had an ending tag
-            OD_ASSERT_TRUE_MSG(false, "nextParam=" + nextParam);
+            OD_LOG_ERR("nextParam=" + nextParam);
             return def;
         }
 

--- a/source/creaturemood/CreatureMoodCreature.cpp
+++ b/source/creaturemood/CreatureMoodCreature.cpp
@@ -46,5 +46,8 @@ int32_t CreatureMoodCreature::computeMood(const Creature* creature) const
 void CreatureMoodCreature::init(GameMap* gameMap)
 {
     mCreatureDefinition = gameMap->getClassDescription(mCreatureClass);
-    OD_ASSERT_TRUE_MSG(mCreatureDefinition != nullptr, "Unknown creature class=" + mCreatureClass);
+    if(mCreatureDefinition == nullptr)
+    {
+        OD_LOG_ERR("Unknown creature class=" + mCreatureClass);
+    }
 }

--- a/source/entities/Building.cpp
+++ b/source/entities/Building.cpp
@@ -422,6 +422,9 @@ void Building::importFromStream(std::istream& is)
     }
     setSeat(seat);
 
+    // Allied seats can always see buildings
+    std::vector<Seat*> alliedSeats = seat->getAlliedSeats();
+    alliedSeats.push_back(seat);
     OD_ASSERT_TRUE(ss >> tilesToLoad);
     while(tilesToLoad > 0)
     {
@@ -441,6 +444,7 @@ void Building::importFromStream(std::istream& is)
 
         TileData* tileData = createTileData(tile);
         mTileData[tile] = tileData;
+        tileData->mSeatsVision = alliedSeats;
         importTileDataFromStream(ss, tile, tileData);
     }
 }

--- a/source/entities/Building.cpp
+++ b/source/entities/Building.cpp
@@ -242,7 +242,7 @@ Tile* Building::getCentralTile()
 
 bool Building::removeCoveredTile(Tile* t)
 {
-    LogManager::getSingleton().logMessage(getGameMap()->serverStr() + "building=" + getName() + ", removing covered tile=" + Tile::displayAsString(t));
+    OD_LOG_INF(getGameMap()->serverStr() + "building=" + getName() + ", removing covered tile=" + Tile::displayAsString(t));
     auto it = std::find(mCoveredTiles.begin(), mCoveredTiles.end(), t);
     if(it == mCoveredTiles.end())
     {

--- a/source/entities/Building.cpp
+++ b/source/entities/Building.cpp
@@ -176,9 +176,11 @@ RenderedMovableEntity* Building::loadBuildingObject(GameMap* gameMap, const std:
     if (targetTile == nullptr)
         targetTile = getCentralTile();
 
-    OD_ASSERT_TRUE(targetTile != nullptr);
     if(targetTile == nullptr)
+    {
+        OD_LOG_ERR("room=" + getName());
         return nullptr;
+    }
 
     return loadBuildingObject(gameMap, meshName, targetTile, static_cast<double>(targetTile->getX()),
         static_cast<double>(targetTile->getY()), rotationAngle, hideCoveredTile, opacity,
@@ -246,7 +248,7 @@ bool Building::removeCoveredTile(Tile* t)
     auto it = std::find(mCoveredTiles.begin(), mCoveredTiles.end(), t);
     if(it == mCoveredTiles.end())
     {
-        OD_ASSERT_TRUE_MSG(false, "building=" + getName() + ", removing unknown covered tile=" + Tile::displayAsString(t));
+        OD_LOG_ERR("building=" + getName() + ", removing unknown covered tile=" + Tile::displayAsString(t));
         return false;
     }
 
@@ -265,11 +267,11 @@ std::vector<Tile*> Building::getCoveredTiles()
 
 Tile* Building::getCoveredTile(int index)
 {
-    OD_ASSERT_TRUE_MSG(index < static_cast<int>(mCoveredTiles.size()), "name=" + getName()
-        + ", index=" + Helper::toString(index));
-
     if(index >= static_cast<int>(mCoveredTiles.size()))
+    {
+        OD_LOG_ERR("name=" + getName() + ", index=" + Helper::toString(index) + ", size=" + Helper::toString(mCoveredTiles.size()));
         return nullptr;
+    }
 
     return mCoveredTiles[index];
 }
@@ -284,9 +286,11 @@ double Building::getHP(Tile *tile) const
     if (tile != nullptr)
     {
         std::map<Tile*, TileData*>::const_iterator tileSearched = mTileData.find(tile);
-        OD_ASSERT_TRUE(tileSearched != mTileData.end());
         if(tileSearched == mTileData.end())
+        {
+            OD_LOG_ERR("couldn't find requested tile=" + Tile::displayAsString(tile));
             return 0.0;
+        }
 
         return tileSearched->second->mHP;
     }
@@ -306,7 +310,7 @@ double Building::takeDamage(GameEntity* attacker, double physicalDamage, double 
 {
     if(mTileData.count(tileTakingDamage) <= 0)
     {
-        OD_ASSERT_TRUE_MSG(false, "building=" + getName() + ", tile=" + Tile::displayAsString(tileTakingDamage));
+        OD_LOG_ERR("building=" + getName() + ", tile=" + Tile::displayAsString(tileTakingDamage));
         return 0.0;
     }
 
@@ -370,7 +374,7 @@ void Building::exportToStream(std::ostream& os) const
     {
         if(mTileData.count(tile) <= 0)
         {
-            OD_ASSERT_TRUE_MSG(false, "building=" + getName() + ", tile=" + Tile::displayAsString(tile));
+            OD_LOG_ERR("building=" + getName() + ", tile=" + Tile::displayAsString(tile));
             continue;
         }
         TileData* tileData = mTileData.at(tile);
@@ -387,7 +391,7 @@ void Building::exportToStream(std::ostream& os) const
     {
         if(mTileData.count(tile) <= 0)
         {
-            OD_ASSERT_TRUE_MSG(false, "building=" + getName() + ", tile=" + Tile::displayAsString(tile));
+            OD_LOG_ERR("building=" + getName() + ", tile=" + Tile::displayAsString(tile));
             continue;
         }
         TileData* tileData = mTileData.at(tile);
@@ -412,7 +416,10 @@ void Building::importFromStream(std::istream& is)
 
     OD_ASSERT_TRUE(ss >> seatId);
     Seat* seat = getGameMap()->getSeatById(seatId);
-    OD_ASSERT_TRUE_MSG(seat != nullptr, "seatId=" + Helper::toString(seatId));
+    if(seat == nullptr)
+    {
+        OD_LOG_ERR("seatId=" + Helper::toString(seatId));
+    }
     setSeat(seat);
 
     OD_ASSERT_TRUE(ss >> tilesToLoad);
@@ -424,9 +431,11 @@ void Building::importFromStream(std::istream& is)
         int xxx, yyy;
         OD_ASSERT_TRUE(ss >> xxx >> yyy);
         Tile* tile = getGameMap()->getTile(xxx, yyy);
-        OD_ASSERT_TRUE_MSG(tile != nullptr, "tile=" + Helper::toString(xxx) + "," + Helper::toString(yyy));
         if (tile == nullptr)
+        {
+            OD_LOG_ERR("tile=" + Helper::toString(xxx) + "," + Helper::toString(yyy));
             continue;
+        }
 
         tile->setSeat(getSeat());
 
@@ -445,7 +454,7 @@ void Building::notifySeatVision(Tile* tile, Seat* seat)
         // We remove the seat
         if(it == tileData->mSeatsVision.end())
         {
-            OD_ASSERT_TRUE_MSG(false, "building=" + getName() + ", tile=" + Tile::displayAsString(tile));
+            OD_LOG_ERR("building=" + getName() + ", tile=" + Tile::displayAsString(tile));
             return;
         }
 

--- a/source/entities/ChickenEntity.cpp
+++ b/source/entities/ChickenEntity.cpp
@@ -58,9 +58,11 @@ void ChickenEntity::doUpkeep()
        return;
 
     Tile* tile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(tile != nullptr, "entityName=" + getName());
     if(tile == nullptr)
+    {
+        OD_LOG_ERR("entityName=" + getName());
         return;
+    }
 
     if(mChickenState == ChickenState::eaten)
         mChickenState = ChickenState::dead;
@@ -184,9 +186,11 @@ bool ChickenEntity::tryPickup(Seat* seat)
         return false;
 
     Tile* tile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(tile != nullptr, "entityName=" + getName());
     if(tile == nullptr)
+    {
+        OD_LOG_ERR("entityName=" + getName());
         return false;
+    }
 
     if(getGameMap()->isInEditorMode())
         return true;
@@ -204,9 +208,11 @@ void ChickenEntity::pickup()
 {
     Tile* tile = getPositionTile();
     RenderedMovableEntity::pickup();
-    OD_ASSERT_TRUE_MSG(tile != nullptr, "entityName=" + getName());
     if(tile == nullptr)
+    {
+        OD_LOG_ERR("entityName=" + getName());
         return;
+    }
     OD_ASSERT_TRUE(tile->removeEntity(this));
 }
 
@@ -236,9 +242,11 @@ bool ChickenEntity::tryDrop(Seat* seat, Tile* tile)
 bool ChickenEntity::eatChicken(Creature* creature)
 {
     Tile* tile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(tile != nullptr, "entityName=" + getName());
     if(tile == nullptr)
+    {
+        OD_LOG_ERR("entityName=" + getName());
         return false;
+    }
 
     if(mChickenState != ChickenState::free)
         return false;
@@ -261,9 +269,11 @@ bool ChickenEntity::canSlap(Seat* seat)
         return false;
 
     Tile* tile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(tile != nullptr, "entityName=" + getName());
     if(tile == nullptr)
+    {
+        OD_LOG_ERR("entityName=" + getName());
         return false;
+    }
 
     if(getGameMap()->isInEditorMode())
         return !mIsSlapped;

--- a/source/entities/CraftedTrap.cpp
+++ b/source/entities/CraftedTrap.cpp
@@ -72,7 +72,7 @@ const std::string& CraftedTrap::getMeshFromTrapType(TrapType trapType)
         case TrapType::doorWooden:
             return TrapDoor::MESH_DOOR;
         default:
-            OD_ASSERT_TRUE_MSG(false, "Wrong enum asked for CraftedTrap " + getName() + ", trapType="
+            OD_LOG_ERR("Wrong enum asked for CraftedTrap " + getName() + ", trapType="
                 + Helper::toString(static_cast<uint32_t>(trapType)));
     }
 
@@ -82,9 +82,11 @@ const std::string& CraftedTrap::getMeshFromTrapType(TrapType trapType)
 void CraftedTrap::notifyEntityCarryOn(Creature* carrier)
 {
     Tile* myTile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(myTile != nullptr, "name=" + getName());
     if(myTile == nullptr)
+    {
+        OD_LOG_ERR("name=" + getName());
         return;
+    }
 
     setIsOnMap(false);
     setSeat(carrier->getSeat());
@@ -97,9 +99,11 @@ void CraftedTrap::notifyEntityCarryOff(const Ogre::Vector3& position)
     setIsOnMap(true);
 
     Tile* myTile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(myTile != nullptr, "name=" + getName());
     if(myTile == nullptr)
+    {
+        OD_LOG_ERR("name=" + getName());
         return;
+    }
 
     myTile->addEntity(this);
 }

--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -892,7 +892,7 @@ void Creature::doUpkeep()
                     break;
 
                 default:
-                    LogManager::getSingleton().logMessage("ERROR:  Unhandled action type in Creature::doUpkeep():" + topActionItem.toString()
+                    OD_LOG_ERR("Unhandled action type in Creature::doUpkeep():" + topActionItem.toString()
                         + ", action=" + Helper::toString(static_cast<int>(topActionItem.getType())));
                     popAction();
                     loopBack = false;
@@ -901,7 +901,7 @@ void Creature::doUpkeep()
         }
         else
         {
-            LogManager::getSingleton().logMessage("ERROR:  Creature has empty action queue in doUpkeep(), this should not happen.");
+            OD_LOG_ERR("Creature has empty action queue in doUpkeep(), this should not happen.");
             loopBack = false;
         }
     } while (loopBack && loops < 20);
@@ -911,7 +911,7 @@ void Creature::doUpkeep()
 
     if(loops >= 20)
     {
-        LogManager::getSingleton().logMessage("> 20 loops in Creature::doUpkeep name:" + getName() +
+        OD_LOG_INF("> 20 loops in Creature::doUpkeep name:" + getName() +
                 " seat id: " + Helper::toString(getSeat()->getId()) + ". Breaking out..");
     }
 }
@@ -4045,7 +4045,7 @@ void Creature::releaseCarriedEntity()
     {
         // We couldn't find the destination. This can happen if it has been destroyed while
         // we were carrying the entity
-        LogManager::getSingleton().logMessage("Couldn't carry entity=" + carriedEntity->getName()
+        OD_LOG_INF("Couldn't carry entity=" + carriedEntity->getName()
             + " to entity name=" + carriedEntityDestName);
         return;
     }

--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -1671,6 +1671,12 @@ bool Creature::handleClaimWallTileAction(const CreatureAction& actionItem)
 
     // Find paths to all of the neighbor tiles for all of the visible wall tiles.
     std::vector<Tile*> wallTiles = getVisibleClaimableWallTiles();
+    if(wallTiles.empty())
+    {
+        mForceAction = forcedActionNone;
+        popAction();
+        return true;
+    }
 
     // Take the shortest path.
     unsigned int shortestPath = 10000;

--- a/source/entities/CreatureDefinition.cpp
+++ b/source/entities/CreatureDefinition.cpp
@@ -27,13 +27,13 @@ static CreatureRoomAffinity EMPTY_AFFINITY(RoomType::nullRoomType, 0, 0);
 
 double CreatureDefinition::getXPNeededWhenLevel(unsigned int level) const
 {
-    // This should never happen
-    OD_ASSERT_TRUE(level < MAX_LEVEL);
-    OD_ASSERT_TRUE(level < mXPTable.size());
-    OD_ASSERT_TRUE(level > 0);
     // Return 0.0, meaning there is an error.
     if (level >= MAX_LEVEL || level < 1 || level >= mXPTable.size())
+    {
+        // This should never happen
+        OD_LOG_ERR("level=" + Helper::toString(level));
         return 0.0;
+    }
 
     return mXPTable[level - 1];
 }
@@ -194,7 +194,7 @@ bool CreatureDefinition::update(CreatureDefinition* creatureDef, std::stringstre
             auto it = defMap.find(baseDefinition);
             if(it == defMap.end())
             {
-                OD_ASSERT_TRUE_MSG(false, "Couldn't find base class " + baseDefinition);
+                OD_LOG_ERR("Couldn't find base class " + baseDefinition);
                 return false;
             }
             *creatureDef = *(it->second);
@@ -497,7 +497,7 @@ bool CreatureDefinition::update(CreatureDefinition* creatureDef, std::stringstre
 
     if (name.empty())
     {
-        OD_ASSERT_TRUE(false);
+        OD_LOG_ERR("Cannot have empty creature def name");
         return false;
     }
     creatureDef->mClassName = name;
@@ -712,9 +712,11 @@ void CreatureDefinition::writeCreatureDefinitionDiff(
 
 void CreatureDefinition::loadXPTable(std::stringstream& defFile, CreatureDefinition* creatureDef)
 {
-    OD_ASSERT_TRUE(creatureDef != nullptr);
     if (creatureDef == nullptr)
+    {
+        OD_LOG_ERR("Cannot load null creature def");
         return;
+    }
 
     std::string nextParam;
     bool exit = false;
@@ -738,9 +740,11 @@ void CreatureDefinition::loadXPTable(std::stringstream& defFile, CreatureDefinit
         }
 
         // Ignore values after the max level
-        OD_ASSERT_TRUE(i < MAX_LEVEL - 1);
         if (i >= MAX_LEVEL - 1)
+        {
+            OD_LOG_ERR("creatureDef=" + creatureDef->getClassName() + ", i=" + Helper::toString(i < MAX_LEVEL - 1));
             continue;
+        }
 
         creatureDef->mXPTable[i++] = Helper::toDouble(nextParam);
     }
@@ -750,7 +754,10 @@ void CreatureDefinition::loadRoomAffinity(std::stringstream& defFile, CreatureDe
 {
     OD_ASSERT_TRUE(creatureDef != nullptr);
     if (creatureDef == nullptr)
+    {
+        OD_LOG_ERR("Cannot load room afinity for null creatureDef");
         return;
+    }
 
     std::string nextParam;
     bool exit = false;
@@ -796,9 +803,11 @@ void CreatureDefinition::loadRoomAffinity(std::stringstream& defFile, CreatureDe
         double efficiency = Helper::toDouble(nextParam);
 
         RoomType roomType = RoomManager::getRoomTypeFromRoomName(roomName);
-        OD_ASSERT_TRUE_MSG(roomType != RoomType::nullRoomType, "Unknown room name=" + roomName);
         if(roomType == RoomType::nullRoomType)
+        {
+            OD_LOG_ERR("Unknown room name=" + roomName);
             continue;
+        }
 
         // We sort the CreatureRoomAffinity from the most liked to the less
         std::vector<CreatureRoomAffinity>::iterator it = creatureDef->mRoomAffinity.begin();

--- a/source/entities/CreatureSound.cpp
+++ b/source/entities/CreatureSound.cpp
@@ -45,7 +45,7 @@ void CreatureSound::play(CreatureSoundType type, float x, float y, float z)
     uint32_t indexType = static_cast<uint32_t>(type);
     if(indexType >= static_cast<uint32_t>(CreatureSoundType::NUM_CREATURE_SOUNDS))
     {
-        OD_ASSERT_TRUE_MSG(false, "Wrong sound type=" + Helper::toString(indexType));
+        OD_LOG_ERR("Wrong sound type=" + Helper::toString(indexType));
         return;
     }
 

--- a/source/entities/DoorEntity.cpp
+++ b/source/entities/DoorEntity.cpp
@@ -58,7 +58,7 @@ void DoorEntity::importFromPacket(ODPacket& is)
     Seat* seat = getGameMap()->getSeatById(seatId);
     if(seat == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "Couldn't get seat id=" + Helper::toString(seatId) + ", name=" + getName());
+        OD_LOG_ERR("Couldn't get seat id=" + Helper::toString(seatId) + ", name=" + getName());
         return;
     }
     setSeat(seat);
@@ -67,9 +67,11 @@ void DoorEntity::importFromPacket(ODPacket& is)
 bool DoorEntity::canSlap(Seat* seat)
 {
     Tile* tile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(tile != nullptr, "entityName=" + getName());
     if(tile == nullptr)
+    {
+        OD_LOG_ERR("entityName=" + getName());
         return false;
+    }
 
     if(getGameMap()->isInEditorMode())
         return true;
@@ -92,7 +94,7 @@ void DoorEntity::slap()
     Trap* trap = getGameMap()->getTrapByName(mBaseName);
     if(trap == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "name=" + getName() + ", trapname=" + mBaseName);
+        OD_LOG_ERR("name=" + getName() + ", trapname=" + mBaseName);
         return;
     }
 
@@ -103,7 +105,7 @@ void DoorEntity::slap()
 
         default:
         {
-            OD_ASSERT_TRUE_MSG(false, "name=" + getName() + ", wrong type=" + TrapManager::getTrapNameFromTrapType(trap->getType()));
+            OD_LOG_ERR("name=" + getName() + ", wrong type=" + TrapManager::getTrapNameFromTrapType(trap->getType()));
             return;
         }
     }
@@ -111,7 +113,7 @@ void DoorEntity::slap()
     Tile* posTile = getPositionTile();
     if(posTile == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "name=" + getName());
+        OD_LOG_ERR("name=" + getName());
         return;
     }
 

--- a/source/entities/EntityLoading.cpp
+++ b/source/entities/EntityLoading.cpp
@@ -50,7 +50,7 @@ GameEntity* getGameEntityFromStream(GameMap* gameMap, GameEntityType type, std::
         case GameEntityType::buildingObject:
         {
             // Building objects are not stored in level files, we should not be here
-            OD_ASSERT_TRUE(false);
+            OD_LOG_ERR("Cannot create entity from stream");
             break;
         }
         case GameEntityType::chickenEntity:
@@ -81,13 +81,13 @@ GameEntity* getGameEntityFromStream(GameMap* gameMap, GameEntityType type, std::
         case GameEntityType::persistentObject:
         {
             // Persistent objects are not stored in level files, we should not be here
-            OD_ASSERT_TRUE(false);
+            OD_LOG_ERR("Cannot create entity from stream");
             break;
         }
         case GameEntityType::smallSpiderEntity:
         {
             // Small spiders are not stored in level files, we should not be here
-            OD_ASSERT_TRUE(false);
+            OD_LOG_ERR("Cannot create entity from stream");
             break;
         }
         case GameEntityType::spell:
@@ -98,7 +98,7 @@ GameEntity* getGameEntityFromStream(GameMap* gameMap, GameEntityType type, std::
         case GameEntityType::trapEntity:
         {
             // Trap entities are handled by the trap
-            OD_ASSERT_TRUE(false);
+            OD_LOG_ERR("Cannot create entity from stream");
             break;
         }
         case GameEntityType::treasuryObject:
@@ -113,15 +113,17 @@ GameEntity* getGameEntityFromStream(GameMap* gameMap, GameEntityType type, std::
         }
         default:
         {
-            OD_ASSERT_TRUE_MSG(false, "Unknown enum value : " + Helper::toString(
+            OD_LOG_ERR("Unknown enum value : " + Helper::toString(
                 static_cast<int>(type)));
             break;
         }
     }
 
-    OD_ASSERT_TRUE(entity != nullptr);
     if(entity == nullptr)
+    {
+        OD_LOG_ERR("null entity type=" + Helper::toString(static_cast<uint32_t>(type)));
         return nullptr;
+    }
 
     entity->importFromStream(is);
     return entity;
@@ -196,15 +198,17 @@ GameEntity* getGameEntityFromPacket(GameMap* gameMap, ODPacket& is)
         }
         default:
         {
-            OD_ASSERT_TRUE_MSG(false, "Unknown enum value : " + Helper::toString(
-                static_cast<int>(type)));
+            OD_LOG_ERR("Unknown enum value : " + Helper::toString(static_cast<int>(type)));
             break;
         }
     }
 
     OD_ASSERT_TRUE(entity != nullptr);
     if(entity == nullptr)
+    {
+        OD_LOG_ERR("null entity type=" + Helper::toString(static_cast<int>(type)));
         return nullptr;
+    }
 
     entity->importFromPacket(is);
     return entity;

--- a/source/entities/MapLight.cpp
+++ b/source/entities/MapLight.cpp
@@ -109,11 +109,11 @@ std::vector<Tile*> MapLight::getCoveredTiles()
 
 Tile* MapLight::getCoveredTile(int index)
 {
-    OD_ASSERT_TRUE_MSG(index == 0, "name=" + getName()
-        + ", index=" + Helper::toString(index));
-
     if(index > 0)
+    {
+        OD_LOG_ERR("name=" + getName() + ", index=" + Helper::toString(index));
         return nullptr;
+    }
 
     return getPositionTile();
 }
@@ -215,9 +215,11 @@ void MapLight::pickup()
 {
     setIsOnMap(false);
     Tile* tile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(tile != nullptr, "entityName=" + getName());
     if(tile == nullptr)
+    {
+        OD_LOG_ERR("entityName=" + getName());
         return;
+    }
     OD_ASSERT_TRUE(tile->removeEntity(this));
 }
 

--- a/source/entities/MissileObject.cpp
+++ b/source/entities/MissileObject.cpp
@@ -65,9 +65,9 @@ void MissileObject::doUpkeep()
     }
 
     Tile* tile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(tile != nullptr, "entityName=" + getName());
     if(tile == nullptr)
     {
+        OD_LOG_ERR("entityName=" + getName());
         removeFromGameMap();
         deleteYourself();
         return;
@@ -181,9 +181,11 @@ bool MissileObject::computeDestination(const Ogre::Vector3& position, double mov
     destination = position + (moveDist * direction);
     tiles = getGameMap()->tilesBetween(Helper::round(position.x),
         Helper::round(position.y), Helper::round(destination.x), Helper::round(destination.y));
-    OD_ASSERT_TRUE(!tiles.empty());
     if(tiles.empty())
+    {
+        OD_LOG_ERR("missile=" + getName() + " has unexpected empty tiles destination");
         return false;
+    }
 
     // If we get out of the map, we take the last tile as the destination
     if((direction.x > 0.0 && destination.x > static_cast<Ogre::Real>(getGameMap()->getMapSizeX() - 1)) ||
@@ -260,7 +262,7 @@ MissileObject* MissileObject::getMissileObjectFromStream(GameMap* gameMap, std::
             break;
         }
         default:
-            OD_ASSERT_TRUE_MSG(false, "Unknown enum value : " + Helper::toString(
+            OD_LOG_ERR("Unknown enum value : " + Helper::toString(
                 static_cast<int>(type)));
             break;
     }
@@ -285,7 +287,7 @@ MissileObject* MissileObject::getMissileObjectFromPacket(GameMap* gameMap, ODPac
             break;
         }
         default:
-            OD_ASSERT_TRUE_MSG(false, "Unknown enum value : " + Helper::toString(
+            OD_LOG_ERR("Unknown enum value : " + Helper::toString(
                 static_cast<int>(type)));
             break;
     }

--- a/source/entities/MovableGameEntity.cpp
+++ b/source/entities/MovableGameEntity.cpp
@@ -298,18 +298,26 @@ void MovableGameEntity::setPosition(const Ogre::Vector3& v, bool isMove)
         RenderManager::getSingleton().rrMoveEntity(this, v);
 
     Tile* tile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(tile != nullptr, "entityName=" + getName());
     if(tile == nullptr)
+    {
+        OD_LOG_ERR("entityName=" + getName());
         return;
+    }
     if(isMove && (tile == oldTile))
         return;
 
     if((oldTile != nullptr) && isMove)
     {
-        OD_ASSERT_TRUE_MSG(removeEntityFromTile(oldTile), "name=" + getName());
+        if(!removeEntityFromTile(oldTile))
+        {
+            OD_LOG_ERR("name=" + getName());
+        }
     }
 
-    OD_ASSERT_TRUE_MSG(addEntityToTile(tile), "name=" + getName());
+    if(!addEntityToTile(tile))
+    {
+        OD_LOG_ERR("name=" + getName());
+    }
 }
 
 void MovableGameEntity::fireObjectAnimationState(const std::string& state, bool loop, const Ogre::Vector3& direction)

--- a/source/entities/PersistentObject.cpp
+++ b/source/entities/PersistentObject.cpp
@@ -145,7 +145,10 @@ void PersistentObject::importFromPacket(ODPacket& is)
     RenderedMovableEntity::importFromPacket(is);
 
     mTile = getGameMap()->tileFromPacket(is);
-    OD_ASSERT_TRUE_MSG(mTile != nullptr, "name=" + getName());
+    if(mTile == nullptr)
+    {
+        OD_LOG_ERR("name=" + getName());
+    }
 }
 
 bool PersistentObject::notifyRemoveAsked()

--- a/source/entities/RenderedMovableEntity.cpp
+++ b/source/entities/RenderedMovableEntity.cpp
@@ -217,11 +217,11 @@ std::vector<Tile*> RenderedMovableEntity::getCoveredTiles()
 
 Tile* RenderedMovableEntity::getCoveredTile(int index)
 {
-    OD_ASSERT_TRUE_MSG(index == 0, "name=" + getName()
-        + ", index=" + Helper::toString(index));
-
     if(index > 0)
+    {
+        OD_LOG_ERR("name=" + getName() + ", index=" + Helper::toString(index));
         return nullptr;
+    }
 
     return getPositionTile();
 }

--- a/source/entities/ResearchEntity.cpp
+++ b/source/entities/ResearchEntity.cpp
@@ -61,9 +61,11 @@ const Ogre::Vector3& ResearchEntity::getScale() const
 void ResearchEntity::notifyEntityCarryOn(Creature* carrier)
 {
     Tile* myTile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(myTile != nullptr, "name=" + getName());
     if(myTile == nullptr)
+    {
+        OD_LOG_ERR("name=" + getName());
         return;
+    }
 
     setIsOnMap(false);
     setSeat(carrier->getSeat());
@@ -76,9 +78,11 @@ void ResearchEntity::notifyEntityCarryOff(const Ogre::Vector3& position)
     setIsOnMap(true);
 
     Tile* myTile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(myTile != nullptr, "name=" + getName());
     if(myTile == nullptr)
+    {
+        OD_LOG_ERR("name=" + getName());
         return;
+    }
 
     myTile->addEntity(this);
 }

--- a/source/entities/SmallSpiderEntity.cpp
+++ b/source/entities/SmallSpiderEntity.cpp
@@ -48,9 +48,9 @@ SmallSpiderEntity::SmallSpiderEntity(GameMap* gameMap, bool isOnServerMap) :
 void SmallSpiderEntity::doUpkeep()
 {
     Tile* tile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(tile != nullptr, "entityName=" + getName());
     if(tile == nullptr)
     {
+        OD_LOG_ERR("entityName=" + getName());
         removeFromGameMap();
         deleteYourself();
         return;
@@ -116,9 +116,11 @@ void SmallSpiderEntity::doUpkeep()
 bool SmallSpiderEntity::canSlap(Seat* seat)
 {
     Tile* tile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(tile != nullptr, "entityName=" + getName());
     if(tile == nullptr)
+    {
+        OD_LOG_ERR("entityName=" + getName());
         return false;
+    }
 
     Room* currentCrypt = tile->getCoveringRoom();
     if(currentCrypt == nullptr)

--- a/source/entities/Tile.cpp
+++ b/source/entities/Tile.cpp
@@ -193,7 +193,7 @@ void Tile::exportToStream(std::ostream& os) const
 void Tile::exportToPacket(ODPacket& os) const
 {
     //Check to make sure this function is not called. Seat argument should be used instead
-    OD_ASSERT_TRUE_MSG(false, "tile=" + displayAsString(this));
+    OD_LOG_ERR("tile=" + displayAsString(this));
     throw std::runtime_error("ERROR: Wrong packet export function used for tile");
 }
 
@@ -627,7 +627,7 @@ void Tile::logFloodFill() const
             ++cpt;
         }
     }
-    LogManager::getSingleton().logMessage(str);
+    OD_LOG_INF(str);
 }
 
 bool Tile::isClaimedForSeat(const Seat* seat) const

--- a/source/entities/Tile.cpp
+++ b/source/entities/Tile.cpp
@@ -54,7 +54,8 @@ Tile::Tile(GameMap* gameMap, bool isOnServerMap, int x, int y, TileType type, do
     mCoveringBuilding   (nullptr),
     mClaimedPercentage  (0.0),
     mScale              (Ogre::Vector3::ZERO),
-    mIsBuilding         (false),
+    mIsRoom             (false),
+    mIsTrap             (false),
     mLocalPlayerHasVision   (false),
     mGameMap(gameMap),
     mIsOnServerMap(isOnServerMap)

--- a/source/entities/Tile.cpp
+++ b/source/entities/Tile.cpp
@@ -85,7 +85,11 @@ bool Tile::isDiggable(const Seat* seat) const
     }
 
     // Should be claimed tile
-    OD_ASSERT_TRUE_MSG(mTileVisual == TileVisual::claimedFull, "mTileVisual=" + tileVisualToString(mTileVisual));
+    if(mTileVisual != TileVisual::claimedFull)
+    {
+        OD_LOG_ERR("mTileVisual=" + tileVisualToString(mTileVisual));
+        return false;
+    }
 
     // If the wall is not claimed, it can be dug
     if(!isClaimed())
@@ -423,9 +427,11 @@ double Tile::scaleDigRate(double digRate)
 
 Tile* Tile::getNeighbor(unsigned int index)
 {
-    OD_ASSERT_TRUE_MSG(index < mNeighbors.size(), "tile=" + displayAsString(this));
     if(index >= mNeighbors.size())
+    {
+        OD_LOG_ERR("tile=" + displayAsString(this) + ", index=" + Helper::toString(index) + ", size=" + Helper::toString(mNeighbors.size()));
         return nullptr;
+    }
 
     return mNeighbors[index];
 }
@@ -525,7 +531,7 @@ bool Tile::updateFloodFillFromTile(Seat* seat, FloodFillType type, Tile* tile)
         if(!logMsg)
         {
             logMsg = true;
-            OD_ASSERT_TRUE_MSG(false, "Wrong floodfill seat index seatId=" + Helper::toString(seat->getId())
+            OD_LOG_ERR("Wrong floodfill seat index seatId=" + Helper::toString(seat->getId())
                 + ", seatIndex=" + Helper::toString(seat->getTeamIndex()) + ", floodfillsize=" + Helper::toString(static_cast<uint32_t>(mFloodFillColor.size())));
         }
         return false;
@@ -539,7 +545,7 @@ bool Tile::updateFloodFillFromTile(Seat* seat, FloodFillType type, Tile* tile)
         if(!logMsg)
         {
             logMsg = true;
-            OD_ASSERT_TRUE_MSG(false, "Wrong floodfill seat index seatId=" + Helper::toString(seat->getId())
+            OD_LOG_ERR("Wrong floodfill seat index seatId=" + Helper::toString(seat->getId())
                 + ", intType=" + Helper::toString(intType) + ", floodfillsize=" + Helper::toString(static_cast<uint32_t>(values.size())));
         }
         return false;
@@ -563,7 +569,7 @@ void Tile::replaceFloodFill(Seat* seat, FloodFillType type, uint32_t newValue)
         if(!logMsg)
         {
             logMsg = true;
-            OD_ASSERT_TRUE_MSG(false, "Wrong floodfill seat index seatId=" + Helper::toString(seat->getId())
+            OD_LOG_ERR("Wrong floodfill seat index seatId=" + Helper::toString(seat->getId())
                 + ", seatIndex=" + Helper::toString(seat->getTeamIndex()) + ", floodfillsize=" + Helper::toString(static_cast<uint32_t>(mFloodFillColor.size())));
         }
         return;
@@ -577,7 +583,7 @@ void Tile::replaceFloodFill(Seat* seat, FloodFillType type, uint32_t newValue)
         if(!logMsg)
         {
             logMsg = true;
-            OD_ASSERT_TRUE_MSG(false, "Wrong floodfill seat index seatId=" + Helper::toString(seat->getId())
+            OD_LOG_ERR("Wrong floodfill seat index seatId=" + Helper::toString(seat->getId())
                 + ", intType=" + Helper::toString(intType) + ", floodfillsize=" + Helper::toString(static_cast<uint32_t>(values.size())));
         }
         return;
@@ -594,7 +600,7 @@ void Tile::copyFloodFillToOtherSeats(Seat* seatToCopy)
         if(!logMsg)
         {
             logMsg = true;
-            OD_ASSERT_TRUE_MSG(false, "Wrong floodfill seat index seatId=" + Helper::toString(seatToCopy->getId())
+            OD_LOG_ERR("Wrong floodfill seat index seatId=" + Helper::toString(seatToCopy->getId())
                 + ", seatIndex=" + Helper::toString(seatToCopy->getTeamIndex()) + ", floodfillsize=" + Helper::toString(static_cast<uint32_t>(mFloodFillColor.size())));
         }
         return;
@@ -693,7 +699,7 @@ bool Tile::hasChangedForSeat(Seat* seat) const
 
         return seatChanged.second;
     }
-    OD_ASSERT_TRUE_MSG(false, "Unknown seat id=" + Helper::toString(seat->getId()));
+    OD_LOG_ERR("Unknown seat id=" + Helper::toString(seat->getId()));
     return false;
 }
 
@@ -765,7 +771,7 @@ uint32_t Tile::getFloodFillValue(Seat* seat, FloodFillType type) const
         if(!logMsg)
         {
             logMsg = true;
-            OD_ASSERT_TRUE_MSG(false, "Wrong floodfill seat index seatId=" + Helper::toString(seat->getId())
+            OD_LOG_ERR("Wrong floodfill seat index seatId=" + Helper::toString(seat->getId())
                 + ", seatIndex=" + Helper::toString(seat->getTeamIndex()) + ", floodfillsize=" + Helper::toString(static_cast<uint32_t>(mFloodFillColor.size())));
         }
         return NO_FLOODFILL;
@@ -779,7 +785,7 @@ uint32_t Tile::getFloodFillValue(Seat* seat, FloodFillType type) const
         if(!logMsg)
         {
             logMsg = true;
-            OD_ASSERT_TRUE_MSG(false, "Wrong floodfill seat index seatId=" + Helper::toString(seat->getId())
+            OD_LOG_ERR("Wrong floodfill seat index seatId=" + Helper::toString(seat->getId())
                 + ", intType=" + Helper::toString(intType) + ", floodfillsize=" + Helper::toString(static_cast<uint32_t>(values.size())));
         }
         return NO_FLOODFILL;

--- a/source/entities/Tile.h
+++ b/source/entities/Tile.h
@@ -268,6 +268,7 @@ public:
     void exportToPacket(ODPacket& os) const;
 
     /*! \brief Updates the tile from the data sent by the server so that it is correctly displayed and used
+     *  The packet is filled in Seat::exportTileToPacket
      */
     void updateFromPacket(ODPacket& is);
 
@@ -360,8 +361,12 @@ public:
 
     //! \brief returns true if there is a building on this tile and false otherwise.
     //! client side function
-    bool getIsBuilding() const
-    { return mIsBuilding; }
+    inline bool getIsBuilding() const
+    { return mIsRoom || mIsTrap; }
+    inline bool getIsRoom() const
+    { return mIsRoom; }
+    inline bool getIsTrap() const
+    { return mIsTrap; }
 
 protected:
     virtual void createMeshLocal();
@@ -413,7 +418,8 @@ private:
 
     //! \brief True if a building is on this tile. False otherwise. It is used on client side because the clients do not know about
     //! buildings. However, it needs to know the tiles where a building is to display the room/trap costs.
-    bool mIsBuilding;
+    bool mIsRoom;
+    bool mIsTrap;
 
     //! \brief Used on client side. true if the local player has vision, false otherwise.
     bool mLocalPlayerHasVision;

--- a/source/entities/Tile.h
+++ b/source/entities/Tile.h
@@ -358,6 +358,11 @@ public:
     //! Sets the number of teams in this gamemap (after seat configuration). This number includes the rogue team.
     void setTeamsNumber(uint32_t nbTeams);
 
+    //! \brief returns true if there is a building on this tile and false otherwise.
+    //! client side function
+    bool getIsBuilding() const
+    { return mIsBuilding; }
+
 protected:
     virtual void createMeshLocal();
     virtual void destroyMeshLocal();

--- a/source/entities/TileFunctions.cpp
+++ b/source/entities/TileFunctions.cpp
@@ -443,8 +443,13 @@ void Tile::fillWithAttackableCreatures(std::vector<GameEntity*>& entities, Seat*
 {
     for(GameEntity* entity : mEntitiesInTile)
     {
-        OD_ASSERT_TRUE(entity != nullptr);
-        if((entity == nullptr) || entity->getObjectType() != GameEntityType::creature)
+        if(entity == nullptr)
+        {
+            OD_LOG_ERR("unexpected null entity in tile=" + Tile::displayAsString(this));
+            continue;
+        }
+
+        if(entity->getObjectType() != GameEntityType::creature)
             continue;
 
         if(!entity->isAttackable(this, seat))
@@ -498,9 +503,11 @@ void Tile::fillWithCarryableEntities(std::vector<GameEntity*>& entities)
 {
     for(GameEntity* entity : mEntitiesInTile)
     {
-        OD_ASSERT_TRUE(entity != nullptr);
         if(entity == nullptr)
+        {
+            OD_LOG_ERR("unexpected null entity in tile=" + Tile::displayAsString(this));
             continue;
+        }
 
         if(entity->getEntityCarryType() == EntityCarryType::notCarryable)
             continue;
@@ -514,9 +521,11 @@ void Tile::fillWithChickenEntities(std::vector<GameEntity*>& entities)
 {
     for(GameEntity* entity : mEntitiesInTile)
     {
-        OD_ASSERT_TRUE(entity != nullptr);
         if(entity == nullptr)
+        {
+            OD_LOG_ERR("unexpected null entity in tile=" + Tile::displayAsString(this));
             continue;
+        }
 
         if(entity->getObjectType() != GameEntityType::chickenEntity)
             continue;
@@ -530,9 +539,11 @@ void Tile::fillWithCraftedTraps(std::vector<GameEntity*>& entities)
 {
     for(GameEntity* entity : mEntitiesInTile)
     {
-        OD_ASSERT_TRUE(entity != nullptr);
         if(entity == nullptr)
+        {
+            OD_LOG_ERR("unexpected null entity in tile=" + Tile::displayAsString(this));
             continue;
+        }
 
         if(entity->getObjectType() != GameEntityType::craftedTrap)
             continue;
@@ -546,9 +557,11 @@ void Tile::fillWithEntities(std::vector<EntityBase*>& entities, SelectionEntityW
 {
     for(GameEntity* entity : mEntitiesInTile)
     {
-        OD_ASSERT_TRUE(entity != nullptr);
         if(entity == nullptr)
+        {
+            OD_LOG_ERR("unexpected null entity in tile=" + Tile::displayAsString(this));
             continue;
+        }
 
         switch(entityWanted)
         {
@@ -617,7 +630,7 @@ void Tile::fillWithEntities(std::vector<EntityBase*>& entities, SelectionEntityW
                 if(!logMsg)
                 {
                     logMsg = true;
-                    OD_ASSERT_TRUE_MSG(false, "Wrong SelectionEntityWanted int=" + Helper::toString(static_cast<uint32_t>(entityWanted)));
+                    OD_LOG_ERR("Wrong SelectionEntityWanted int=" + Helper::toString(static_cast<uint32_t>(entityWanted)));
                 }
                 continue;
             }
@@ -640,9 +653,11 @@ bool Tile::addTreasuryObject(TreasuryObject* obj)
     bool isMerged = false;
     for(GameEntity* entity : mEntitiesInTile)
     {
-        OD_ASSERT_TRUE(entity != nullptr);
         if(entity == nullptr)
+        {
+            OD_LOG_ERR("unexpected null entity in tile=" + Tile::displayAsString(this));
             continue;
+        }
 
         if(entity->getObjectType() != GameEntityType::treasuryObject)
             continue;

--- a/source/entities/TileFunctions.cpp
+++ b/source/entities/TileFunctions.cpp
@@ -79,7 +79,7 @@ bool Tile::isBuildableUpon(Seat* seat) const
 {
     if(isFullTile())
         return false;
-    if(mIsBuilding)
+    if(getIsBuilding())
         return false;
     if(!isClaimedForSeat(seat))
         return false;
@@ -106,7 +106,8 @@ void Tile::setCoveringBuilding(Building *building)
         }
     }
     mCoveringBuilding = building;
-    mIsBuilding = (mCoveringBuilding != nullptr);
+    mIsRoom = (getCoveringRoom() != nullptr);
+    mIsTrap = (getCoveringTrap() != nullptr);
     if(mCoveringBuilding != nullptr)
     {
         for(std::pair<Seat*, bool>& seatChanged : mTileChangedForSeats)
@@ -151,7 +152,8 @@ void Tile::updateFromPacket(ODPacket& is)
     std::stringstream ss;
 
     // We set the seat if there is one
-    OD_ASSERT_TRUE(is >> mIsBuilding);
+    OD_ASSERT_TRUE(is >> mIsRoom);
+    OD_ASSERT_TRUE(is >> mIsTrap);
     OD_ASSERT_TRUE(is >> mRefundPriceRoom);
     OD_ASSERT_TRUE(is >> mRefundPriceTrap);
 

--- a/source/entities/TrapEntity.cpp
+++ b/source/entities/TrapEntity.cpp
@@ -73,12 +73,6 @@ bool TrapEntity::isVisibleForSeat(Seat* seat)
     return true;
 }
 
-void TrapEntity::seatsSawTriggering(const std::vector<Seat*>& seats)
-{
-    for(Seat* seat : seats)
-        seatSawTriggering(seat);
-}
-
 void TrapEntity::seatSawTriggering(Seat* seat)
 {
     if(std::find(mSeatsNotHidden.begin(), mSeatsNotHidden.end(), seat) != mSeatsNotHidden.end())

--- a/source/entities/TrapEntity.cpp
+++ b/source/entities/TrapEntity.cpp
@@ -55,7 +55,7 @@ TrapEntity* TrapEntity::getTrapEntityFromPacket(GameMap* gameMap, ODPacket& is)
             trapEntity = new DoorEntity(gameMap, false);
             break;
         default:
-            OD_ASSERT_TRUE_MSG(false, "Unknown TrapEntityType=" + Helper::toString(static_cast<uint32_t>(trapEntityType)));
+            OD_LOG_ERR("Unknown TrapEntityType=" + Helper::toString(static_cast<uint32_t>(trapEntityType)));
             break;
     }
     return trapEntity;

--- a/source/entities/TrapEntity.h
+++ b/source/entities/TrapEntity.h
@@ -48,14 +48,10 @@ public:
     virtual TrapEntityType getTrapEntityType() const
     { return TrapEntityType::trapEntity; }
 
-    virtual bool isVisibleForSeat(Seat* seat);
+    virtual bool isVisibleForSeat(Seat* seat) override;
 
-    void seatsSawTriggering(const std::vector<Seat*>& seats);
     void seatSawTriggering(Seat* seat);
-    void notifySeatsWithVision(const std::vector<Seat*>& seats);
-
-    const std::vector<Seat*>& getSeatsNotHidden() const
-    { return mSeatsNotHidden; }
+    void notifySeatsWithVision(const std::vector<Seat*>& seats) override;
 
     virtual void exportHeadersToPacket(ODPacket& os) const override;
 

--- a/source/entities/TreasuryObject.cpp
+++ b/source/entities/TreasuryObject.cpp
@@ -62,9 +62,11 @@ void TreasuryObject::doUpkeep()
 
     // We check if we are on a tile where there is a treasury room. If so, we add gold there
     Tile* tile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(tile != nullptr, "entityName=" + getName());
     if(tile == nullptr)
+    {
+        OD_LOG_ERR("entityName=" + getName());
         return;
+    }
 
     if((mGoldValue > 0) &&
        (tile->getCoveringRoom() != nullptr) &&
@@ -116,9 +118,11 @@ bool TreasuryObject::tryPickup(Seat* seat)
         return false;
 
     Tile* tile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(tile != nullptr, "entityName=" + getName());
     if(tile == nullptr)
+    {
+        OD_LOG_ERR("entityName=" + getName());
         return false;
+    }
 
     if(!tile->isClaimedForSeat(seat) && !getGameMap()->isInEditorMode())
         return false;
@@ -130,9 +134,11 @@ void TreasuryObject::pickup()
 {
     Tile* tile = getPositionTile();
     RenderedMovableEntity::pickup();
-    OD_ASSERT_TRUE_MSG(tile != nullptr, "entityName=" + getName());
     if(tile == nullptr)
+    {
+        OD_LOG_ERR("entityName=" + getName());
         return;
+    }
 
     tile->removeEntity(this);
 }
@@ -181,9 +187,11 @@ EntityCarryType TreasuryObject::getEntityCarryType()
 
     // If we are on a treasury not full, we doesn't allow to be carried
     Tile* myTile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(myTile != nullptr, "name=" + getName());
     if(myTile == nullptr)
+    {
+        OD_LOG_ERR("name=" + getName());
         return EntityCarryType::gold;
+    }
 
     if(myTile->getCoveringRoom() == nullptr)
         return EntityCarryType::gold;
@@ -201,9 +209,11 @@ EntityCarryType TreasuryObject::getEntityCarryType()
 void TreasuryObject::notifyEntityCarryOn(Creature* carrier)
 {
     Tile* myTile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(myTile != nullptr, "name=" + getName());
     if(myTile == nullptr)
+    {
+        OD_LOG_ERR("name=" + getName());
         return;
+    }
 
     setIsOnMap(false);
     myTile->removeEntity(this);
@@ -215,9 +225,11 @@ void TreasuryObject::notifyEntityCarryOff(const Ogre::Vector3& position)
     setIsOnMap(true);
 
     Tile* myTile = getPositionTile();
-    OD_ASSERT_TRUE_MSG(myTile != nullptr, "name=" + getName());
     if(myTile == nullptr)
+    {
+        OD_LOG_ERR("name=" + getName());
         return;
+    }
 
     myTile->addTreasuryObject(this);
 }

--- a/source/entities/Weapon.cpp
+++ b/source/entities/Weapon.cpp
@@ -68,9 +68,11 @@ bool Weapon::update(Weapon* weapon, std::stringstream& defFile)
         {
             defFile >> baseDefinition;
             const Weapon* def = ConfigManager::getSingleton().getWeapon(baseDefinition);
-            OD_ASSERT_TRUE_MSG(def != nullptr, "Couldn't find base class " + baseDefinition);
             if(def == nullptr)
+            {
+                OD_LOG_ERR("Couldn't find base class " + baseDefinition);
                 return false;
+            }
 
             *weapon = *def;
             continue;
@@ -143,7 +145,7 @@ bool Weapon::update(Weapon* weapon, std::stringstream& defFile)
 
     if (name.empty() || weapon->mMeshName.empty())
     {
-        OD_ASSERT_TRUE(false);
+        OD_LOG_ERR("name=" + name + ", weapon mesh name=" + weapon->mMeshName);
         return false;
     }
 

--- a/source/game/Player.cpp
+++ b/source/game/Player.cpp
@@ -121,7 +121,7 @@ uint32_t Player::getSpellCooldownTurns(SpellType spellType)
     uint32_t spellIndex = static_cast<uint32_t>(spellType);
     if(spellIndex >= mSpellsCooldown.size())
     {
-        OD_ASSERT_TRUE_MSG(false, "seatId=" + Helper::toString(getId()) + ", spellType=" + SpellManager::getSpellNameFromSpellType(spellType));
+        OD_LOG_ERR("seatId=" + Helper::toString(getId()) + ", spellType=" + SpellManager::getSpellNameFromSpellType(spellType));
         return 0;
     }
 

--- a/source/game/Player.h
+++ b/source/game/Player.h
@@ -137,7 +137,7 @@ public:
     bool isDropHandPossible(Tile *t, unsigned int index = 0);
 
     //! \brief Drops the creature on tile t. Returns the dropped creature
-    GameEntity* dropHand(Tile *t, unsigned int index = 0);
+    void dropHand(Tile *t, unsigned int index = 0);
 
     void rotateHand(Direction d);
 

--- a/source/game/PlayerSelection.cpp
+++ b/source/game/PlayerSelection.cpp
@@ -17,6 +17,7 @@
 
 #include "game/PlayerSelection.h"
 
+#include "modes/InputCommand.h"
 #include "rooms/RoomType.h"
 #include "spells/SpellType.h"
 #include "traps/TrapType.h"

--- a/source/game/PlayerSelection.h
+++ b/source/game/PlayerSelection.h
@@ -63,6 +63,7 @@ public:
 
     inline void setNewSpellType(SpellType newSpellType)
     { mNewSpellType = newSpellType; }
+
 private:
     //! \brief Room, trap or Spell tile type the player has currently selected for an action
     RoomType mNewRoomType;

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -20,7 +20,6 @@
 #include "entities/Tile.h"
 #include "game/Player.h"
 #include "goals/Goal.h"
-#include "network/ODPacket.h"
 #include "rooms/RoomType.h"
 #include "utils/Helper.h"
 #include "utils/LogManager.h"

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -273,8 +273,17 @@ void Seat::notifyVisionOnTile(Tile* tile)
     if(!mPlayer->getIsHuman())
         return;
 
-    OD_ASSERT_TRUE_MSG(tile->getX() < static_cast<int>(mTilesStates.size()), "Tile=" + Tile::displayAsString(tile));
-    OD_ASSERT_TRUE_MSG(tile->getY() < static_cast<int>(mTilesStates[tile->getX()].size()), "Tile=" + Tile::displayAsString(tile));
+    if(tile->getX() >= static_cast<int>(mTilesStates.size()))
+    {
+        OD_LOG_ERR("Tile=" + Tile::displayAsString(tile));
+        return;
+    }
+    if(tile->getY() >= static_cast<int>(mTilesStates[tile->getX()].size()))
+    {
+        OD_LOG_ERR("Tile=" + Tile::displayAsString(tile));
+        return;
+    }
+
     TileStateNotified& tileState = mTilesStates[tile->getX()][tile->getY()];
     tileState.mVisionTurnCurrent = true;
 }
@@ -286,8 +295,17 @@ void Seat::notifyTileClaimedByEnemy(Tile* tile)
     if(!mPlayer->getIsHuman())
         return;
 
-    OD_ASSERT_TRUE_MSG(tile->getX() < static_cast<int>(mTilesStates.size()), "Tile=" + Tile::displayAsString(tile));
-    OD_ASSERT_TRUE_MSG(tile->getY() < static_cast<int>(mTilesStates[tile->getX()].size()), "Tile=" + Tile::displayAsString(tile));
+    if(tile->getX() >= static_cast<int>(mTilesStates.size()))
+    {
+        OD_LOG_ERR("Tile=" + Tile::displayAsString(tile));
+        return;
+    }
+    if(tile->getY() >= static_cast<int>(mTilesStates[tile->getX()].size()))
+    {
+        OD_LOG_ERR("Tile=" + Tile::displayAsString(tile));
+        return;
+    }
+
     TileStateNotified& tileState = mTilesStates[tile->getX()][tile->getY()];
 
     // By default, we set the tile like if it was not claimed anymore
@@ -300,10 +318,10 @@ const std::string Seat::getFactionFromLine(const std::string& line)
 {
     const uint32_t indexFactionInLine = 3;
     std::vector<std::string> elems = Helper::split(line, '\t');
-    OD_ASSERT_TRUE_MSG(elems.size() > indexFactionInLine, "line=" + line);
     if(elems.size() > indexFactionInLine)
         return elems[indexFactionInLine];
 
+    OD_LOG_ERR("line=" + line);
     return std::string();
 }
 

--- a/source/game/SeatFunctions.cpp
+++ b/source/game/SeatFunctions.cpp
@@ -548,20 +548,20 @@ bool Seat::importSeatFromStream(std::istream& is)
     OD_ASSERT_TRUE(is >> str);
     if(str != "seatId")
     {
-        LogManager::getSingleton().logMessage("WARNING: expected seatId and read " + str);
+        OD_LOG_INF("WARNING: expected seatId and read " + str);
         return false;
     }
     OD_ASSERT_TRUE(is >> mId);
     if(mId == 0)
     {
-        LogManager::getSingleton().logMessage("WARNING: Forbidden seatId used");
+        OD_LOG_INF("WARNING: Forbidden seatId used");
         return false;
     }
 
     OD_ASSERT_TRUE(is >> str);
     if(str != "teamId")
     {
-        LogManager::getSingleton().logMessage("WARNING: expected teamId and read " + str);
+        OD_LOG_INF("WARNING: expected teamId and read " + str);
         return false;
     }
     OD_ASSERT_TRUE(is >> str);
@@ -572,7 +572,7 @@ bool Seat::importSeatFromStream(std::istream& is)
         int teamId = Helper::toInt(strTeamId);
         if(teamId == 0)
         {
-            LogManager::getSingleton().logMessage("WARNING: forbidden teamId in seat id=" + Helper::toString(mId));
+            OD_LOG_INF("WARNING: forbidden teamId in seat id=" + Helper::toString(mId));
             continue;
         }
 
@@ -582,7 +582,7 @@ bool Seat::importSeatFromStream(std::istream& is)
     OD_ASSERT_TRUE(is >> str);
     if(str != "player")
     {
-        LogManager::getSingleton().logMessage("WARNING: expected player and read " + str);
+        OD_LOG_INF("WARNING: expected player and read " + str);
         return false;
     }
     OD_ASSERT_TRUE(is >> mPlayerType);
@@ -590,7 +590,7 @@ bool Seat::importSeatFromStream(std::istream& is)
     OD_ASSERT_TRUE(is >> str);
     if(str != "faction")
     {
-        LogManager::getSingleton().logMessage("WARNING: expected faction and read " + str);
+        OD_LOG_INF("WARNING: expected faction and read " + str);
         return false;
     }
     OD_ASSERT_TRUE(is >> mFaction);
@@ -598,7 +598,7 @@ bool Seat::importSeatFromStream(std::istream& is)
     OD_ASSERT_TRUE(is >> str);
     if(str != "startingX")
     {
-        LogManager::getSingleton().logMessage("WARNING: expected startingX and read " + str);
+        OD_LOG_INF("WARNING: expected startingX and read " + str);
         return false;
     }
     OD_ASSERT_TRUE(is >> mStartingX);
@@ -606,7 +606,7 @@ bool Seat::importSeatFromStream(std::istream& is)
     OD_ASSERT_TRUE(is >> str);
     if(str != "startingY")
     {
-        LogManager::getSingleton().logMessage("WARNING: expected startingY and read " + str);
+        OD_LOG_INF("WARNING: expected startingY and read " + str);
         return false;
     }
     OD_ASSERT_TRUE(is >> mStartingY);
@@ -614,7 +614,7 @@ bool Seat::importSeatFromStream(std::istream& is)
     OD_ASSERT_TRUE(is >> str);
     if(str != "colorId")
     {
-        LogManager::getSingleton().logMessage("WARNING: expected colorId and read " + str);
+        OD_LOG_INF("WARNING: expected colorId and read " + str);
         return false;
     }
     OD_ASSERT_TRUE(is >> mColorId);
@@ -622,7 +622,7 @@ bool Seat::importSeatFromStream(std::istream& is)
     OD_ASSERT_TRUE(is >> str);
     if(str != "gold")
     {
-        LogManager::getSingleton().logMessage("WARNING: expected gold and read " + str);
+        OD_LOG_INF("WARNING: expected gold and read " + str);
         return false;
     }
     OD_ASSERT_TRUE(is >> mGold);
@@ -630,7 +630,7 @@ bool Seat::importSeatFromStream(std::istream& is)
     OD_ASSERT_TRUE(is >> str);
     if(str != "goldMined")
     {
-        LogManager::getSingleton().logMessage("WARNING: expected goldMined and read " + str);
+        OD_LOG_INF("WARNING: expected goldMined and read " + str);
         return false;
     }
     OD_ASSERT_TRUE(is >> mGoldMined);
@@ -638,7 +638,7 @@ bool Seat::importSeatFromStream(std::istream& is)
     OD_ASSERT_TRUE(is >> str);
     if(str != "mana")
     {
-        LogManager::getSingleton().logMessage("WARNING: expected mana and read " + str);
+        OD_LOG_INF("WARNING: expected mana and read " + str);
         return false;
     }
     OD_ASSERT_TRUE(is >> mMana);
@@ -649,7 +649,7 @@ bool Seat::importSeatFromStream(std::istream& is)
     OD_ASSERT_TRUE(is >> str);
     if(str != "[ResearchDone]")
     {
-        LogManager::getSingleton().logMessage("WARNING: expected [ResearchDone] and read " + str);
+        OD_LOG_INF("WARNING: expected [ResearchDone] and read " + str);
         return false;
     }
     while(true)
@@ -679,7 +679,7 @@ bool Seat::importSeatFromStream(std::istream& is)
     OD_ASSERT_TRUE(is >> str);
     if(str != "[ResearchNotAllowed]")
     {
-        LogManager::getSingleton().logMessage("WARNING: expected [ResearchNotAllowed] and read " + str);
+        OD_LOG_INF("WARNING: expected [ResearchNotAllowed] and read " + str);
         return false;
     }
 
@@ -713,7 +713,7 @@ bool Seat::importSeatFromStream(std::istream& is)
     OD_ASSERT_TRUE(is >> str);
     if(str != "[ResearchPending]")
     {
-        LogManager::getSingleton().logMessage("WARNING: expected [ResearchPending] and read " + str);
+        OD_LOG_INF("WARNING: expected [ResearchPending] and read " + str);
         return false;
     }
 
@@ -774,7 +774,7 @@ bool Seat::importSeatFromStream(std::istream& is)
     OD_ASSERT_TRUE(is >> str);
     if(str != "[markedTiles]")
     {
-        LogManager::getSingleton().logMessage("WARNING: expected [markedTiles] and read " + str);
+        OD_LOG_INF("WARNING: expected [markedTiles] and read " + str);
         return false;
     }
 
@@ -797,7 +797,7 @@ bool Seat::importSeatFromStream(std::istream& is)
     OD_ASSERT_TRUE(is >> str);
     if(str != "[/Seat]")
     {
-        LogManager::getSingleton().logMessage("WARNING: expected [/Seat] and read " + str);
+        OD_LOG_INF("WARNING: expected [/Seat] and read " + str);
         return false;
     }
 
@@ -1661,7 +1661,7 @@ int Seat::readTilesVisualInitialStates(TileVisual tileVisual, std::istream& is)
 
     if(str != "[" + Tile::tileVisualToString(tileVisual) + "]")
     {
-        LogManager::getSingleton().logMessage("WARNING: expected [" + Tile::tileVisualToString(tileVisual) + "] and read " + str);
+        OD_LOG_INF("WARNING: expected [" + Tile::tileVisualToString(tileVisual) + "] and read " + str);
         return -1;
     }
 

--- a/source/game/SeatFunctions.cpp
+++ b/source/game/SeatFunctions.cpp
@@ -1457,25 +1457,29 @@ void Seat::exportTileToPacket(ODPacket& os, Tile* tile) const
         meshName.clear();
         scale = Ogre::Vector3::ZERO;
     }
-    bool isBuilding = (tileState.mBuilding != nullptr);
+    bool isRoom = false;
+    bool isTrap = false;
     uint32_t refundPriceRoom = 0;
     uint32_t refundPriceTrap = 0;
     if(tileState.mBuilding != nullptr)
     {
         if(tileState.mBuilding->getObjectType() == GameEntityType::room)
         {
+            isRoom = true;
             Room* room = static_cast<Room*>(tileState.mBuilding);
             if(room->getSeat() == this)
                 refundPriceRoom = (RoomManager::costPerTile(room->getType()) / 2);
         }
         else if(tileState.mBuilding->getObjectType() == GameEntityType::trap)
         {
+            isTrap = true;
             Trap* trap = static_cast<Trap*>(tileState.mBuilding);
             if(trap->getSeat() == this)
                 refundPriceTrap = (TrapManager::costPerTile(trap->getType()) / 2);
         }
     }
-    os << isBuilding;
+    os << isRoom;
+    os << isTrap;
     os << refundPriceRoom;
     os << refundPriceTrap;
     os << tileSeatId;

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -221,7 +221,7 @@ bool GameMap::loadLevel(const std::string& levelFilepath)
     Seat* rogueSeat = Seat::createRogueSeat(this);
     if(!addSeat(rogueSeat))
     {
-        OD_ASSERT_TRUE(false);
+        OD_LOG_ERR("Couldn't add rogue seat");
         delete rogueSeat;
     }
 
@@ -310,55 +310,55 @@ void GameMap::clearAll()
     // We check if the different vectors are empty
     if(!mActiveObjects.empty())
     {
-        OD_ASSERT_TRUE_MSG(false, "mActiveObjects not empty size=" + Helper::toString(static_cast<uint32_t>(mActiveObjects.size())));
+        OD_LOG_ERR("mActiveObjects not empty size=" + Helper::toString(static_cast<uint32_t>(mActiveObjects.size())));
         for(GameEntity* entity : mActiveObjects)
         {
-            OD_ASSERT_TRUE_MSG(false, "entity not removed=" + entity->getName());
+            OD_LOG_ERR("entity not removed=" + entity->getName());
         }
         mActiveObjects.clear();
     }
     if(!mActiveObjectsToAdd.empty())
     {
-        OD_ASSERT_TRUE_MSG(false, "mActiveObjectsToAdd not empty size=" + Helper::toString(static_cast<uint32_t>(mActiveObjectsToAdd.size())));
+        OD_LOG_ERR("mActiveObjectsToAdd not empty size=" + Helper::toString(static_cast<uint32_t>(mActiveObjectsToAdd.size())));
         for(GameEntity* entity : mActiveObjectsToAdd)
         {
-            OD_ASSERT_TRUE_MSG(false, "entity not removed=" + entity->getName());
+            OD_LOG_ERR("entity not removed=" + entity->getName());
         }
         mActiveObjectsToAdd.clear();
     }
     if(!mActiveObjectsToRemove.empty())
     {
-        OD_ASSERT_TRUE_MSG(false, "mActiveObjectsToRemove not empty size=" + Helper::toString(static_cast<uint32_t>(mActiveObjectsToRemove.size())));
+        OD_LOG_ERR("mActiveObjectsToRemove not empty size=" + Helper::toString(static_cast<uint32_t>(mActiveObjectsToRemove.size())));
         for(GameEntity* entity : mActiveObjectsToRemove)
         {
-            OD_ASSERT_TRUE_MSG(false, "entity not removed=" + entity->getName());
+            OD_LOG_ERR("entity not removed=" + entity->getName());
         }
         mActiveObjectsToRemove.clear();
     }
     if(!mAnimatedObjects.empty())
     {
-        OD_ASSERT_TRUE_MSG(false, "mAnimatedObjects not empty size=" + Helper::toString(static_cast<uint32_t>(mAnimatedObjects.size())));
+        OD_LOG_ERR("mAnimatedObjects not empty size=" + Helper::toString(static_cast<uint32_t>(mAnimatedObjects.size())));
         for(GameEntity* entity : mAnimatedObjects)
         {
-            OD_ASSERT_TRUE_MSG(false, "entity not removed=" + entity->getName());
+            OD_LOG_ERR("entity not removed=" + entity->getName());
         }
         mAnimatedObjects.clear();
     }
     if(!mEntitiesToDelete.empty())
     {
-        OD_ASSERT_TRUE_MSG(false, "mEntitiesToDelete not empty size=" + Helper::toString(static_cast<uint32_t>(mEntitiesToDelete.size())));
+        OD_LOG_ERR("mEntitiesToDelete not empty size=" + Helper::toString(static_cast<uint32_t>(mEntitiesToDelete.size())));
         for(GameEntity* entity : mEntitiesToDelete)
         {
-            OD_ASSERT_TRUE_MSG(false, "entity not removed=" + entity->getName());
+            OD_LOG_ERR("entity not removed=" + entity->getName());
         }
         mEntitiesToDelete.clear();
     }
     if(!mGameEntityClientUpkeep.empty())
     {
-        OD_ASSERT_TRUE_MSG(false, "mGameEntityClientUpkeep not empty size=" + Helper::toString(static_cast<uint32_t>(mGameEntityClientUpkeep.size())));
+        OD_LOG_ERR("mGameEntityClientUpkeep not empty size=" + Helper::toString(static_cast<uint32_t>(mGameEntityClientUpkeep.size())));
         for(GameEntity* entity : mGameEntityClientUpkeep)
         {
-            OD_ASSERT_TRUE_MSG(false, "entity not removed=" + entity->getName());
+            OD_LOG_ERR("entity not removed=" + entity->getName());
         }
         mGameEntityClientUpkeep.clear();
     }
@@ -454,9 +454,11 @@ void GameMap::addWeapon(const Weapon* weapon)
 
 const Weapon* GameMap::getWeapon(int index)
 {
-    OD_ASSERT_TRUE_MSG(index < static_cast<int>(mWeapons.size()), "index=" + Helper::toString(index));
     if(index >= static_cast<int>(mWeapons.size()))
+    {
+        OD_LOG_ERR("index=" + Helper::toString(index));
         return nullptr;
+    }
 
     std::pair<const Weapon*,Weapon*>& def = mWeapons[index];
     if(def.second != nullptr)
@@ -534,9 +536,11 @@ void GameMap::removeCreature(Creature *c)
     OD_LOG_INF(serverStr() + "Removing Creature " + c->getName());
 
     std::vector<Creature*>::iterator it = std::find(mCreatures.begin(), mCreatures.end(), c);
-    OD_ASSERT_TRUE_MSG(it != mCreatures.end(), "creature name=" + c->getName());
     if(it == mCreatures.end())
+    {
+        OD_LOG_ERR("creature name=" + c->getName());
         return;
+    }
 
     mCreatures.erase(it);
 }
@@ -877,9 +881,11 @@ void GameMap::removeRenderedMovableEntity(RenderedMovableEntity *obj)
     OD_LOG_INF(serverStr() + "Removing rendered object " + obj->getName()
         + ",MeshName=" + obj->getMeshName());
     std::vector<RenderedMovableEntity*>::iterator it = std::find(mRenderedMovableEntities.begin(), mRenderedMovableEntities.end(), obj);
-    OD_ASSERT_TRUE_MSG(it != mRenderedMovableEntities.end(), "obj name=" + obj->getName());
     if(it == mRenderedMovableEntities.end())
+    {
+        OD_LOG_ERR("obj name=" + obj->getName());
         return;
+    }
 
     mRenderedMovableEntities.erase(it);
 }
@@ -1725,9 +1731,11 @@ std::vector<GameEntity*> GameMap::getVisibleForce(const std::vector<Tile*>& visi
     // Loop over the visible tiles
     for (Tile* tile : visibleTiles)
     {
-        OD_ASSERT_TRUE(tile != nullptr);
         if(tile == nullptr)
+        {
+            OD_LOG_ERR("unexpected null tile");
             continue;
+        }
 
         tile->fillWithAttackableCreatures(returnList, seat, enemyForce);
         tile->fillWithAttackableRoom(returnList, seat, enemyForce);
@@ -1744,9 +1752,11 @@ std::vector<GameEntity*> GameMap::getVisibleCreatures(const std::vector<Tile*>& 
     // Loop over the visible tiles
     for (Tile* tile : visibleTiles)
     {
-        OD_ASSERT_TRUE(tile != nullptr);
         if(tile == nullptr)
+        {
+            OD_LOG_ERR("unexpected null tile");
             continue;
+        }
 
         tile->fillWithAttackableCreatures(returnList, seat, enemyCreatures);
     }
@@ -1761,9 +1771,11 @@ std::vector<GameEntity*> GameMap::getVisibleCarryableEntities(const std::vector<
     // Loop over the visible tiles
     for (Tile* tile : visibleTiles)
     {
-        OD_ASSERT_TRUE(tile != nullptr);
         if(tile == nullptr)
+        {
+            OD_LOG_ERR("unexpected null tile");
             continue;
+        }
 
         tile->fillWithCarryableEntities(returnList);
     }
@@ -1803,9 +1815,11 @@ void GameMap::removeRoom(Room *r)
     // Rooms are removed when absorbed by another room or when they have no more tile
     // In both cases, the client have enough information to do that alone so no need to notify him
     std::vector<Room*>::iterator it = std::find(mRooms.begin(), mRooms.end(), r);
-    OD_ASSERT_TRUE_MSG(it != mRooms.end(), "Room name=" + r->getName());
     if(it == mRooms.end())
+    {
+        OD_LOG_ERR("Room name=" + r->getName());
         return;
+    }
 
     mRooms.erase(it);
 }
@@ -1959,9 +1973,11 @@ void GameMap::removeTrap(Trap *t)
 {
     OD_LOG_INF(serverStr() + "Removing trap " + t->getName());
     std::vector<Trap*>::iterator it = std::find(mTraps.begin(), mTraps.end(), t);
-    OD_ASSERT_TRUE_MSG(it != mTraps.end(), "Trap name=" + t->getName());
     if(it == mTraps.end())
+    {
+        OD_LOG_ERR("Trap name=" + t->getName());
         return;
+    }
 
     mTraps.erase(it);
 }
@@ -2019,9 +2035,11 @@ void GameMap::removeMapLight(MapLight *m)
     OD_LOG_INF(serverStr() + "Removing MapLight " + m->getName());
 
     std::vector<MapLight*>::iterator it = std::find(mMapLights.begin(), mMapLights.end(), m);
-    OD_ASSERT_TRUE_MSG(it != mMapLights.end(), "MapLight name=" + m->getName());
     if(it == mMapLights.end())
+    {
+        OD_LOG_ERR("MapLight name=" + m->getName());
         return;
+    }
 
     mMapLights.erase(it);
 }
@@ -2048,15 +2066,17 @@ void GameMap::clearSeats()
 
 bool GameMap::addSeat(Seat *s)
 {
-    OD_ASSERT_TRUE(s != nullptr);
-    if (s == nullptr)
+    if(s == nullptr)
+    {
+        OD_LOG_ERR("unexpected null seat");
         return false;
+    }
 
     for(Seat* seat : mSeats)
     {
         if(seat->getId() == s->getId())
         {
-            OD_ASSERT_TRUE_MSG(false, "Duplicated seat id=" + Helper::toString(seat->getId()));
+            OD_LOG_ERR("Duplicated seat id=" + Helper::toString(seat->getId()));
             return false;
         }
     }
@@ -2331,7 +2351,7 @@ void GameMap::enableFloodFill()
                     break;
                 }
                 default:
-                    OD_ASSERT_TRUE_MSG(false, "Unexpected enum value=" + Tile::toString(currentType));
+                    OD_LOG_ERR("Unexpected enum value=" + Tile::toString(currentType));
                     break;
             }
         }
@@ -2436,9 +2456,12 @@ void GameMap::processActiveObjectsChanges()
         GameEntity* ge = mActiveObjectsToRemove.front();
         mActiveObjectsToRemove.pop_front();
         std::vector<GameEntity*>::iterator it = std::find(mActiveObjects.begin(), mActiveObjects.end(), ge);
-        OD_ASSERT_TRUE_MSG(it != mActiveObjects.end(), "name=" + ge->getName());
-        if(it != mActiveObjects.end())
-            mActiveObjects.erase(it);
+        if(it == mActiveObjects.end())
+        {
+            OD_LOG_ERR("name=" + ge->getName());
+            continue;
+        }
+        mActiveObjects.erase(it);
     }
 }
 
@@ -2819,10 +2842,13 @@ GameEntity* GameMap::getClosestTileWhereGameEntityFromList(std::vector<GameEntit
     {
         GameEntity* gameEntity = *itObj;
         std::vector<Tile*> tiles = gameEntity->getCoveredTiles();
-        for(std::vector<Tile*>::iterator itTile = tiles.begin(); itTile != tiles.end(); ++itTile)
+        for(Tile* tile : tiles)
         {
-            Tile* tile = *itTile;
-            OD_ASSERT_TRUE(tile != nullptr);
+            if(tile == nullptr)
+            {
+                OD_LOG_ERR("unexpected null tile");
+                continue;
+            }
             double dist = std::pow(static_cast<double>(std::abs(tile->getX() - origin->getX())), 2);
             dist += std::pow(static_cast<double>(std::abs(tile->getY() - origin->getY())), 2);
             if(closestGameEntity == nullptr || dist < shortestDist)
@@ -2875,9 +2901,11 @@ bool GameMap::addCreatureMoodModifiers(const std::string& name,
     const std::vector<CreatureMood*>& moodModifiers)
 {
     uint32_t nb = mCreatureMoodModifiers.count(name);
-    OD_ASSERT_TRUE_MSG(nb <= 0, "Duplicate mood modifier=" + name);
     if(nb > 0)
+    {
+        OD_LOG_ERR("Duplicate mood modifier=" + name);
         return false;
+    }
 
     mCreatureMoodModifiers[name] = moodModifiers;
     return true;
@@ -2943,9 +2971,11 @@ void GameMap::removeSpell(Spell *spell)
     OD_LOG_INF(serverStr() + "Removing spell " + spell->getName()
         + ",MeshName=" + spell->getMeshName());
     std::vector<Spell*>::iterator it = std::find(mSpells.begin(), mSpells.end(), spell);
-    OD_ASSERT_TRUE_MSG(it != mSpells.end(), "spell name=" + spell->getName());
     if(it == mSpells.end())
+    {
+        OD_LOG_ERR("spell name=" + spell->getName());
         return;
+    }
 
     mSpells.erase(it);
 }
@@ -2992,8 +3022,6 @@ std::vector<Spell*> GameMap::getSpellsBySeatAndType(Seat* seat, SpellType type) 
 
 const TileSetValue& GameMap::getMeshForTile(const Tile* tile) const
 {
-    OD_ASSERT_TRUE(!isServerGameMap());
-
     int index = 0;
     for(int i = 0; i < 4; ++i)
     {
@@ -3115,7 +3143,7 @@ void GameMap::playerSelects(std::vector<EntityBase*>& entities, int tileX1, int 
                 if(!logMsg)
                 {
                     logMsg = true;
-                    OD_ASSERT_TRUE_MSG(false, "Wrong SelectionTileAllowed int=" + Helper::toString(static_cast<uint32_t>(tileAllowed)));
+                    OD_LOG_ERR("Wrong SelectionTileAllowed int=" + Helper::toString(static_cast<uint32_t>(tileAllowed)));
                 }
                 continue;
             }

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -523,7 +523,7 @@ void GameMap::saveLevelEquipments(std::ofstream& levelFile)
 
 void GameMap::addCreature(Creature *cc)
 {
-    LogManager::getSingleton().logMessage(serverStr() + "Adding Creature " + cc->getName()
+    OD_LOG_INF(serverStr() + "Adding Creature " + cc->getName()
         + ", seatId=" + (cc->getSeat() != nullptr ? Helper::toString(cc->getSeat()->getId()) : std::string("null")));
 
     mCreatures.push_back(cc);
@@ -531,7 +531,7 @@ void GameMap::addCreature(Creature *cc)
 
 void GameMap::removeCreature(Creature *c)
 {
-    LogManager::getSingleton().logMessage(serverStr() + "Removing Creature " + c->getName());
+    OD_LOG_INF(serverStr() + "Removing Creature " + c->getName());
 
     std::vector<Creature*>::iterator it = std::find(mCreatures.begin(), mCreatures.end(), c);
     OD_ASSERT_TRUE_MSG(it != mCreatures.end(), "creature name=" + c->getName());
@@ -867,14 +867,14 @@ MovableGameEntity* GameMap::getAnimatedObject(const std::string& name) const
 
 void GameMap::addRenderedMovableEntity(RenderedMovableEntity *obj)
 {
-    LogManager::getSingleton().logMessage(serverStr() + "Adding rendered object " + obj->getName()
+    OD_LOG_INF(serverStr() + "Adding rendered object " + obj->getName()
         + ",MeshName=" + obj->getMeshName());
     mRenderedMovableEntities.push_back(obj);
 }
 
 void GameMap::removeRenderedMovableEntity(RenderedMovableEntity *obj)
 {
-    LogManager::getSingleton().logMessage(serverStr() + "Removing rendered object " + obj->getName()
+    OD_LOG_INF(serverStr() + "Removing rendered object " + obj->getName()
         + ",MeshName=" + obj->getMeshName());
     std::vector<RenderedMovableEntity*>::iterator it = std::find(mRenderedMovableEntities.begin(), mRenderedMovableEntities.end(), obj);
     OD_ASSERT_TRUE_MSG(it != mRenderedMovableEntities.end(), "obj name=" + obj->getName());
@@ -1068,7 +1068,7 @@ void GameMap::createAllEntities()
         rendered->restoreInitialEntityState();
     }*/
 
-    LogManager::getSingleton().logMessage("entities created");
+    OD_LOG_INF("entities created");
 }
 
 void GameMap::destroyAllEntities()
@@ -1120,7 +1120,7 @@ Creature* GameMap::getCreature(const std::string& cName) const
 
 void GameMap::doTurn(double timeSinceLastTurn)
 {
-    std::cout << "\nComputing turn " << mTurnNumber << ", timeSinceLastTurn=" << timeSinceLastTurn << std::endl;
+    OD_LOG_INF("Computing turn " + Helper::toString(mTurnNumber) + ", timeSinceLastTurn=" + Helper::toString(timeSinceLastTurn));
     unsigned int numCallsTo_path_atStart = mNumCallsTo_path;
 
     uint32_t miscUpkeepTime = doMiscUpkeep(timeSinceLastTurn);
@@ -1143,9 +1143,8 @@ void GameMap::doTurn(double timeSinceLastTurn)
         ++(tempSeat->mNumCreaturesFighters);
     }
 
-    std::cout << "During this turn there were " << mNumCallsTo_path
-              - numCallsTo_path_atStart << " calls to GameMap::path()."
-              << "miscUpkeepTime=" << miscUpkeepTime << std::endl;
+    OD_LOG_INF("During this turn there were " + Helper::toString(mNumCallsTo_path - numCallsTo_path_atStart)
+        + " calls to GameMap::path(), miscUpkeepTime=" + Helper::toString(miscUpkeepTime));
 }
 
 void GameMap::doPlayerAITurn(double timeSinceLastTurn)
@@ -1670,7 +1669,7 @@ std::list<Tile*> GameMap::path(int x1, int y1, int x2, int y2, const Creature* c
 bool GameMap::addPlayer(Player* player)
 {
     mPlayers.push_back(player);
-    LogManager::getSingleton().logMessage(serverStr() + "Added player: " + player->getNick());
+    OD_LOG_INF(serverStr() + "Added player: " + player->getNick());
     return true;
 }
 
@@ -1678,11 +1677,11 @@ bool GameMap::assignAI(Player& player, const std::string& aiType, const std::str
 {
     if (mAiManager.assignAI(player, aiType, parameters))
     {
-        LogManager::getSingleton().logMessage("Assign AI: " + aiType + ", to player: " + player.getNick());
+        OD_LOG_INF("Assign AI: " + aiType + ", to player: " + player.getNick());
         return true;
     }
 
-    LogManager::getSingleton().logMessage("Couldn't assign AI: " + aiType + ", to player: " + player.getNick());
+    OD_LOG_INF("Couldn't assign AI: " + aiType + ", to player: " + player.getNick());
     return false;
 }
 
@@ -1788,11 +1787,11 @@ void GameMap::clearRooms()
 void GameMap::addRoom(Room *r)
 {
     int nbTiles = r->numCoveredTiles();
-    LogManager::getSingleton().logMessage(serverStr() + "Adding room " + r->getName() + ", nbTiles="
+    OD_LOG_INF(serverStr() + "Adding room " + r->getName() + ", nbTiles="
         + Helper::toString(nbTiles) + ", seatId=" + Helper::toString(r->getSeat()->getId()));
     for(Tile* tile : r->getCoveredTiles())
     {
-        LogManager::getSingleton().logMessage(serverStr() + "Adding room " + r->getName() + ", tile=" + Tile::displayAsString(tile));
+        OD_LOG_INF(serverStr() + "Adding room " + r->getName() + ", tile=" + Tile::displayAsString(tile));
     }
 
     mRooms.push_back(r);
@@ -1800,7 +1799,7 @@ void GameMap::addRoom(Room *r)
 
 void GameMap::removeRoom(Room *r)
 {
-    LogManager::getSingleton().logMessage(serverStr() + "Removing room " + r->getName());
+    OD_LOG_INF(serverStr() + "Removing room " + r->getName());
     // Rooms are removed when absorbed by another room or when they have no more tile
     // In both cases, the client have enough information to do that alone so no need to notify him
     std::vector<Room*>::iterator it = std::find(mRooms.begin(), mRooms.end(), r);
@@ -1950,7 +1949,7 @@ void GameMap::clearTraps()
 void GameMap::addTrap(Trap *trap)
 {
     int nbTiles = trap->numCoveredTiles();
-    LogManager::getSingleton().logMessage(serverStr() + "Adding trap " + trap->getName() + ", nbTiles="
+    OD_LOG_INF(serverStr() + "Adding trap " + trap->getName() + ", nbTiles="
         + Helper::toString(nbTiles) + ", seatId=" + Helper::toString(trap->getSeat()->getId()));
 
     mTraps.push_back(trap);
@@ -1958,7 +1957,7 @@ void GameMap::addTrap(Trap *trap)
 
 void GameMap::removeTrap(Trap *t)
 {
-    LogManager::getSingleton().logMessage(serverStr() + "Removing trap " + t->getName());
+    OD_LOG_INF(serverStr() + "Removing trap " + t->getName());
     std::vector<Trap*>::iterator it = std::find(mTraps.begin(), mTraps.end(), t);
     OD_ASSERT_TRUE_MSG(it != mTraps.end(), "Trap name=" + t->getName());
     if(it == mTraps.end())
@@ -2011,13 +2010,13 @@ void GameMap::clearMapLights()
 
 void GameMap::addMapLight(MapLight *m)
 {
-    LogManager::getSingleton().logMessage(serverStr() + "Adding MapLight " + m->getName());
+    OD_LOG_INF(serverStr() + "Adding MapLight " + m->getName());
     mMapLights.push_back(m);
 }
 
 void GameMap::removeMapLight(MapLight *m)
 {
-    LogManager::getSingleton().logMessage(serverStr() + "Removing MapLight " + m->getName());
+    OD_LOG_INF(serverStr() + "Removing MapLight " + m->getName());
 
     std::vector<MapLight*>::iterator it = std::find(mMapLights.begin(), mMapLights.end(), m);
     OD_ASSERT_TRUE_MSG(it != mMapLights.end(), "MapLight name=" + m->getName());
@@ -2934,14 +2933,14 @@ std::vector<GameEntity*> GameMap::getNaturalEnemiesInList(const Creature* creatu
 
 void GameMap::addSpell(Spell *spell)
 {
-    LogManager::getSingleton().logMessage(serverStr() + "Adding spell " + spell->getName()
+    OD_LOG_INF(serverStr() + "Adding spell " + spell->getName()
         + ",MeshName=" + spell->getMeshName());
     mSpells.push_back(spell);
 }
 
 void GameMap::removeSpell(Spell *spell)
 {
-    LogManager::getSingleton().logMessage(serverStr() + "Removing spell " + spell->getName()
+    OD_LOG_INF(serverStr() + "Removing spell " + spell->getName()
         + ",MeshName=" + spell->getMeshName());
     std::vector<Spell*>::iterator it = std::find(mSpells.begin(), mSpells.end(), spell);
     OD_ASSERT_TRUE_MSG(it != mSpells.end(), "spell name=" + spell->getName());

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -1341,23 +1341,6 @@ int GameMap::getNbFightersForSeat(Seat* seat) const
 
 void GameMap::updateAnimations(Ogre::Real timeSinceLastFrame)
 {
-    // During the first turn, we setup everything
-    if(getTurnNumber() == 0 && !isServerGameMap())
-    {
-        assert(getTile(0, 0) != nullptr);
-        //NOTE: This test is a workaround to prevent this being called more than once.
-        //This should probably be fixed in a better way.
-        if(!getTile(0, 0)->isMeshExisting())
-        {
-            LogManager::getSingleton().logMessage("Starting game map");
-
-            setGamePaused(false);
-
-            // Create ogre entities for the tiles, rooms, and creatures
-            createAllEntities();
-        }
-    }
-
     if(mIsPaused)
         return;
 

--- a/source/gamemap/MapLoader.cpp
+++ b/source/gamemap/MapLoader.cpp
@@ -266,9 +266,11 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
             continue;
 
         Room* tempRoom = RoomManager::getRoomFromStream(&gameMap, levelFile);
-        OD_ASSERT_TRUE(tempRoom != nullptr);
         if(tempRoom == nullptr)
+        {
+            OD_LOG_ERR("unexpected null room");
             return false;
+        }
 
         tempRoom->importFromStream(levelFile);
 
@@ -300,9 +302,11 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
             return false;
 
         Trap* tempTrap = TrapManager::getTrapFromStream(&gameMap, levelFile);
-        OD_ASSERT_TRUE(tempTrap != nullptr);
         if(tempTrap == nullptr)
+        {
+            OD_LOG_ERR("unexpected null trap");
             return false;
+        }
 
         tempTrap->importFromStream(levelFile);
         tempTrap->addToGameMap();
@@ -335,9 +339,11 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
 
         std::stringstream ss(entire_line);
         MapLight* tempLight = MapLight::getMapLightFromStream(&gameMap, ss);
-        OD_ASSERT_TRUE(tempLight != nullptr);
         if(tempLight == nullptr)
+        {
+            OD_LOG_ERR("unexpected null map light");
             return false;
+        }
         tempLight->importFromStream(ss);
         tempLight->setName(gameMap.nextUniqueNameMapLight());
         tempLight->addToGameMap();
@@ -360,7 +366,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
 
             if (nextParam != "[CreatureMood]")
             {
-                OD_ASSERT_TRUE_MSG(false, "Invalid CreatureMood format. Line was " + nextParam);
+                OD_LOG_ERR("Invalid CreatureMood format. Line was " + nextParam);
                 return false;
             }
 
@@ -368,7 +374,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
                     break;
             if (nextParam != "CreatureMoodName")
             {
-                OD_ASSERT_TRUE_MSG(false, "Invalid CreatureMoodName format. Line was " + nextParam);
+                OD_LOG_ERR("Invalid CreatureMoodName format. Line was " + nextParam);
                 return false;
             }
             std::string moodModifierName;
@@ -385,7 +391,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
 
                 if (nextParam != "[MoodModifier]")
                 {
-                    OD_ASSERT_TRUE_MSG(false, "Invalid CreatureMood MoodModifier format. nextParam=" + nextParam);
+                    OD_LOG_ERR("Invalid CreatureMood MoodModifier format. nextParam=" + nextParam);
                     return false;
                 }
 
@@ -393,7 +399,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
                 CreatureMood* def = CreatureMood::load(levelFile);
                 if (def == nullptr)
                 {
-                    OD_ASSERT_TRUE_MSG(false, "Invalid CreatureMood MoodModifier definition");
+                    OD_LOG_ERR("Invalid CreatureMood MoodModifier definition");
                     return false;
                 }
                 moodModifiers.push_back(def);
@@ -498,9 +504,11 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
 
         std::stringstream ss(entire_line);
         Creature* tempCreature = Creature::getCreatureFromStream(&gameMap, ss);
-        OD_ASSERT_TRUE(tempCreature != nullptr);
         if(tempCreature == nullptr)
+        {
+            OD_LOG_ERR("unexpected null creature");
             return false;
+        }
 
         tempCreature->importFromStream(ss);
         tempCreature->addToGameMap();
@@ -570,9 +578,11 @@ bool readGameEntity(GameMap& gameMap, const std::string& item, GameEntityType ty
 
         std::stringstream ss(entire_line);
         GameEntity* entity = Entities::getGameEntityFromStream(&gameMap, type, ss);
-        OD_ASSERT_TRUE(entity != nullptr);
         if(entity == nullptr)
+        {
+            OD_LOG_ERR("unexpected null entity type=" + Helper::toString(static_cast<uint32_t>(type)));
             return false;
+        }
 
         entity->addToGameMap();
         ++nbEntity;

--- a/source/gamemap/MapLoader.cpp
+++ b/source/gamemap/MapLoader.cpp
@@ -68,20 +68,15 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
     levelFile >> nextParam;
     if (nextParam.compare(ODApplication::VERSIONSTRING) != 0)
     {
-        std::cerr
-                << "\n\n\nERROR:  Attempting to load a file produced by a different version of OpenDungeons.\n"
-                << "ERROR:  Filename:  " << fileName
-                << "\nERROR:  The file is for OpenDungeons:  " << nextParam
-                << "\nERROR:  This version of OpenDungeons:  " << ODApplication::VERSION
-                << "\n\n\n";
+        OD_LOG_WRN("Attempting to load a file produced by a different version of OpenDungeons, filename="
+            + fileName + ", file version=" + nextParam + ", odversion=" + ODApplication::VERSION);
         return false;
     }
 
     levelFile >> nextParam;
     if (nextParam != "[Info]")
     {
-        std::cout << "Invalid info start format." << std::endl;
-        std::cout << "Line was " << nextParam << std::endl;
+        OD_LOG_WRN("Invalid info start format: " + nextParam);
         return false;
     }
 
@@ -120,7 +115,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
         {
             std::string musicFile = nextParam.substr(param.size());
             gameMap.setLevelMusicFile(musicFile);
-            LogManager::getSingleton().logMessage("Level Music: " + musicFile);
+            OD_LOG_INF("Level Music: " + musicFile);
             continue;
         }
 
@@ -129,7 +124,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
         {
             std::string musicFile = nextParam.substr(param.size());
             gameMap.setLevelFightMusicFile(nextParam.substr(param.size()));
-            LogManager::getSingleton().logMessage("Level Fight Music: " + musicFile);
+            OD_LOG_INF("Level Fight Music: " + musicFile);
             continue;
         }
 
@@ -138,7 +133,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
         {
             std::string tileSet = nextParam.substr(param.size());
             gameMap.setTileSetName(tileSet);
-            LogManager::getSingleton().logMessage("TileSet: " + tileSet);
+            OD_LOG_INF("TileSet: " + tileSet);
             continue;
         }
     }
@@ -146,8 +141,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
     levelFile >> nextParam;
     if (nextParam != "[Seats]")
     {
-        std::cout << "Invalid seats start format." << std::endl;
-        std::cout << "Line was " << nextParam << std::endl;
+        OD_LOG_WRN("Invalid seats start format=" + nextParam);
         return false;
     }
 
@@ -163,7 +157,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
 
         if (nextParam != "[Seat]")
         {
-            LogManager::getSingleton().logMessage("Expected a Seat tag but got " + nextParam);
+            OD_LOG_WRN("Expected a Seat tag but got " + nextParam);
             return false;
         }
 
@@ -176,7 +170,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
 
         if(!gameMap.addSeat(tempSeat))
         {
-            LogManager::getSingleton().logMessage("Couldn't add seat id="
+            OD_LOG_WRN("Couldn't add seat id="
                 + Helper::toString(tempSeat->getId()));
             delete tempSeat;
         }
@@ -186,8 +180,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
     levelFile >> nextParam;
     if (nextParam != "[Goals]")
     {
-        std::cout << "Invalid Goals start format." << std::endl;
-        std::cout << "Line was " << nextParam << std::endl;
+        OD_LOG_WRN("Invalid Goals start format=" + nextParam);
         return false;
     }
 
@@ -209,8 +202,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
     levelFile >> nextParam;
     if (nextParam != "[Tiles]")
     {
-        std::cout << "Invalid tile start format." << std::endl;
-        std::cout << "Line was " << nextParam << std::endl;
+        OD_LOG_WRN("Invalid tile start format:" + nextParam);
         return false;
     }
 
@@ -239,7 +231,6 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
         std::string entire_line = nextParam;
         std::getline(levelFile, nextParam);
         entire_line += nextParam;
-        //std::cout << "Entire line: " << entire_line << std::endl;
 
         Tile* tempTile = new Tile(&gameMap, true);
 
@@ -255,8 +246,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
     levelFile >> nextParam;
     if (nextParam != "[Rooms]")
     {
-        std::cout << "Invalid Rooms start format." << std::endl;
-        std::cout << "Line was " << nextParam << std::endl;
+        OD_LOG_WRN("Invalid Rooms start format:" + nextParam);
         return false;
     }
 
@@ -293,8 +283,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
     levelFile >> nextParam;
     if (nextParam != "[Traps]")
     {
-        std::cout << "Invalid Traps start format." << std::endl;
-        std::cout << "Line was " << nextParam << std::endl;
+        OD_LOG_WRN("Invalid Traps start format:" + nextParam);
         return false;
     }
 
@@ -327,8 +316,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
     levelFile >> nextParam;
     if (nextParam != "[Lights]")
     {
-        std::cout << "Invalid Lights start format." << std::endl;
-        std::cout << "Line was " << nextParam << std::endl;
+        OD_LOG_WRN("Invalid Lights start format:" + nextParam);
         return false;
     }
 
@@ -344,7 +332,6 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
         std::string entire_line = nextParam;
         std::getline(levelFile, nextParam);
         entire_line += nextParam;
-        //std::cout << "Entire line: " << entire_line << std::endl;
 
         std::stringstream ss(entire_line);
         MapLight* tempLight = MapLight::getMapLightFromStream(&gameMap, ss);
@@ -431,8 +418,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
             // Seek the [Creature] tag
             if (nextParam != "[Creature]")
             {
-                std::cout << "Invalid Creature start format." << std::endl;
-                std::cout << "Line was " << nextParam << std::endl;
+                OD_LOG_WRN("Invalid Creature start format:" + nextParam);
                 return false;
             }
 
@@ -443,7 +429,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
                 CreatureDefinition* def = gameMap.getClassDescriptionForTuning(nextParam);
                 if (def == nullptr)
                 {
-                    std::cout << "Invalid Creature definition format." << std::endl;
+                    OD_LOG_WRN("Invalid Creature definition format for " + nextParam);
                     return false;
                 }
                 if(!CreatureDefinition::update(def, levelFile, ConfigManager::getSingleton().getCreatureDefinitions()))
@@ -467,8 +453,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
 
             if (nextParam != "[Equipment]")
             {
-                std::cout << "Invalid Weapon start format." << std::endl;
-                std::cout << "Line was " << nextParam << std::endl;
+                OD_LOG_WRN("Invalid Weapon start format:" + nextParam);
                 return false;
             }
 
@@ -479,7 +464,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
                 Weapon* def = gameMap.getWeaponForTuning(nextParam);
                 if (def == nullptr)
                 {
-                    std::cout << "Invalid Weapon definition format." << std::endl;
+                    OD_LOG_WRN("Invalid Weapon definition format for " + nextParam);
                     return false;
                 }
                 if(!Weapon::update(def, levelFile))
@@ -493,8 +478,7 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
     // Read in the actual creatures themselves
     if (nextParam != "[Creatures]")
     {
-        std::cout << "Invalid Creatures start format." << std::endl;
-        std::cout << "Line was " << nextParam << std::endl;
+        OD_LOG_WRN("Invalid Creatures start format:" + nextParam);
         return false;
     }
 
@@ -522,41 +506,41 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
         tempCreature->addToGameMap();
         ++nbCreatures;
     }
-    LogManager::getSingleton().logMessage("Loaded " + Helper::toString(nbCreatures) + " creatures in level");
+    OD_LOG_INF("Loaded " + Helper::toString(nbCreatures) + " creatures in level");
 
     if(!readGameEntity(gameMap, "Spells", GameEntityType::spell, levelFile))
     {
-        LogManager::getSingleton().logMessage("Invalid Spells section");
+        OD_LOG_WRN("Invalid Spells section");
         return false;
     }
 
     if(!readGameEntity(gameMap, "CraftedTraps", GameEntityType::craftedTrap, levelFile))
     {
-        LogManager::getSingleton().logMessage("Invalid CraftedTraps section");
+        OD_LOG_WRN("Invalid CraftedTraps section");
         return false;
     }
 
     if(!readGameEntity(gameMap, "ResearchEntity", GameEntityType::researchEntity, levelFile))
     {
-        LogManager::getSingleton().logMessage("Invalid ResearchEntity section");
+        OD_LOG_WRN("Invalid ResearchEntity section");
         return false;
     }
 
     if(!readGameEntity(gameMap, "Missiles", GameEntityType::missileObject, levelFile))
     {
-        LogManager::getSingleton().logMessage("Invalid Missiles section");
+        OD_LOG_WRN("Invalid Missiles section");
         return false;
     }
 
     if(!readGameEntity(gameMap, "TreasuryObject", GameEntityType::treasuryObject, levelFile))
     {
-        LogManager::getSingleton().logMessage("Invalid TreasuryObject section");
+        OD_LOG_WRN("Invalid TreasuryObject section");
         return false;
     }
 
     if(!readGameEntity(gameMap, "Chickens", GameEntityType::chickenEntity, levelFile))
     {
-        LogManager::getSingleton().logMessage("Invalid Chickens section");
+        OD_LOG_WRN("Invalid Chickens section");
         return false;
     }
 
@@ -593,7 +577,7 @@ bool readGameEntity(GameMap& gameMap, const std::string& item, GameEntityType ty
         entity->addToGameMap();
         ++nbEntity;
     }
-    LogManager::getSingleton().logMessage("Loaded " + Helper::toString(nbEntity) + " " + item + " in level");
+    OD_LOG_INF("Loaded " + Helper::toString(nbEntity) + " " + item + " in level");
 
     return true;
 }

--- a/source/gamemap/TileContainer.cpp
+++ b/source/gamemap/TileContainer.cpp
@@ -427,7 +427,7 @@ Tile* TileContainer::tileFromPacket(ODPacket& packet) const
     Tile* tile = getTile(x, y);
     if(tile == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "tile=" + Helper::toString(x) + "," + Helper::toString(y));
+        OD_LOG_ERR("tile=" + Helper::toString(x) + "," + Helper::toString(y));
     }
     return tile;
 }

--- a/source/gamemap/TileContainer.cpp
+++ b/source/gamemap/TileContainer.cpp
@@ -230,7 +230,7 @@ public:
                 + ", val=" + Helper::toString(p.second);
         }
 
-        LogManager::getSingleton().logMessage(log);
+        OD_LOG_INF(log);
     }
 
     const std::vector<std::pair<uint32_t, double>>& getHiddenTilesNorth() const
@@ -397,8 +397,8 @@ void TileContainer::setTileNeighbors(Tile *t)
             break;
 
         default:
-            std::cerr << "\n\n\nERROR:  Unknown neighbor index.\n\n\n";
-            exit(1);
+            OD_LOG_ERR("Unknown neighbor index=" + Helper::toString(i));
+            continue;
         }
 
         // If the current neigbor tile exists, add the current tile as one of its
@@ -436,7 +436,7 @@ bool TileContainer::allocateMapMemory(int xSize, int ySize)
 {
     if (xSize <= 0 || ySize <= 0)
     {
-        std::cerr << "Invalid map size given. Couldn't allocate map memory" << std::endl;
+        OD_LOG_ERR("Invalid map size given, xSize=" + Helper::toString(xSize) + ", ySize=" + Helper::toString(ySize));
         return false;
     }
 
@@ -461,7 +461,7 @@ bool TileContainer::allocateMapMemory(int xSize, int ySize)
     mTiles = new Tile **[mMapSizeX];
     if(!mTiles)
     {
-        std::cerr << "Failed to allocate map memory" << std::endl;
+        OD_LOG_ERR("Failed to allocate map memory");
         return false;
     }
     for(int ii = 0; ii < mMapSizeX; ++ii)

--- a/source/gamemap/TileSet.cpp
+++ b/source/gamemap/TileSet.cpp
@@ -32,7 +32,7 @@ std::vector<TileSetValue>& TileSet::configureTileValues(TileVisual tileVisual)
     uint32_t tileTypeNumber = static_cast<uint32_t>(tileVisual);
     if(tileTypeNumber >= mTileValues.size())
     {
-        OD_ASSERT_TRUE_MSG(false, "Trying to get unknow tileType=" + Tile::tileVisualToString(tileVisual));
+        OD_LOG_ERR("Trying to get unknow tileType=" + Tile::tileVisualToString(tileVisual));
         return mTileValues.at(0);
     }
 
@@ -44,7 +44,7 @@ const std::vector<TileSetValue>& TileSet::getTileValues(TileVisual tileVisual) c
     uint32_t tileTypeNumber = static_cast<uint32_t>(tileVisual);
     if(tileTypeNumber >= mTileValues.size())
     {
-        OD_ASSERT_TRUE_MSG(false, "Trying to get unknow tileType=" + Tile::tileVisualToString(tileVisual));
+        OD_LOG_ERR("Trying to get unknow tileType=" + Tile::tileVisualToString(tileVisual));
         return mTileValues.at(0);
     }
 
@@ -57,12 +57,12 @@ void TileSet::addTileLink(TileVisual tileVisual1, TileVisual tileVisual2)
     uint32_t intTile2Visual = static_cast<uint32_t>(tileVisual2);
     if(intTile1Visual >= mTileLinks.size())
     {
-        OD_ASSERT_TRUE_MSG(false, "TileVisual=" + Tile::tileVisualToString(tileVisual1));
+        OD_LOG_ERR("TileVisual=" + Tile::tileVisualToString(tileVisual1));
         return;
     }
     if(intTile2Visual >= mTileLinks.size())
     {
-        OD_ASSERT_TRUE_MSG(false, "TileVisual=" + Tile::tileVisualToString(tileVisual2));
+        OD_LOG_ERR("TileVisual=" + Tile::tileVisualToString(tileVisual2));
         return;
     }
 

--- a/source/gamemap/TileSet.h
+++ b/source/gamemap/TileSet.h
@@ -20,6 +20,7 @@
 
 #include <OgreVector3.h>
 
+#include <cstdint>
 #include <string>
 
 class Tile;

--- a/source/goals/Goal.cpp
+++ b/source/goals/Goal.cpp
@@ -17,10 +17,13 @@
 
 #include "goals/Goal.h"
 
+#include "utils/LogManager.h"
+
 Goal::Goal(const std::string& nName, const std::string& nArguments) :
     mName(nName),
     mArguments(nArguments)
 {
+    OD_LOG_INF("Adding goal " + mName);
 }
 
 void Goal::doSuccessAction()

--- a/source/goals/GoalClaimNTiles.cpp
+++ b/source/goals/GoalClaimNTiles.cpp
@@ -28,7 +28,6 @@ GoalClaimNTiles::GoalClaimNTiles(const std::string& nName,
         Goal(nName, nArguments),
         mNumberOfTiles(atoi(nArguments.c_str()))
 {
-    std::cout << "\nAdding goal " << getName();
 }
 
 bool GoalClaimNTiles::isMet(const Seat &s, const GameMap&)

--- a/source/goals/GoalKillAllEnemies.cpp
+++ b/source/goals/GoalKillAllEnemies.cpp
@@ -29,7 +29,6 @@ GoalKillAllEnemies::GoalKillAllEnemies(const std::string& nName,
     const std::string& nArguments) :
     Goal(nName, nArguments)
 {
-    std::cout << "\nAdding goal " << getName();
 }
 
 bool GoalKillAllEnemies::isMet(const Seat &s, const GameMap& gameMap)

--- a/source/goals/GoalMineNGold.cpp
+++ b/source/goals/GoalMineNGold.cpp
@@ -27,7 +27,6 @@ GoalMineNGold::GoalMineNGold(const std::string& nName, const std::string& nArgum
         Goal(nName, nArguments),
         mGoldToMine(atoi(nArguments.c_str()))
 {
-    std::cout << "\nAdding goal " << getName();
 }
 
 bool GoalMineNGold::isMet(const Seat &s, const GameMap&)

--- a/source/goals/GoalProtectCreature.cpp
+++ b/source/goals/GoalProtectCreature.cpp
@@ -26,8 +26,6 @@ GoalProtectCreature::GoalProtectCreature(const std::string& nName, const std::st
     Goal(nName, nArguments),
     mCreatureName(nArguments)
 {
-    std::cout << "\nAdding goal " << getName() << "\tCreature name: "
-              << mCreatureName;
 }
 
 bool GoalProtectCreature::isMet(const Seat&, const GameMap& gameMap)

--- a/source/goals/GoalProtectDungeonTemple.cpp
+++ b/source/goals/GoalProtectDungeonTemple.cpp
@@ -27,7 +27,6 @@
 GoalProtectDungeonTemple::GoalProtectDungeonTemple(const std::string& nName, const std::string& nArguments) :
     Goal(nName, nArguments)
 {
-    std::cout << "\nAdding goal " << getName();
 }
 
 bool GoalProtectDungeonTemple::isMet(const Seat& s, const GameMap& gameMap)

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -917,7 +917,8 @@ void EditorMode::checkInputCommand()
     switch(mPlayerSelection.getCurrentAction())
     {
         case SelectedAction::changeTile:
-            break;
+            handlePlayerActionChangeTile();
+            return;
         case SelectedAction::buildRoom:
             RoomManager::checkBuildRoomEditor(mGameMap, mPlayerSelection.getNewRoomType(), inputManager, *this);
             return;
@@ -936,7 +937,11 @@ void EditorMode::checkInputCommand()
         default:
             return;
     }
+}
 
+void EditorMode::handlePlayerActionChangeTile()
+{
+    const InputManager& inputManager = mModeManager->getInputManager();
     if(inputManager.mCommandState == InputCommandState::infoOnly)
     {
         selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -78,7 +78,6 @@ EditorMode::EditorMode(ModeManager* modeManager):
     GameEditorModeBase(modeManager, ModeManager::EDITOR, modeManager->getGui().getGuiSheet(Gui::guiSheet::editorModeGui)),
     mCurrentTileVisual(TileVisual::nullTileVisual),
     mCurrentFullness(100.0),
-    mCurrentSeatId(0),
     mCurrentCreatureIndex(0),
     mMouseX(0),
     mMouseY(0)
@@ -173,7 +172,7 @@ void EditorMode::activate()
 
     // By default, we set the current seat id to the connected player
     Player* player = mGameMap->getLocalPlayer();
-    mCurrentSeatId = player->getSeat()->getId();
+    getModeManager().getInputManager().mSeatIdSelected = player->getSeat()->getId();
 
     refreshGuiResearch();
 
@@ -188,47 +187,16 @@ bool EditorMode::mouseMoved(const OIS::MouseEvent &arg)
         return true;
 
     InputManager& inputManager = mModeManager->getInputManager();
+    inputManager.mCommandState = (inputManager.mLMouseDown ? InputCommandState::building : InputCommandState::infoOnly);
 
-    Player* player = mGameMap->getLocalPlayer();
-    SelectedAction playerSelectedAction = mPlayerSelection.getCurrentAction();
-    if (playerSelectedAction != SelectedAction::none)
-    {
-        TextRenderer::getSingleton().moveText(ODApplication::POINTER_INFO_STRING,
-            static_cast<Ogre::Real>(arg.state.X.abs + 30), static_cast<Ogre::Real>(arg.state.Y.abs));
+    // If we have a room/trap/spell selected, show it
+    // TODO: This should be changed, or combined with an icon or something later.
+    TextRenderer& textRenderer = TextRenderer::getSingleton();
+    textRenderer.moveText(ODApplication::POINTER_INFO_STRING,
+        static_cast<Ogre::Real>(arg.state.X.abs + 30), static_cast<Ogre::Real>(arg.state.Y.abs));
 
-        switch(playerSelectedAction)
-        {
-            case SelectedAction::buildRoom:
-            {
-                RoomType selectedRoomType = mPlayerSelection.getNewRoomType();
-                TextRenderer::getSingleton().setText(ODApplication::POINTER_INFO_STRING, std::string(RoomManager::getRoomNameFromRoomType(selectedRoomType)));
-                break;
-            }
-            case SelectedAction::buildTrap:
-            {
-                TrapType selectedTrapType = mPlayerSelection.getNewTrapType();
-                TextRenderer::getSingleton().setText(ODApplication::POINTER_INFO_STRING, std::string(TrapManager::getTrapNameFromTrapType(selectedTrapType)));
-                break;
-            }
-            case SelectedAction::changeTile:
-            {
-                TextRenderer::getSingleton().setText(ODApplication::POINTER_INFO_STRING, std::string(Tile::tileVisualToString(mCurrentTileVisual)));
-                break;
-            }
-            case SelectedAction::destroyRoom:
-            {
-                TextRenderer::getSingleton().setText(ODApplication::POINTER_INFO_STRING, "Destroy room");
-                break;
-            }
-            case SelectedAction::destroyTrap:
-            {
-                TextRenderer::getSingleton().setText(ODApplication::POINTER_INFO_STRING, "Destroy trap");
-                break;
-            }
-            default :
-                break;
-        }
-    }
+    // We notify current selection input
+    checkInputCommand();
 
     handleMouseWheel(arg);
 
@@ -261,29 +229,6 @@ bool EditorMode::mouseMoved(const OIS::MouseEvent &arg)
             mMouseX = inputManager.mXPos;
             mMouseY = inputManager.mYPos;
             updateCursorText();
-        }
-
-        // If we don't drag anything, there is no affected tiles to compute.
-        if (!inputManager.mLMouseDown || mPlayerSelection.getCurrentAction() == SelectedAction::none)
-            break;
-
-        for (int jj = 0; jj < mGameMap->getMapSizeY(); ++jj)
-        {
-            for (int ii = 0; ii < mGameMap->getMapSizeX(); ++ii)
-            {
-                mGameMap->getTile(ii, jj)->setSelected(false, player);
-            }
-        }
-
-        // Loop over the tiles in the rectangular selection region and set their setSelected flag accordingly.
-        std::vector<Tile*> affectedTiles = mGameMap->rectangularRegion(inputManager.mXPos,
-                                                                        inputManager.mYPos,
-                                                                        inputManager.mLStartDragX,
-                                                                        inputManager.mLStartDragY);
-
-        for( std::vector<Tile*>::iterator itr = affectedTiles.begin(); itr != affectedTiles.end(); ++itr)
-        {
-            (*itr)->setSelected(true, player);
         }
 
         break;
@@ -496,18 +441,10 @@ bool EditorMode::mouseReleased(const OIS::MouseEvent& arg, OIS::MouseButtonID id
     CEGUI::System::getSingleton().getDefaultGUIContext().injectMouseButtonUp(Gui::convertButton(id));
 
     InputManager& inputManager = mModeManager->getInputManager();
+    inputManager.mCommandState = InputCommandState::validated;
     // If the mouse press was on a CEGUI window ignore it
     if (inputManager.mMouseDownOnCEGUIWindow)
         return true;
-
-    // Unselect all tiles
-    for (int jj = 0; jj < mGameMap->getMapSizeY(); ++jj)
-    {
-        for (int ii = 0; ii < mGameMap->getMapSizeX(); ++ii)
-        {
-            mGameMap->getTile(ii,jj)->setSelected(false, mGameMap->getLocalPlayer());
-        }
-    }
 
     // Right mouse button up
     if (id == OIS::MB_Right)
@@ -522,96 +459,9 @@ bool EditorMode::mouseReleased(const OIS::MouseEvent& arg, OIS::MouseButtonID id
     // Left mouse button up
     inputManager.mLMouseDown = false;
 
-    // On the client:  Inform the server about what we are doing
-    switch(mPlayerSelection.getCurrentAction())
-    {
-        case SelectedAction::changeTile:
-        {
-            TileType tileType = TileType::nullTileType;
-            int seatId = -1;
-            double fullness = mCurrentFullness;
-            switch(mCurrentTileVisual)
-            {
-                case TileVisual::nullTileVisual:
-                    return true;
-                case TileVisual::dirtGround:
-                    tileType = TileType::dirt;
-                    break;
-                case TileVisual::goldGround:
-                    tileType = TileType::gold;
-                    break;
-                case TileVisual::rockGround:
-                    tileType = TileType::rock;
-                    break;
-                case TileVisual::claimedGround:
-                case TileVisual::claimedFull:
-                    tileType = TileType::dirt;
-                    seatId = mCurrentSeatId;
-                    break;
-                case TileVisual::waterGround:
-                    tileType = TileType::water;
-                    fullness = 0.0;
-                    break;
-                case TileVisual::lavaGround:
-                    tileType = TileType::lava;
-                    fullness = 0.0;
-                    break;
-                default:
-                    return true;
-            }
-            ClientNotification *clientNotification = new ClientNotification(
-                ClientNotificationType::editorAskChangeTiles);
-            clientNotification->mPacket << inputManager.mXPos << inputManager.mYPos;
-            clientNotification->mPacket << inputManager.mLStartDragX << inputManager.mLStartDragY;
-            clientNotification->mPacket << tileType;
-            clientNotification->mPacket << fullness;
-            clientNotification->mPacket << seatId;
-            ODClient::getSingleton().queueClientNotification(clientNotification);
-            break;
-        }
-        case SelectedAction::buildRoom:
-        {
-            int intRoomType = static_cast<int>(mPlayerSelection.getNewRoomType());
-            ClientNotification *clientNotification = new ClientNotification(
-                ClientNotificationType::editorAskBuildRoom);
-            clientNotification->mPacket << inputManager.mXPos << inputManager.mYPos;
-            clientNotification->mPacket << inputManager.mLStartDragX << inputManager.mLStartDragY;
-            clientNotification->mPacket << intRoomType << mCurrentSeatId;
-            ODClient::getSingleton().queueClientNotification(clientNotification);
-            break;
-        }
-        case SelectedAction::buildTrap:
-        {
-            ClientNotification *clientNotification = new ClientNotification(
-                ClientNotificationType::editorAskBuildTrap);
-            int intTrapType = static_cast<int>(mPlayerSelection.getNewTrapType());
-            clientNotification->mPacket << inputManager.mXPos << inputManager.mYPos;
-            clientNotification->mPacket << inputManager.mLStartDragX << inputManager.mLStartDragY;
-            clientNotification->mPacket << intTrapType << mCurrentSeatId;
-            ODClient::getSingleton().queueClientNotification(clientNotification);
-            break;
-        }
-        case SelectedAction::destroyRoom:
-        {
-            ClientNotification *clientNotification = new ClientNotification(
-                ClientNotificationType::editorAskDestroyRoomTiles);
-            clientNotification->mPacket << inputManager.mXPos << inputManager.mYPos;
-            clientNotification->mPacket << inputManager.mLStartDragX << inputManager.mLStartDragY;
-            ODClient::getSingleton().queueClientNotification(clientNotification);
-            break;
-        }
-        case SelectedAction::destroyTrap:
-        {
-            ClientNotification *clientNotification = new ClientNotification(
-                ClientNotificationType::editorAskDestroyTrapTiles);
-            clientNotification->mPacket << inputManager.mXPos << inputManager.mYPos;
-            clientNotification->mPacket << inputManager.mLStartDragX << inputManager.mLStartDragY;
-            ODClient::getSingleton().queueClientNotification(clientNotification);
-            break;
-        }
-        default:
-            return true;
-    }
+    // We notify current selection input
+    checkInputCommand();
+
     return true;
 }
 
@@ -635,7 +485,8 @@ void EditorMode::updateCursorText()
     // Update the seat id
     posWin = mRootWindow->getChild(Gui::EDITOR_SEAT_ID);
     textSS.str("");
-    textSS << "Seat id (Y): " << mCurrentSeatId;
+    textSS << "Seat id (Y): " << getModeManager().getInputManager().mSeatIdSelected;
+;
     posWin->setText(textSS.str());
 
     // Update the seat id
@@ -733,9 +584,9 @@ bool EditorMode::keyPressed(const OIS::KeyEvent &arg)
         updateCursorText();
         break;
 
-    //Toggle mCurrentSeatId
+    //Toggle selected seat ID
     case OIS::KC_Y:
-        mCurrentSeatId = mGameMap->nextSeatId(mCurrentSeatId);
+        getModeManager().getInputManager().mSeatIdSelected = mGameMap->nextSeatId(getModeManager().getInputManager().mSeatIdSelected);
         updateCursorText();
         updateFlagColor();
         break;
@@ -888,7 +739,7 @@ void EditorMode::notifyGuiAction(GuiAction guiAction)
                 {
                     ClientNotification *clientNotification = new ClientNotification(
                         ClientNotificationType::editorCreateWorker);
-                    clientNotification->mPacket << mCurrentSeatId;
+                    clientNotification->mPacket << getModeManager().getInputManager().mSeatIdSelected;
                     ODClient::getSingleton().queueClientNotification(clientNotification);
                 }
                 break;
@@ -903,7 +754,7 @@ void EditorMode::notifyGuiAction(GuiAction guiAction)
                         break;
                     ClientNotification *clientNotification = new ClientNotification(
                         ClientNotificationType::editorCreateFighter);
-                    clientNotification->mPacket << mCurrentSeatId;
+                    clientNotification->mPacket << getModeManager().getInputManager().mSeatIdSelected;
                     clientNotification->mPacket << def->getClassName();
                     ODClient::getSingleton().queueClientNotification(clientNotification);
                 }
@@ -1013,6 +864,68 @@ void EditorMode::connectTileSelect(const std::string& buttonName, TileVisual til
 
 void EditorMode::updateFlagColor()
 {
-    std::string colorStr = Helper::getImageColoursStringFromColourValue(mGameMap->getSeatById(mCurrentSeatId)->getColorValue());
+    std::string colorStr = Helper::getImageColoursStringFromColourValue(
+        mGameMap->getSeatById(getModeManager().getInputManager().mSeatIdSelected)->getColorValue());
     mRootWindow->getChild("HorizontalPipe/SeatIdDisplay/Icon")->setProperty("ImageColours", colorStr);
+}
+
+void EditorMode::selectSquaredTiles(int tileX1, int tileY1, int tileX2, int tileY2)
+{
+    // Loop over the tiles in the rectangular selection region and set their setSelected flag accordingly.
+    std::vector<Tile*> affectedTiles = mGameMap->rectangularRegion(tileX1,
+        tileY1, tileX2, tileY2);
+
+    selectTiles(affectedTiles);
+}
+
+void EditorMode::selectTiles(const std::vector<Tile*> tiles)
+{
+    unselectAllTiles();
+
+    Player* player = mGameMap->getLocalPlayer();
+    for(Tile* tile : tiles)
+    {
+        tile->setSelected(true, player);
+    }
+}
+
+void EditorMode::unselectAllTiles()
+{
+    Player* player = mGameMap->getLocalPlayer();
+    // Compute selected tiles
+    for (int jj = 0; jj < mGameMap->getMapSizeY(); ++jj)
+    {
+        for (int ii = 0; ii < mGameMap->getMapSizeX(); ++ii)
+        {
+            mGameMap->getTile(ii, jj)->setSelected(false, player);
+        }
+    }
+}
+
+void EditorMode::displayText(const Ogre::ColourValue& txtColour, const std::string& txt)
+{
+    TextRenderer& textRenderer = TextRenderer::getSingleton();
+    textRenderer.setColor(ODApplication::POINTER_INFO_STRING, txtColour);
+    textRenderer.setText(ODApplication::POINTER_INFO_STRING, txt);
+}
+
+void EditorMode::checkInputCommand()
+{
+    // In the editor mode, by default, we do nothing if mouse dragged while no action selected
+    const InputManager& inputManager = mModeManager->getInputManager();
+
+    switch(mPlayerSelection.getCurrentAction())
+    {
+        case SelectedAction::buildRoom:
+            RoomManager::checkBuildRoomEditor(mGameMap, mPlayerSelection.getNewRoomType(), inputManager, *this);
+            return;
+        case SelectedAction::destroyRoom:
+            RoomManager::checkSellRoomTilesEditor(mGameMap, inputManager, *this);
+            return;
+        case SelectedAction::castSpell:
+            // TODO: create research entity with corresponding spell
+            return;
+        default:
+            return;
+    }
 }

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -749,9 +749,11 @@ void EditorMode::notifyGuiAction(GuiAction guiAction)
                 if(ODClient::getSingleton().isConnected())
                 {
                     const CreatureDefinition* def = mGameMap->getClassDescription(mCurrentCreatureIndex);
-                    OD_ASSERT_TRUE(def != nullptr);
                     if(def == nullptr)
+                    {
+                        OD_LOG_ERR("unexpected null CreatureDefinition mCurrentCreatureIndex=" + Helper::toString(mCurrentCreatureIndex));
                         break;
+                    }
                     ClientNotification *clientNotification = new ClientNotification(
                         ClientNotificationType::editorCreateFighter);
                     clientNotification->mPacket << getModeManager().getInputManager().mSeatIdSelected;

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -260,7 +260,6 @@ bool EditorMode::mouseMoved(const OIS::MouseEvent &arg)
         {
             mMouseX = inputManager.mXPos;
             mMouseY = inputManager.mYPos;
-            RenderManager::getSingleton().setHoveredTile(mMouseX, mMouseY);
             updateCursorText();
         }
 

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -922,6 +922,12 @@ void EditorMode::checkInputCommand()
         case SelectedAction::destroyRoom:
             RoomManager::checkSellRoomTilesEditor(mGameMap, inputManager, *this);
             return;
+        case SelectedAction::buildTrap:
+            TrapManager::checkBuildTrapEditor(mGameMap, mPlayerSelection.getNewTrapType(), inputManager, *this);
+            return;
+        case SelectedAction::destroyTrap:
+            TrapManager::checkSellTrapTilesEditor(mGameMap, inputManager, *this);
+            return;
         case SelectedAction::castSpell:
             // TODO: create research entity with corresponding spell
             return;

--- a/source/modes/EditorMode.h
+++ b/source/modes/EditorMode.h
@@ -111,6 +111,7 @@ private:
 
     //! \brief Called when there is a mouse input change
     void checkInputCommand();
+    void handlePlayerActionChangeTile();
 };
 
 #endif // EDITORMODE_H

--- a/source/modes/EditorMode.h
+++ b/source/modes/EditorMode.h
@@ -19,13 +19,14 @@
 #define EDITORMODE_H
 
 #include "GameEditorModeBase.h"
+#include "modes/InputCommand.h"
 
-class Gui; // Used to change the Current tile type
 class GameMap;
+class Gui; // Used to change the Current tile type
 
 enum class TileVisual;
 
-class EditorMode final: public GameEditorModeBase
+class EditorMode final: public GameEditorModeBase, public InputCommand
 {
 public:
     EditorMode(ModeManager* modeManager);
@@ -64,6 +65,12 @@ public:
     void setTileVisual(TileVisual tileVisual)
     { mCurrentTileVisual = tileVisual; }
 
+    void selectSquaredTiles(int tileX1, int tileY1, int tileX2, int tileY2) override;
+    void selectTiles(const std::vector<Tile*> tiles) override;
+    void unselectAllTiles();
+
+    void displayText(const Ogre::ColourValue& txtColour, const std::string& txt) override;
+
 private:
     void connectTileSelect(const std::string& buttonName, TileVisual tileVisual);
 
@@ -73,9 +80,6 @@ private:
     //! \brief how of the wall type is there (0 - 100.0)
     //! < 1.0 means no walls.
     double mCurrentFullness;
-
-    //! \brief Current selected seat id
-    int mCurrentSeatId;
 
     //! \brief Current selected creature to spawn
     uint32_t mCurrentCreatureIndex;
@@ -104,6 +108,9 @@ private:
 
     //! \brief Updates the flag icon color when switching seats.
     void updateFlagColor();
+
+    //! \brief Called when there is a mouse input change
+    void checkInputCommand();
 };
 
 #endif // EDITORMODE_H

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -532,7 +532,11 @@ bool GameMode::mousePressed(const OIS::MouseEvent& arg, OIS::MouseButtonID id)
     }
 
     Player* player = mGameMap->getLocalPlayer();
-    OD_ASSERT_TRUE_MSG(player, "LOCAL PLAYER DOES NOT EXIST!!");
+    if(player == nullptr)
+    {
+        OD_LOG_ERR("LOCAL PLAYER DOES NOT EXIST!!");
+        return true;
+    }
 
     // See if the mouse is over any creatures
     for (;itr != result.end(); ++itr)

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -1393,6 +1393,7 @@ void GameMode::checkInputCommand()
 
     switch(mPlayerSelection.getCurrentAction())
     {
+        case SelectedAction::none:
         case SelectedAction::selectTile:
             break;
         case SelectedAction::buildRoom:
@@ -1412,6 +1413,13 @@ void GameMode::checkInputCommand()
             return;
         default:
             return;
+    }
+
+    if(inputManager.mCommandState == InputCommandState::infoOnly)
+    {
+        selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
+            inputManager.mYPos);
+        return;
     }
 
     if(inputManager.mCommandState == InputCommandState::building)

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -1404,6 +1404,12 @@ void GameMode::checkInputCommand()
         case SelectedAction::castSpell:
             SpellManager::checkSpellCast(mGameMap, mPlayerSelection.getNewSpellType(), inputManager, *this);
             return;
+        case SelectedAction::buildTrap:
+            TrapManager::checkBuildTrap(mGameMap, mPlayerSelection.getNewTrapType(), inputManager, *this);
+            return;
+        case SelectedAction::destroyTrap:
+            TrapManager::checkSellTrapTiles(mGameMap, inputManager, *this);
+            return;
         default:
             return;
     }

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -1394,8 +1394,11 @@ void GameMode::checkInputCommand()
     switch(mPlayerSelection.getCurrentAction())
     {
         case SelectedAction::none:
+            handlePlayerActionNone();
+            return;
         case SelectedAction::selectTile:
-            break;
+            handlePlayerActionSelectTile();
+            return;
         case SelectedAction::buildRoom:
             RoomManager::checkBuildRoom(mGameMap, mPlayerSelection.getNewRoomType(), inputManager, *this);
             return;
@@ -1414,7 +1417,25 @@ void GameMode::checkInputCommand()
         default:
             return;
     }
+}
 
+void GameMode::handlePlayerActionNone()
+{
+    const InputManager& inputManager = mModeManager->getInputManager();
+    // We only display the selection cursor on the hovered tile
+    if(inputManager.mCommandState == InputCommandState::validated)
+    {
+        unselectAllTiles();
+        return;
+    }
+
+    selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
+        inputManager.mYPos);
+}
+
+void GameMode::handlePlayerActionSelectTile()
+{
+    const InputManager& inputManager = mModeManager->getInputManager();
     if(inputManager.mCommandState == InputCommandState::infoOnly)
     {
         selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -73,15 +73,10 @@ namespace
         PlayerSelection& playerSelection;
     };
 }
-//! \brief Colors used by the room/trap/spell text overlay
-static Ogre::ColourValue white = Ogre::ColourValue(1.0f, 1.0f, 1.0f, 1.0f);
-static Ogre::ColourValue red = Ogre::ColourValue(1.0f, 0.0f, 0.0, 1.0f);
 
 GameMode::GameMode(ModeManager *modeManager):
     GameEditorModeBase(modeManager, ModeManager::GAME, modeManager->getGui().getGuiSheet(Gui::guiSheet::inGameMenu)),
     mDigSetBool(false),
-    mMouseX(0),
-    mMouseY(0),
     mIndexEvent(0)
 {
     // Set per default the input on the map
@@ -294,218 +289,16 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
         return true;
 
     InputManager& inputManager = mModeManager->getInputManager();
+    inputManager.mCommandState = (inputManager.mLMouseDown ? InputCommandState::building : InputCommandState::infoOnly);
 
-    // If we have a room or trap (or later spell) selected, show what we have selected
+    // If we have a room/trap/spell selected, show it
     // TODO: This should be changed, or combined with an icon or something later.
-    Player* player = mGameMap->getLocalPlayer();
-    if (mPlayerSelection.getCurrentAction() != SelectedAction::none)
-    {
-        TextRenderer& textRenderer = TextRenderer::getSingleton();
-        textRenderer.moveText(ODApplication::POINTER_INFO_STRING,
-            static_cast<Ogre::Real>(arg.state.X.abs + 30), static_cast<Ogre::Real>(arg.state.Y.abs));
+    TextRenderer& textRenderer = TextRenderer::getSingleton();
+    textRenderer.moveText(ODApplication::POINTER_INFO_STRING,
+        static_cast<Ogre::Real>(arg.state.X.abs + 30), static_cast<Ogre::Real>(arg.state.Y.abs));
 
-        switch(mPlayerSelection.getCurrentAction())
-        {
-            case SelectedAction::buildRoom:
-            {
-                // If the player is dragging to build, we display the total price the spell will cost.
-                // If he is not, we display the price for 1 tile.
-                int tileX1;
-                int tileY1;
-                int tileX2;
-                int tileY2;
-                if(inputManager.mLMouseDown)
-                {
-                    tileX1 = inputManager.mXPos;
-                    tileY1 = inputManager.mYPos;
-                    tileX2 = inputManager.mLStartDragX;
-                    tileY2 = inputManager.mLStartDragY;
-                }
-                else
-                {
-                    tileX1 = inputManager.mXPos;
-                    tileY1 = inputManager.mYPos;
-                    tileX2 = inputManager.mXPos;
-                    tileY2 = inputManager.mYPos;
-                }
-
-                RoomType selectedRoomType = mPlayerSelection.getNewRoomType();
-                std::vector<Tile*> tiles;
-                int price = RoomManager::getRoomCost(tiles, mGameMap, selectedRoomType, tileX1, tileY1, tileX2, tileY2, player);
-                if(price < 0)
-                {
-                    textRenderer.setColor(ODApplication::POINTER_INFO_STRING, red);
-                    textRenderer.setText(ODApplication::POINTER_INFO_STRING, "Cannot build " + std::string(RoomManager::getRoomNameFromRoomType(selectedRoomType)) + " here");
-                    break;
-                }
-                int gold = player->getSeat()->getGold();
-                const Ogre::ColourValue& textColor = ((gold < price) || (tiles.empty() && inputManager.mLMouseDown)) ? red : white;
-                textRenderer.setColor(ODApplication::POINTER_INFO_STRING, textColor);
-                textRenderer.setText(ODApplication::POINTER_INFO_STRING, std::string(RoomManager::getRoomNameFromRoomType(selectedRoomType))
-                    + " [" + Helper::toString(price)+ " Gold]");
-                break;
-            }
-            case SelectedAction::buildTrap:
-            {
-                // If the player is dragging to build, we display the total price the spell will cost.
-                // If he is not, we display the price for 1 tile.
-                int tileX1;
-                int tileY1;
-                int tileX2;
-                int tileY2;
-                if(inputManager.mLMouseDown)
-                {
-                    tileX1 = inputManager.mXPos;
-                    tileY1 = inputManager.mYPos;
-                    tileX2 = inputManager.mLStartDragX;
-                    tileY2 = inputManager.mLStartDragY;
-                }
-                else
-                {
-                    tileX1 = inputManager.mXPos;
-                    tileY1 = inputManager.mYPos;
-                    tileX2 = inputManager.mXPos;
-                    tileY2 = inputManager.mYPos;
-                }
-
-                TrapType selectedTrapType = mPlayerSelection.getNewTrapType();
-                std::vector<Tile*> tiles;
-                int price = TrapManager::getTrapCost(tiles, mGameMap, selectedTrapType, tileX1, tileY1, tileX2, tileY2, player);
-                if(price < 0)
-                {
-                    textRenderer.setColor(ODApplication::POINTER_INFO_STRING, red);
-                    textRenderer.setText(ODApplication::POINTER_INFO_STRING, "Cannot build " + std::string(TrapManager::getTrapNameFromTrapType(selectedTrapType)) + " here");
-                    break;
-                }
-                int gold = player->getSeat()->getGold();
-                const Ogre::ColourValue& textColor = ((gold < price) || (tiles.empty() && inputManager.mLMouseDown)) ? red : white;
-                textRenderer.setColor(ODApplication::POINTER_INFO_STRING, textColor);
-                textRenderer.setText(ODApplication::POINTER_INFO_STRING, std::string(TrapManager::getTrapNameFromTrapType(selectedTrapType))
-                    + " [" + Helper::toString(price)+ " Gold]");
-                break;
-            }
-            case SelectedAction::castSpell:
-            {
-                // If the player is dragging to build, we display the total price the spell will cost.
-                // If he is not, we display the price for 1 tile.
-                int tileX1;
-                int tileY1;
-                int tileX2;
-                int tileY2;
-                if(inputManager.mLMouseDown)
-                {
-                    tileX1 = inputManager.mXPos;
-                    tileY1 = inputManager.mYPos;
-                    tileX2 = inputManager.mLStartDragX;
-                    tileY2 = inputManager.mLStartDragY;
-                }
-                else
-                {
-                    tileX1 = inputManager.mXPos;
-                    tileY1 = inputManager.mYPos;
-                    tileX2 = inputManager.mXPos;
-                    tileY2 = inputManager.mYPos;
-                }
-
-                SpellType selectedSpellType = mPlayerSelection.getNewSpellType();
-                uint32_t cooldown = player->getSpellCooldownTurns(selectedSpellType);
-                if(cooldown > 0)
-                {
-                    double remainingTime = static_cast<double>(cooldown) / ODApplication::turnsPerSecond;
-                    textRenderer.setColor(ODApplication::POINTER_INFO_STRING, red);
-                    textRenderer.setText(ODApplication::POINTER_INFO_STRING, std::string(SpellManager::getSpellNameFromSpellType(selectedSpellType))
-                        + " (" + Helper::toString(remainingTime, 2)+ " s)");
-
-                    break;
-                }
-
-                std::vector<EntityBase*> targets;
-                int price = SpellManager::getSpellCost(targets, mGameMap, selectedSpellType, tileX1, tileY1, tileX2, tileY2, player);
-                if(price < 0)
-                {
-                    textRenderer.setColor(ODApplication::POINTER_INFO_STRING, red);
-                    textRenderer.setText(ODApplication::POINTER_INFO_STRING, "Cannot cast " + std::string(SpellManager::getSpellNameFromSpellType(selectedSpellType)) + " here");
-                    break;
-                }
-                int mana = player->getSeat()->getMana();
-                const Ogre::ColourValue& textColor = ((mana < price) || (targets.empty() && inputManager.mLMouseDown)) ? red : white;
-                textRenderer.setColor(ODApplication::POINTER_INFO_STRING, textColor);
-                textRenderer.setText(ODApplication::POINTER_INFO_STRING, std::string(SpellManager::getSpellNameFromSpellType(selectedSpellType))
-                    + " [" + Helper::toString(price)+ " Mana]");
-                break;
-            }
-            case SelectedAction::destroyRoom:
-            {
-                int tileX1;
-                int tileY1;
-                int tileX2;
-                int tileY2;
-                if(inputManager.mLMouseDown)
-                {
-                    tileX1 = inputManager.mXPos;
-                    tileY1 = inputManager.mYPos;
-                    tileX2 = inputManager.mLStartDragX;
-                    tileY2 = inputManager.mLStartDragY;
-                }
-                else
-                {
-                    tileX1 = inputManager.mXPos;
-                    tileY1 = inputManager.mYPos;
-                    tileX2 = inputManager.mXPos;
-                    tileY2 = inputManager.mYPos;
-                }
-                std::vector<Tile*> tiles;
-                int price = RoomManager::getRefundPrice(tiles, mGameMap, tileX1, tileY1, tileX2, tileY2, player);
-                if(price < 0)
-                {
-                    textRenderer.setColor(ODApplication::POINTER_INFO_STRING, red);
-                    textRenderer.setText(ODApplication::POINTER_INFO_STRING, "Cannot destroy room");
-                    break;
-                }
-
-                textRenderer.setColor(ODApplication::POINTER_INFO_STRING, white);
-                textRenderer.setText(ODApplication::POINTER_INFO_STRING, "Destroy room ["
-                    + Helper::toString(price)+ " Gold]");
-                break;
-            }
-            case SelectedAction::destroyTrap:
-            {
-                int tileX1;
-                int tileY1;
-                int tileX2;
-                int tileY2;
-                if(inputManager.mLMouseDown)
-                {
-                    tileX1 = inputManager.mXPos;
-                    tileY1 = inputManager.mYPos;
-                    tileX2 = inputManager.mLStartDragX;
-                    tileY2 = inputManager.mLStartDragY;
-                }
-                else
-                {
-                    tileX1 = inputManager.mXPos;
-                    tileY1 = inputManager.mYPos;
-                    tileX2 = inputManager.mXPos;
-                    tileY2 = inputManager.mYPos;
-                }
-                std::vector<Tile*> tiles;
-                int price = TrapManager::getRefundPrice(tiles, mGameMap, tileX1, tileY1, tileX2, tileY2, player);
-                if(price < 0)
-                {
-                    textRenderer.setColor(ODApplication::POINTER_INFO_STRING, red);
-                    textRenderer.setText(ODApplication::POINTER_INFO_STRING, "Cannot destroy trap");
-                    break;
-                }
-
-                textRenderer.setColor(ODApplication::POINTER_INFO_STRING, white);
-                textRenderer.setText(ODApplication::POINTER_INFO_STRING, "Destroy trap ["
-                    + Helper::toString(price)+ " Gold]");
-                break;
-            }
-            default:
-                break;
-        }
-    }
+    // We notify current selection input
+    checkInputCommand();
 
     handleMouseWheel(arg);
 
@@ -553,36 +346,15 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
 
     inputManager.mXPos = tileClicked->getX();
     inputManager.mYPos = tileClicked->getY();
-    if (mMouseX != inputManager.mXPos || mMouseY != inputManager.mYPos)
+    if (!inputManager.mLMouseDown)
     {
-        mMouseX = inputManager.mXPos;
-        mMouseY = inputManager.mYPos;
-        RenderManager::getSingleton().setHoveredTile(mMouseX, mMouseY);
+        inputManager.mLStartDragX = inputManager.mXPos;
+        inputManager.mLStartDragY = inputManager.mYPos;
     }
 
     // If we don't drag anything, there is no affected tiles to compute.
     if (!inputManager.mLMouseDown || mPlayerSelection.getCurrentAction() == SelectedAction::none)
         return true;
-
-    // COmpute selected tiles
-    for (int jj = 0; jj < mGameMap->getMapSizeY(); ++jj)
-    {
-        for (int ii = 0; ii < mGameMap->getMapSizeX(); ++ii)
-        {
-            mGameMap->getTile(ii, jj)->setSelected(false, player);
-        }
-    }
-
-    // Loop over the tiles in the rectangular selection region and set their setSelected flag accordingly.
-    std::vector<Tile*> affectedTiles = mGameMap->rectangularRegion(inputManager.mXPos,
-                                                                    inputManager.mYPos,
-                                                                    inputManager.mLStartDragX,
-                                                                    inputManager.mLStartDragY);
-
-    for(Tile* tile : affectedTiles)
-    {
-        tile->setSelected(true, player);
-    }
 
     return true;
 }
@@ -689,10 +461,17 @@ bool GameMode::mousePressed(const OIS::MouseEvent& arg, OIS::MouseButtonID id)
     if (id == OIS::MB_Right)
     {
         inputManager.mRMouseDown = true;
-        inputManager.mRStartDragX = inputManager.mXPos;
-        inputManager.mRStartDragY = inputManager.mYPos;
 
         // Stop creating rooms, traps, etc.
+        inputManager.mLStartDragX = inputManager.mXPos;
+        inputManager.mLStartDragY = inputManager.mYPos;
+        for (int jj = 0; jj < mGameMap->getMapSizeY(); ++jj)
+        {
+            for (int ii = 0; ii < mGameMap->getMapSizeX(); ++ii)
+            {
+                mGameMap->getTile(ii, jj)->setSelected(false, mGameMap->getLocalPlayer());
+            }
+        }
         mPlayerSelection.setCurrentAction(SelectedAction::none);
         TextRenderer::getSingleton().setText(ODApplication::POINTER_INFO_STRING, "");
 
@@ -833,6 +612,7 @@ bool GameMode::mouseReleased(const OIS::MouseEvent &arg, OIS::MouseButtonID id)
     CEGUI::System::getSingleton().getDefaultGUIContext().injectMouseButtonUp(Gui::convertButton(id));
 
     InputManager& inputManager = mModeManager->getInputManager();
+    inputManager.mCommandState = InputCommandState::validated;
 
     // If the mouse press was on a CEGUI window ignore it
     if (inputManager.mMouseDownOnCEGUIWindow)
@@ -863,71 +643,8 @@ bool GameMode::mouseReleased(const OIS::MouseEvent &arg, OIS::MouseButtonID id)
     // Left mouse button up
     inputManager.mLMouseDown = false;
 
-    // On the client:  Inform the server about what we are doing
-    switch(mPlayerSelection.getCurrentAction())
-    {
-        case SelectedAction::selectTile:
-        {
-            ClientNotification *clientNotification = new ClientNotification(
-                ClientNotificationType::askMarkTiles);
-            clientNotification->mPacket << inputManager.mXPos << inputManager.mYPos;
-            clientNotification->mPacket << inputManager.mLStartDragX << inputManager.mLStartDragY;
-            clientNotification->mPacket << mDigSetBool;
-            ODClient::getSingleton().queueClientNotification(clientNotification);
-            mPlayerSelection.setCurrentAction(SelectedAction::none);
-            break;
-        }
-        case SelectedAction::buildRoom:
-        {
-            ClientNotification *clientNotification = new ClientNotification(
-                ClientNotificationType::askBuildRoom);
-            clientNotification->mPacket << inputManager.mXPos << inputManager.mYPos;
-            clientNotification->mPacket << inputManager.mLStartDragX << inputManager.mLStartDragY;
-            clientNotification->mPacket << mPlayerSelection.getNewRoomType();
-            ODClient::getSingleton().queueClientNotification(clientNotification);
-            break;
-        }
-        case SelectedAction::buildTrap:
-        {
-            ClientNotification *clientNotification = new ClientNotification(
-                ClientNotificationType::askBuildTrap);
-            clientNotification->mPacket << inputManager.mXPos << inputManager.mYPos;
-            clientNotification->mPacket << inputManager.mLStartDragX << inputManager.mLStartDragY;
-            clientNotification->mPacket << mPlayerSelection.getNewTrapType();
-            ODClient::getSingleton().queueClientNotification(clientNotification);
-            break;
-        }
-        case SelectedAction::castSpell:
-        {
-            ClientNotification *clientNotification = new ClientNotification(
-                ClientNotificationType::askCastSpell);
-            clientNotification->mPacket << inputManager.mXPos << inputManager.mYPos;
-            clientNotification->mPacket << inputManager.mLStartDragX << inputManager.mLStartDragY;
-            clientNotification->mPacket << mPlayerSelection.getNewSpellType();
-            ODClient::getSingleton().queueClientNotification(clientNotification);
-            break;
-        }
-        case SelectedAction::destroyRoom:
-        {
-            ClientNotification *clientNotification = new ClientNotification(
-                ClientNotificationType::askSellRoomTiles);
-            clientNotification->mPacket << inputManager.mXPos << inputManager.mYPos;
-            clientNotification->mPacket << inputManager.mLStartDragX << inputManager.mLStartDragY;
-            ODClient::getSingleton().queueClientNotification(clientNotification);
-            break;
-        }
-        case SelectedAction::destroyTrap:
-        {
-            ClientNotification *clientNotification = new ClientNotification(
-                ClientNotificationType::askSellTrapTiles);
-            clientNotification->mPacket << inputManager.mXPos << inputManager.mYPos;
-            clientNotification->mPacket << inputManager.mLStartDragX << inputManager.mLStartDragY;
-            ODClient::getSingleton().queueClientNotification(clientNotification);
-            break;
-        }
-        default:
-            return true;
-    }
+    // We notify current selection input
+    checkInputCommand();
 
     return true;
 }
@@ -1646,4 +1363,71 @@ void GameMode::connectSpellSelect(const std::string& buttonName, SpellType spell
           CEGUI::Event::Subscriber(SpellSelector{spellType, mPlayerSelection})
         )
     );
+}
+
+void GameMode::selectSquaredTiles(int tileX1, int tileY1, int tileX2, int tileY2)
+{
+    // Loop over the tiles in the rectangular selection region and set their setSelected flag accordingly.
+    std::vector<Tile*> affectedTiles = mGameMap->rectangularRegion(tileX1,
+        tileY1, tileX2, tileY2);
+
+    selectTiles(affectedTiles);
+}
+
+void GameMode::selectTiles(const std::vector<Tile*> tiles)
+{
+    Player* player = mGameMap->getLocalPlayer();
+    // Compute selected tiles
+    for (int jj = 0; jj < mGameMap->getMapSizeY(); ++jj)
+    {
+        for (int ii = 0; ii < mGameMap->getMapSizeX(); ++ii)
+        {
+            mGameMap->getTile(ii, jj)->setSelected(false, player);
+        }
+    }
+
+
+    for(Tile* tile : tiles)
+    {
+        tile->setSelected(true, player);
+    }
+}
+
+void GameMode::displayText(const Ogre::ColourValue& txtColour, const std::string& txt)
+{
+    TextRenderer& textRenderer = TextRenderer::getSingleton();
+    textRenderer.setColor(ODApplication::POINTER_INFO_STRING, txtColour);
+    textRenderer.setText(ODApplication::POINTER_INFO_STRING, txt);
+}
+
+void GameMode::checkInputCommand()
+{
+    // In the gamemode, by default, we select tiles
+    const InputManager& inputManager = mModeManager->getInputManager();
+
+    switch(mPlayerSelection.getCurrentAction())
+    {
+        case SelectedAction::selectTile:
+            break;
+        case SelectedAction::castSpell:
+            SpellManager::checkSpellCast(mGameMap, mPlayerSelection.getNewSpellType(), inputManager, *this);
+            return;
+        default:
+            return;
+    }
+
+    selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mLStartDragX,
+        inputManager.mLStartDragY);
+
+    if(inputManager.mCommandState == InputCommandState::validated)
+    {
+        ClientNotification *clientNotification = new ClientNotification(
+            ClientNotificationType::askMarkTiles);
+        clientNotification->mPacket << inputManager.mXPos << inputManager.mYPos;
+        clientNotification->mPacket << inputManager.mLStartDragX << inputManager.mLStartDragY;
+        clientNotification->mPacket << mDigSetBool;
+        ODClient::getSingleton().queueClientNotification(clientNotification);
+        mPlayerSelection.setCurrentAction(SelectedAction::none);
+        return;
+    }
 }

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -117,6 +117,12 @@ class GameMode final : public GameEditorModeBase, public InputCommand
     //! \brief Refreshed the main ui data, such as mana, gold, ...
     void refreshMainUI();
 
+    void selectSquaredTiles(int tileX1, int tileY1, int tileX2, int tileY2) override;
+    void selectTiles(const std::vector<Tile*> tiles) override;
+    void unselectAllTiles() override;
+
+    void displayText(const Ogre::ColourValue& txtColour, const std::string& txt) override;
+
 protected:
     bool onClickYesQuitMenu(const CEGUI::EventArgs& /*arg*/);
 
@@ -135,12 +141,6 @@ protected:
 
     //! \brief Handle the keyboard input in normal mode
     virtual bool keyReleasedNormal  (const OIS::KeyEvent &arg);
-
-    void selectSquaredTiles(int tileX1, int tileY1, int tileX2, int tileY2) override;
-
-    void selectTiles(const std::vector<Tile*> tiles) override;
-
-    void displayText(const Ogre::ColourValue& txtColour, const std::string& txt) override;
 
 private:
     //! \brief Sets whether a tile must marked or unmarked for digging.

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -175,6 +175,8 @@ private:
 
     //! \brief Called when there is a mouse input change
     void checkInputCommand();
+    void handlePlayerActionNone();
+    void handlePlayerActionSelectTile();
 };
 
 #endif // GAMEMODE_H

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -19,6 +19,7 @@
 #define GAMEMODE_H
 
 #include "GameEditorModeBase.h"
+#include "modes/InputCommand.h"
 
 #include <CEGUI/EventArgs.h>
 
@@ -30,7 +31,7 @@ class Window;
 enum class SpellType;
 enum class ResearchType;
 
-class GameMode final : public GameEditorModeBase
+class GameMode final : public GameEditorModeBase, public InputCommand
 {
  public:
     GameMode(ModeManager*);
@@ -135,14 +136,16 @@ protected:
     //! \brief Handle the keyboard input in normal mode
     virtual bool keyReleasedNormal  (const OIS::KeyEvent &arg);
 
+    void selectSquaredTiles(int tileX1, int tileY1, int tileX2, int tileY2) override;
+
+    void selectTiles(const std::vector<Tile*> tiles) override;
+
+    void displayText(const Ogre::ColourValue& txtColour, const std::string& txt) override;
+
 private:
     //! \brief Sets whether a tile must marked or unmarked for digging.
     //! this value is based on the first marked flag tile selected.
     bool mDigSetBool;
-
-    //! \brief Stores the lastest mouse cursor and light positions.
-    int mMouseX;
-    int mMouseY;
 
     //! \brief Index of the event in the game event queue (for zooming automatically)
     uint32_t mIndexEvent;
@@ -169,6 +172,9 @@ private:
     //! \brief Tells whether the latest mouse click was made on a relevant CEGUI widget,
     //! and thus, the game should ignore it.
     bool isMouseDownOnCEGUIWindow();
+
+    //! \brief Called when there is a mouse input change
+    void checkInputCommand();
 };
 
 #endif // GAMEMODE_H

--- a/source/modes/InputCommand.h
+++ b/source/modes/InputCommand.h
@@ -36,6 +36,7 @@ public:
     //! as selected for the local player
     virtual void selectSquaredTiles(int tileX1, int tileY1, int tileX2, int tileY2) = 0;
     virtual void selectTiles(const std::vector<Tile*> tiles) = 0;
+    virtual void unselectAllTiles() = 0;
     //! \brief Notify the InputCommand that we want to display the given text to the local player
     virtual void displayText(const Ogre::ColourValue& txtColour, const std::string& txt) = 0;
 };

--- a/source/modes/InputCommand.h
+++ b/source/modes/InputCommand.h
@@ -15,24 +15,30 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SPELLCREATUREEXPLOSION_H
-#define SPELLCREATUREEXPLOSION_H
+#ifndef INPUTCOMMAND_H
+#define INPUTCOMMAND_H
 
-#include "spells/Spell.h"
-#include "spells/SpellType.h"
+#include <string>
+#include <vector>
 
-class GameMap;
-class InputCommand;
-class InputManager;
+namespace Ogre
+{
+class ColourValue;
+}
 
-class SpellCreatureExplosion : public Spell
+class Tile;
+
+//! Abstract class used for spell manager clients (on client side)
+class InputCommand
 {
 public:
-    static void checkSpellCast(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
-    static bool castSpell(GameMap* gameMap, Player* player, ODPacket& packet);
-
-    static Spell* getSpellFromStream(GameMap* gameMap, std::istream &is);
-    static Spell* getSpellFromPacket(GameMap* gameMap, ODPacket &is);
+    //! \brief Notify the InputCommand that we want to display tiles within given square
+    //! as selected for the local player
+    virtual void selectSquaredTiles(int tileX1, int tileY1, int tileX2, int tileY2) = 0;
+    virtual void selectTiles(const std::vector<Tile*> tiles) = 0;
+    //! \brief Notify the InputCommand that we want to display the given text to the local player
+    virtual void displayText(const Ogre::ColourValue& txtColour, const std::string& txt) = 0;
 };
 
-#endif // SPELLCREATUREEXPLOSION_H
+
+#endif // INPUTCOMMAND_H

--- a/source/modes/InputManager.cpp
+++ b/source/modes/InputManager.cpp
@@ -35,7 +35,8 @@ InputManager::InputManager(Ogre::RenderWindow* renderWindow):
     mLStartDragX(0),
     mLStartDragY(0),
     mRStartDragX(0),
-    mRStartDragY(0)
+    mRStartDragY(0),
+    mCommandState(InputCommandState::infoOnly)
 {
     LogManager::getSingleton().logMessage("*** Initializing OIS - Input Manager ***");
 

--- a/source/modes/InputManager.cpp
+++ b/source/modes/InputManager.cpp
@@ -39,7 +39,7 @@ InputManager::InputManager(Ogre::RenderWindow* renderWindow):
     mSeatIdSelected(0),
     mCommandState(InputCommandState::infoOnly)
 {
-    LogManager::getSingleton().logMessage("*** Initializing OIS - Input Manager ***");
+    OD_LOG_INF("*** Initializing OIS - Input Manager ***");
 
     for (int i = 0; i < 10; ++i)
     {
@@ -85,7 +85,7 @@ InputManager::InputManager(Ogre::RenderWindow* renderWindow):
 
 InputManager::~InputManager()
 {
-    LogManager::getSingleton().logMessage("*** Destroying Input Manager ***");
+    OD_LOG_INF("*** Destroying Input Manager ***");
     mInputManager->destroyInputObject(mMouse);
     mInputManager->destroyInputObject(mKeyboard);
     OIS::InputManager::destroyInputSystem(mInputManager);

--- a/source/modes/InputManager.cpp
+++ b/source/modes/InputManager.cpp
@@ -36,6 +36,7 @@ InputManager::InputManager(Ogre::RenderWindow* renderWindow):
     mLStartDragY(0),
     mRStartDragX(0),
     mRStartDragY(0),
+    mSeatIdSelected(0),
     mCommandState(InputCommandState::infoOnly)
 {
     LogManager::getSingleton().logMessage("*** Initializing OIS - Input Manager ***");

--- a/source/modes/InputManager.h
+++ b/source/modes/InputManager.h
@@ -59,6 +59,8 @@ public:
     int                 mXPos, mYPos;
     int                 mLStartDragX, mLStartDragY;
     int                 mRStartDragX, mRStartDragY;
+    //! \brief In editor mode, it contains the selected seat Id. In gamemode, it is not used
+    int                 mSeatIdSelected;
     InputCommandState   mCommandState;
 };
 

--- a/source/modes/InputManager.h
+++ b/source/modes/InputManager.h
@@ -32,6 +32,13 @@ namespace Ogre
   class RenderWindow;
 }
 
+enum class InputCommandState
+{
+    infoOnly, // When the player is only moving mouse (but not building)
+    building, // When the player is building (but has not validated he build)
+    validated // When the player is happy with the build and wants to build
+};
+
 class InputManager
 {
 public:
@@ -52,6 +59,7 @@ public:
     int                 mXPos, mYPos;
     int                 mLStartDragX, mLStartDragY;
     int                 mRStartDragX, mRStartDragY;
+    InputCommandState   mCommandState;
 };
 
 #endif // INPUTMANAGER_H

--- a/source/modes/MenuModeEditor.cpp
+++ b/source/modes/MenuModeEditor.cpp
@@ -191,7 +191,7 @@ bool MenuModeEditor::launchSelectedButtonPressed(const CEGUI::EventArgs&)
     // In single player mode, we act as a server
     if(!ODServer::getSingleton().startServer(level, ServerMode::ModeEditor))
     {
-        LogManager::getSingleton().logMessage("ERROR: Could not start server for editor !!!");
+        OD_LOG_ERR("Could not start server for editor !!!");
         tmpWin = getModeManager().getGui().getGuiSheet(Gui::editorMenu)->getChild(Gui::EDM_TEXT_LOADING);
         tmpWin->setText("ERROR: Could not start server for editor !!!");
         tmpWin->show();
@@ -199,7 +199,7 @@ bool MenuModeEditor::launchSelectedButtonPressed(const CEGUI::EventArgs&)
 
     if(!ODClient::getSingleton().connect("localhost", ConfigManager::getSingleton().getNetworkPort()))
     {
-        LogManager::getSingleton().logMessage("ERROR: Could not connect to server for editor !!!");
+        OD_LOG_ERR("Could not connect to server for editor !!!");
         tmpWin = getModeManager().getGui().getGuiSheet(Gui::editorMenu)->getChild(Gui::EDM_TEXT_LOADING);
         tmpWin->setText("Error: Couldn't connect to local server!");
         tmpWin->show();

--- a/source/modes/MenuModeLoad.cpp
+++ b/source/modes/MenuModeLoad.cpp
@@ -142,7 +142,7 @@ bool MenuModeLoad::launchSelectedButtonPressed(const CEGUI::EventArgs&)
     // In single player mode, we act as a server
     if(!ODServer::getSingleton().startServer(level, ServerMode::ModeGameLoaded))
     {
-        LogManager::getSingleton().logMessage("ERROR: Could not start server for single player game !!!");
+        OD_LOG_ERR("Could not start server for single player game !!!");
         tmpWin = getModeManager().getGui().getGuiSheet(Gui::loadSavedGameMenu)->getChild("LoadingText");
         tmpWin->setText("ERROR: Could not start server for single player game !!!");
         tmpWin->show();
@@ -151,7 +151,7 @@ bool MenuModeLoad::launchSelectedButtonPressed(const CEGUI::EventArgs&)
 
     if(!ODClient::getSingleton().connect("localhost", ConfigManager::getSingleton().getNetworkPort()))
     {
-        LogManager::getSingleton().logMessage("ERROR: Could not connect to server for single player game !!!");
+        OD_LOG_ERR("Could not connect to server for single player game !!!");
         tmpWin = getModeManager().getGui().getGuiSheet(Gui::loadSavedGameMenu)->getChild("LoadingText");
         tmpWin->setText("Error: Couldn't connect to local server!");
         tmpWin->show();
@@ -179,7 +179,7 @@ bool MenuModeLoad::deleteSelectedButtonPressed(const CEGUI::EventArgs&)
     const std::string& levelFile = mFilesList[id];
     if(!boost::filesystem::remove(levelFile))
     {
-        LogManager::getSingleton().logMessage("ERROR: Could not delete saved game !!!");
+        OD_LOG_ERR("Could not delete saved game !!!");
         tmpWin = getModeManager().getGui().getGuiSheet(Gui::loadSavedGameMenu)->getChild("LoadingText");
         tmpWin->setText("Error: Couldn't delete saved game!");
         tmpWin->show();

--- a/source/modes/MenuModeMultiplayerServer.cpp
+++ b/source/modes/MenuModeMultiplayerServer.cpp
@@ -179,7 +179,7 @@ bool MenuModeMultiplayerServer::serverButtonPressed(const CEGUI::EventArgs&)
     // We are a server
     if(!ODServer::getSingleton().startServer(level, ServerMode::ModeGameMultiPlayer))
     {
-        LogManager::getSingleton().logMessage("ERROR: Could not start server for multi player game !!!");
+        OD_LOG_ERR("Could not start server for multi player game !!!");
         tmpWin = getModeManager().getGui().getGuiSheet(Gui::multiplayerServerMenu)->getChild(Gui::MPM_TEXT_LOADING);
         tmpWin->setText("ERROR: Could not start server for multi player game !!!");
         tmpWin->show();
@@ -189,7 +189,7 @@ bool MenuModeMultiplayerServer::serverButtonPressed(const CEGUI::EventArgs&)
     // We connect ourself
     if(!ODClient::getSingleton().connect("localhost", ConfigManager::getSingleton().getNetworkPort()))
     {
-        LogManager::getSingleton().logMessage("ERROR: Could not connect to server for multi player game !!!");
+        OD_LOG_ERR("Could not connect to server for multi player game !!!");
         tmpWin = getModeManager().getGui().getGuiSheet(Gui::multiplayerServerMenu)->getChild(Gui::MPM_TEXT_LOADING);
         tmpWin->setText("Error: Couldn't connect to local server!");
         tmpWin->show();

--- a/source/modes/MenuModeReplay.cpp
+++ b/source/modes/MenuModeReplay.cpp
@@ -151,7 +151,7 @@ bool MenuModeReplay::launchSelectedButtonPressed(const CEGUI::EventArgs&)
     const std::string& replayFile = mFilesList[id];
     if(!ODClient::getSingleton().replay(replayFile))
     {
-        LogManager::getSingleton().logMessage("ERROR: Could not launch replay !!!");
+        OD_LOG_ERR("Could not launch replay !!!");
         tmpWin = getModeManager().getGui().getGuiSheet(Gui::replayMenu)->getChild(Gui::REM_TEXT_LOADING);
         tmpWin->setText("Error: Couldn't launch replay!");
         tmpWin->show();
@@ -179,7 +179,7 @@ bool MenuModeReplay::deleteSelectedButtonPressed(const CEGUI::EventArgs&)
     const std::string& replayFile = mFilesList[id];
     if(!boost::filesystem::remove(replayFile))
     {
-        LogManager::getSingleton().logMessage("ERROR: Could not delete replay !!!");
+        OD_LOG_ERR("Could not delete replay !!!");
         tmpWin = getModeManager().getGui().getGuiSheet(Gui::replayMenu)->getChild(Gui::REM_TEXT_LOADING);
         tmpWin->setText("Error: Couldn't delete replay!");
         tmpWin->show();

--- a/source/modes/MenuModeSkirmish.cpp
+++ b/source/modes/MenuModeSkirmish.cpp
@@ -198,7 +198,7 @@ bool MenuModeSkirmish::launchSelectedButtonPressed(const CEGUI::EventArgs&)
     // In single player mode, we act as a server
     if(!ODServer::getSingleton().startServer(level, ServerMode::ModeGameSinglePlayer))
     {
-        LogManager::getSingleton().logMessage("ERROR: Could not start server for single player game !!!");
+        OD_LOG_ERR("Could not start server for single player game !!!");
         tmpWin = getModeManager().getGui().getGuiSheet(Gui::skirmishMenu)->getChild(Gui::SKM_TEXT_LOADING);
         tmpWin->setText("ERROR: Could not start server for single player game !!!");
         tmpWin->show();
@@ -207,7 +207,7 @@ bool MenuModeSkirmish::launchSelectedButtonPressed(const CEGUI::EventArgs&)
 
     if(!ODClient::getSingleton().connect("localhost", ConfigManager::getSingleton().getNetworkPort()))
     {
-        LogManager::getSingleton().logMessage("ERROR: Could not connect to server for single player game !!!");
+        OD_LOG_ERR("Could not connect to server for single player game !!!");
         tmpWin = getModeManager().getGui().getGuiSheet(Gui::skirmishMenu)->getChild(Gui::SKM_TEXT_LOADING);
         tmpWin->setText("Error: Couldn't connect to local server!");
         tmpWin->show();

--- a/source/network/ClientNotification.cpp
+++ b/source/network/ClientNotification.cpp
@@ -86,7 +86,7 @@ std::string ClientNotification::typeString(ClientNotificationType type)
         case ClientNotificationType::editorAskCreateMapLight:
             return "editorAskCreateMapLight";
         default:
-            LogManager::getSingleton().logMessage("ERROR: Unknown enum for ClientNotificationType="
+            OD_LOG_ERR("Unknown enum for ClientNotificationType="
                 + Helper::toString(static_cast<int>(type)));
     }
     return "";

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -84,9 +84,6 @@ bool ODClient::processOneClientSocketMessage()
     if(!isDataAvailable())
         return false;
 
-    // Get a reference to the LogManager
-    LogManager& logManager = LogManager::getSingleton();
-
     ODPacket packetReceived;
 
     // Check if data available
@@ -345,7 +342,7 @@ bool ODClient::processOneClientSocketMessage()
             OD_ASSERT_TRUE(packetReceived >> serverMode);
 
             // Now that the we have received all needed information, we can launch the requested mode
-            LogManager::getSingleton().logMessage("Starting game map");
+            OD_LOG_INF("Starting game map");
             gameMap->setGamePaused(false);
             // Create ogre entities for the tiles, rooms, and creatures
             gameMap->createAllEntities();
@@ -451,7 +448,7 @@ bool ODClient::processOneClientSocketMessage()
         {
             int64_t turnNum;
             OD_ASSERT_TRUE(packetReceived >> turnNum);
-            logManager.logMessage("Client (" + getPlayer()->getNick() + ") received turnStarted="
+            OD_LOG_INF("Client (" + getPlayer()->getNick() + ") received turnStarted="
                 + boost::lexical_cast<std::string>(turnNum));
 
             gameMap->clientUpKeep(turnNum);
@@ -947,7 +944,7 @@ bool ODClient::processOneClientSocketMessage()
 
         default:
         {
-            logManager.logMessage("ERROR:  Unknown server command:"
+            OD_LOG_ERR("Unknown server command:"
                 + Helper::toString(static_cast<int>(serverCommand)));
             break;
         }
@@ -1037,12 +1034,11 @@ void ODClient::sendToServer(ODPacket& packetToSend)
 
 bool ODClient::connect(const std::string& host, const int port)
 {
-    LogManager& logManager = LogManager::getSingleton();
     mIsPlayerConfig = false;
     // Start the server socket listener as well as the server socket thread
     if (ODClient::getSingleton().isConnected())
     {
-        logManager.logMessage("Couldn't try to connect: The client is already connected");
+        OD_LOG_INF("Couldn't try to connect: The client is already connected");
         return false;
     }
 
@@ -1060,12 +1056,11 @@ bool ODClient::connect(const std::string& host, const int port)
 
 bool ODClient::replay(const std::string& filename)
 {
-    LogManager& logManager = LogManager::getSingleton();
     mIsPlayerConfig = false;
     // Start the server socket listener as well as the server socket thread
     if (ODClient::getSingleton().isConnected())
     {
-        logManager.logMessage("Couldn't try to launch replay: The client is already connected");
+        OD_LOG_INF("Couldn't try to launch replay: The client is already connected");
         return false;
     }
 

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -345,6 +345,11 @@ bool ODClient::processOneClientSocketMessage()
             OD_ASSERT_TRUE(packetReceived >> serverMode);
 
             // Now that the we have received all needed information, we can launch the requested mode
+            LogManager::getSingleton().logMessage("Starting game map");
+            gameMap->setGamePaused(false);
+            // Create ogre entities for the tiles, rooms, and creatures
+            gameMap->createAllEntities();
+
             switch(serverMode)
             {
                 case ServerMode::ModeGameSinglePlayer:

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -1272,7 +1272,8 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
 
         case ClientNotificationType::askSellTrapTiles:
         {
-            TrapManager::sellTrapTilesEditor(gameMap, packetReceived);
+            Player* player = clientSocket->getPlayer();
+            TrapManager::sellTrapTiles(gameMap, player->getSeat(), packetReceived);
             break;
         }
 

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -1273,10 +1273,9 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
 
         case ClientNotificationType::askCastSpell:
         {
-            int x1, y1, x2, y2;
             SpellType spellType;
 
-            OD_ASSERT_TRUE(packetReceived >> x1 >> y1 >> x2 >> y2 >> spellType);
+            OD_ASSERT_TRUE(packetReceived >> spellType);
             Player* player = clientSocket->getPlayer();
 
             // We check if the spell is available. It is not normal to receive a message
@@ -1298,17 +1297,9 @@ bool ODServer::processClientNotifications(ODSocketClient* clientSocket)
                 break;
             }
 
-            std::vector<EntityBase*> targets;
-            int manaRequired = SpellManager::getSpellCost(targets, gameMap, spellType, x1, y1, x2, y2, player);
-
-            // If there are no suitable targets, we do not cast the spell (and, thus, do not decrease mana or trigger countdown
-            if(targets.empty())
+            if(!SpellManager::castSpell(gameMap, spellType, player, packetReceived))
                 break;
 
-            if(!player->getSeat()->takeMana(manaRequired))
-                break;
-
-            SpellManager::castSpell(mGameMap, spellType, targets, player);
             break;
         }
 

--- a/source/network/ODSocketClient.cpp
+++ b/source/network/ODSocketClient.cpp
@@ -161,7 +161,7 @@ ODSocketClient::ODComStatus ODSocketClient::recv(ODPacket& s)
         case ODSource::none:
         {
             // We should not try to send anything until connected
-            OD_ASSERT_TRUE(false);
+            OD_LOG_ERR("Unexpected null server mode");
             return ODComStatus::Error;
         }
         case ODSource::network:

--- a/source/network/ODSocketClient.cpp
+++ b/source/network/ODSocketClient.cpp
@@ -35,13 +35,13 @@ bool ODSocketClient::connect(const std::string& host, const int port)
     sf::Socket::Status status = mSockClient.connect(host, port, sf::milliseconds(timeout));
     if (status != sf::Socket::Done)
     {
-        LogManager::getSingleton().logMessage("ERROR : Could not connect to distant server status="
+        OD_LOG_ERR("Could not connect to distant server status="
             + Helper::toString(status));
         mSockClient.disconnect();
         return false;
     }
     mSockSelector.add(mSockClient);
-    LogManager::getSingleton().logMessage("Connected to server successfully");
+    OD_LOG_INF("Connected to server successfully");
     static std::locale loc(std::wcout.getloc(), new boost::posix_time::time_facet("%Y%m%d_%H%M%S"));
     std::ostringstream ss;
     ss.imbue(loc);
@@ -56,7 +56,7 @@ bool ODSocketClient::connect(const std::string& host, const int port)
 
 bool ODSocketClient::replay(const std::string& filename)
 {
-    LogManager::getSingleton().logMessage("Reading replay from file " + filename);
+    OD_LOG_INF("Reading replay from file " + filename);
     mReplayInputStream.open(filename, std::ios::in | std::ios::binary);
     mGameClock.restart();
     mSource = ODSource::file;
@@ -149,7 +149,7 @@ ODSocketClient::ODComStatus ODSocketClient::send(ODPacket& s)
     if (status == sf::Socket::Done)
         return ODComStatus::OK;
 
-    LogManager::getSingleton().logMessage("ERROR : Could not send data from client status="
+    OD_LOG_ERR("Could not send data from client status="
         + Helper::toString(status));
     return ODComStatus::Error;
 }
@@ -178,7 +178,7 @@ ODSocketClient::ODComStatus ODSocketClient::recv(ODPacket& s)
             {
                     return ODComStatus::NotReady;
             }
-            LogManager::getSingleton().logMessage("ERROR : Could not receive data from client status="
+            OD_LOG_ERR("Could not receive data from client status="
                 + Helper::toString(status));
             return ODComStatus::Error;
         }

--- a/source/network/ODSocketServer.cpp
+++ b/source/network/ODSocketServer.cpp
@@ -45,7 +45,7 @@ bool ODSocketServer::createServer(int listeningPort)
     sf::Socket::Status status = mSockListener.listen(listeningPort);
     if (status != sf::Socket::Done)
     {
-        LogManager::getSingleton().logMessage("ERROR : Could not listen to server port status="
+        OD_LOG_ERR("Could not listen to server port status="
             + Helper::toString(status));
         return false;
     }
@@ -53,7 +53,7 @@ bool ODSocketServer::createServer(int listeningPort)
     mSockSelector.add(mSockListener);
     mNewClient = new ODSocketClient;
     mIsConnected = true;
-    LogManager::getSingleton().logMessage("Server connected and listening");
+    OD_LOG_INF("Server connected and listening");
     mThread = new sf::Thread(&ODSocketServer::serverThread, this);
     mThread->launch();
 
@@ -96,7 +96,7 @@ void ODSocketServer::doTask(int timeoutMs)
             if (status == sf::Socket::Done)
             {
                 // New connection
-                LogManager::getSingleton().logMessage("New client connected.");
+                OD_LOG_INF("New client connected.");
                 if(notifyNewConnection(mNewClient))
                 {
                     // The server wants to keep the client
@@ -105,17 +105,17 @@ void ODSocketServer::doTask(int timeoutMs)
                     mSockClients.push_back(mNewClient);
 
                     mNewClient = new ODSocketClient;
-                    LogManager::getSingleton().logMessage("New client accepted.");
+                    OD_LOG_INF("New client accepted.");
                 }
                 else
                 {
-                    LogManager::getSingleton().logMessage("New client refused.");
+                    OD_LOG_INF("New client refused.");
                 }
             }
             else
             {
                 // Error
-                LogManager::getSingleton().logMessage("ERROR : Could not listen to server port error="
+                OD_LOG_ERR("Could not listen to server port error="
                     + Helper::toString(status));
             }
         }

--- a/source/network/ServerNotification.cpp
+++ b/source/network/ServerNotification.cpp
@@ -115,7 +115,7 @@ std::string ServerNotification::typeString(ServerNotificationType type)
         case ServerNotificationType::exit:
             return "exit";
         default:
-            LogManager::getSingleton().logMessage("ERROR: Unknown enum for ServerNotificationType="
+            OD_LOG_ERR("Unknown enum for ServerNotificationType="
                 + Helper::toString(static_cast<int>(type)));
     }
     return "";

--- a/source/render/CreatureOverlayStatus.cpp
+++ b/source/render/CreatureOverlayStatus.cpp
@@ -145,7 +145,7 @@ void CreatureOverlayStatus::updateStatus(Ogre::Real timeSincelastFrame)
             {
                 // We have looped without finding a fitting status. That is not normal since creature mood
                 // value is not 0 and we are supposed to have tried every bit
-                OD_ASSERT_TRUE_MSG(false, "mStatus=" + Helper::toString(mStatus) + ", CreatureOverlayMoodValue=" + Helper::toString(mCreature->getOverlayMoodValue()));
+                OD_LOG_ERR("mStatus=" + Helper::toString(mStatus) + ", CreatureOverlayMoodValue=" + Helper::toString(mCreature->getOverlayMoodValue()));
                 mStatus = 0;
                 return;
             }

--- a/source/render/CreatureOverlayStatus.h
+++ b/source/render/CreatureOverlayStatus.h
@@ -20,6 +20,8 @@
 
 #include <OgrePrerequisites.h>
 
+#include <cstdint>
+
 class Creature;
 class MovableTextOverlay;
 class Seat;

--- a/source/render/MovableTextOverlay.cpp
+++ b/source/render/MovableTextOverlay.cpp
@@ -35,7 +35,11 @@ ChildOverlay::ChildOverlay(const Ogre::String& fontName, Ogre::Real charHeight,
     mTimeToDisplay(0),
     mFont(dynamic_cast<Ogre::Font*>(Ogre::FontManager::getSingleton().getByName(fontName).getPointer()))
 {
-    OD_ASSERT_TRUE_MSG(mFont != nullptr, "fontName=" + fontName);
+    if(mFont == nullptr)
+    {
+        OD_LOG_ERR("fontName=" + fontName);
+        return;
+    }
     mFont->load();
 }
 
@@ -196,7 +200,7 @@ void MovableTextOverlay::setCaption(uint32_t childOverlayId, const Ogre::String&
 {
     if(childOverlayId >= mChildOverlays.size())
     {
-        OD_ASSERT_TRUE_MSG(false, "childOverlayId=" + Helper::toString(childOverlayId));
+        OD_LOG_ERR("childOverlayId=" + Helper::toString(childOverlayId));
         return;
     }
 
@@ -208,7 +212,7 @@ void MovableTextOverlay::forceTextArea(uint32_t childOverlayId, Ogre::Real textW
 {
     if(childOverlayId >= mChildOverlays.size())
     {
-        OD_ASSERT_TRUE_MSG(false, "childOverlayId=" + Helper::toString(childOverlayId));
+        OD_LOG_ERR("childOverlayId=" + Helper::toString(childOverlayId));
         return;
     }
 
@@ -220,7 +224,7 @@ void MovableTextOverlay::setMaterialName(uint32_t childOverlayId, const Ogre::St
 {
     if(childOverlayId >= mChildOverlays.size())
     {
-        OD_ASSERT_TRUE_MSG(false, "childOverlayId=" + Helper::toString(childOverlayId));
+        OD_LOG_ERR("childOverlayId=" + Helper::toString(childOverlayId));
         return;
     }
 
@@ -259,7 +263,7 @@ void MovableTextOverlay::displayOverlay(uint32_t childOverlayId, Ogre::Real time
 {
     if(childOverlayId >= mChildOverlays.size())
     {
-        OD_ASSERT_TRUE_MSG(false, "childOverlayId=" + Helper::toString(childOverlayId));
+        OD_LOG_ERR("childOverlayId=" + Helper::toString(childOverlayId));
         return;
     }
 

--- a/source/render/ODFrameListener.cpp
+++ b/source/render/ODFrameListener.cpp
@@ -80,8 +80,7 @@ ODFrameListener::ODFrameListener(Ogre::RenderWindow* renderWindow, Ogre::Overlay
     mCameraManager(mRenderManager->getSceneManager(), mGameMap.get(), renderWindow),
     mFpsLimiter(DEFAULT_FRAME_RATE)
 {
-    LogManager* logManager = LogManager::getSingletonPtr();
-    logManager->logMessage("Creating frame listener...");
+    OD_LOG_INF("Creating frame listener...");
 
     mRenderManager->createScene(mCameraManager.getViewport());
 
@@ -128,18 +127,18 @@ void ODFrameListener::requestExit()
 
 void ODFrameListener::exitApplication()
 {
-    LogManager::getSingleton().logMessage("Closing down.");
+    OD_LOG_INF("Closing down.");
 
     ODClient::getSingleton().notifyExit();
     ODServer::getSingleton().notifyExit();
     mGameMap->clearAll();
     mRenderManager->getSceneManager()->destroyQuery(mRaySceneQuery);
 
-    Ogre::LogManager::getSingleton().logMessage("Remove listener registration");
+    OD_LOG_INF("Remove listener registration");
     //Remove ourself as a Window listener
     Ogre::WindowEventUtilities::removeWindowEventListener(mWindow, this);
 
-    Ogre::LogManager::getSingleton().logMessage("Frame listener uninitialization done.");
+    OD_LOG_INF("Frame listener uninitialization done.");
     mInitialized = false;
 }
 

--- a/source/render/ODFrameListener.cpp
+++ b/source/render/ODFrameListener.cpp
@@ -27,7 +27,6 @@
 #include "gamemap/GameMap.h"
 #include "modes/AbstractApplicationMode.h"
 #include "modes/ModeManager.h"
-#include "modes/GameMode.h"
 #include "network/ODServer.h"
 #include "network/ODClient.h"
 #include "render/Gui.h"

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -112,7 +112,7 @@ void RenderManager::triggerCompositor(const std::string& compositorName)
 
 void RenderManager::createScene(Ogre::Viewport* nViewport)
 {
-    LogManager::getSingleton().logMessage("Creating scene...");
+    OD_LOG_INF("Creating scene...");
 
     mViewport = nViewport;
 
@@ -449,7 +449,7 @@ void RenderManager::rrUpdateEntityOpacity(RenderedMovableEntity* entity)
     Ogre::Entity* ogreEnt = mSceneManager->hasEntity(entStr) ? mSceneManager->getEntity(entStr) : nullptr;
     if (ogreEnt == nullptr)
     {
-        LogManager::getSingleton().logMessage("Update opacity: Couldn't find entity: " + entStr);
+        OD_LOG_INF("Update opacity: Couldn't find entity: " + entStr);
         return;
     }
 
@@ -551,7 +551,7 @@ void RenderManager::rrCreateWeapon(Creature* curCreature, const Weapon* curWeapo
     std::string weaponName = curWeapon->getOgreNamePrefix() + hand;
     if(!ent->getSkeleton()->hasBone(weaponName))
     {
-        LogManager::getSingleton().logMessage("WARNING: Tried to add weapons to entity \"" + ent->getName() + " \" using model \"" +
+        OD_LOG_INF("WARNING: Tried to add weapons to entity \"" + ent->getName() + " \" using model \"" +
                               ent->getMesh()->getName() + "\" that is missing the required bone \"" +
                               curWeapon->getOgreNamePrefix() + hand + "\"");
         return;
@@ -993,7 +993,7 @@ std::string RenderManager::colourizeMaterial(const std::string& materialName, co
                                                  newMaterial->getName(), newMaterial->getGroup());
     if(!cloned)
     {
-        LogManager::getSingleton().logMessage("Failed to clone rtss for material: " + materialName, LogMessageLevel::CRITICAL);
+        OD_LOG_ERR("Failed to clone rtss for material: " + materialName);
     }
 
     // Loop over the techniques for the new material
@@ -1132,7 +1132,7 @@ std::string RenderManager::setMaterialOpacity(const std::string& materialName, f
                                                                newMaterial->getName(), newMaterial->getGroup());
     if(!cloned)
     {
-        LogManager::getSingleton().logMessage("Failed to clone rtss for material: " + materialName, LogMessageLevel::CRITICAL);
+        OD_LOG_ERR("Failed to clone rtss for material: " + materialName);
     }
 
     // Loop over the techniques for the new material

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -538,9 +538,11 @@ void RenderManager::rrOrientEntityToward(MovableGameEntity* gameEntity, const Og
 
 void RenderManager::rrScaleEntity(GameEntity* entity)
 {
-    OD_ASSERT_TRUE_MSG(entity->getEntityNode() != nullptr, "entity=" + entity->getName());
     if(entity->getEntityNode() == nullptr)
+    {
+        OD_LOG_ERR("entity=" + entity->getName());
         return;
+    }
 
     entity->getEntityNode()->setScale(entity->getScale());
 }
@@ -870,18 +872,22 @@ void RenderManager::rrSetObjectAnimationState(MovableGameEntity* curAnimatedObje
 }
 void RenderManager::rrMoveEntity(GameEntity* entity, const Ogre::Vector3& position)
 {
-    OD_ASSERT_TRUE_MSG(entity->getEntityNode() != nullptr, "Entity do not have node=" + entity->getName());
     if(entity->getEntityNode() == nullptr)
+    {
+        OD_LOG_ERR("Entity do not have node=" + entity->getName());
         return;
+    }
 
     entity->getEntityNode()->setPosition(position);
 }
 
 void RenderManager::rrMoveMapLightFlicker(MapLight* mapLight, const Ogre::Vector3& position)
 {
-    OD_ASSERT_TRUE_MSG(mapLight->getFlickerNode() != nullptr, "MapLight do not have flicker=" + mapLight->getName());
     if(mapLight->getFlickerNode() == nullptr)
+    {
+        OD_LOG_ERR("MapLight do not have flicker=" + mapLight->getName());
         return;
+    }
 
     mapLight->getFlickerNode()->setPosition(position);
 }
@@ -1236,7 +1242,7 @@ std::string RenderManager::rrBuildSkullFlagMaterial(const std::string& materialN
     if(!mShaderGenerator->cloneShaderBasedTechniques(oldMaterial->getName(), oldMaterial->getGroup(),
             newMaterial->getName(), newMaterial->getGroup()))
     {
-        OD_ASSERT_TRUE_MSG(false, "Failed to clone rtss for material: " + materialNameBase);
+        OD_LOG_ERR("Failed to clone rtss for material: " + materialNameBase);
     }
 
     for (unsigned int j = 0; j < newMaterial->getNumTechniques(); ++j)

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -80,13 +80,11 @@ RenderManager::RenderManager(Ogre::OverlaySystem* overlaySystem) :
     mViewport(nullptr),
     mShaderGenerator(nullptr),
     mHandLight(nullptr),
-    mHandSquareSelectorNode(nullptr),
     mHandKeeperMesh(nullptr),
     mCurrentFOVy(0.0f),
     mFactorWidth(0.0f),
     mFactorHeight(0.0f),
     mCreatureTextOverlayDisplayed(false),
-    mHandSquareSelectorVisibility(0),
     mHandKeeperHandVisibility(0)
 {
     // Use Ogre::SceneType enum instead of string to identify the scene manager type; this is more robust!
@@ -138,21 +136,12 @@ void RenderManager::createScene(Ogre::Viewport* nViewport)
     // Sets the overall world lighting.
     mSceneManager->setAmbientLight(Ogre::ColourValue(0.3, 0.3, 0.3));
 
-    // Create the scene nodes that will follow the mouse pointer.
-    // Create the single tile selection mesh
-    Ogre::Entity* squareSelectorEnt = mSceneManager->createEntity("SquareSelector", "SquareSelector.mesh");
-    squareSelectorEnt->setLightMask(0);
-    squareSelectorEnt->setCastShadows(false);
-    mHandSquareSelectorNode = mSceneManager->getRootSceneNode()->createChildSceneNode("SquareSelectorNode");
-    mHandSquareSelectorNode->translate(Ogre::Vector3(0, 0, 0));
-    mHandSquareSelectorNode->scale(Ogre::Vector3(BLENDER_UNITS_PER_OGRE_UNIT,
-                              BLENDER_UNITS_PER_OGRE_UNIT, 0.45 * BLENDER_UNITS_PER_OGRE_UNIT));
-    mHandSquareSelectorNode->attachObject(squareSelectorEnt);
-    Ogre::SceneNode *node2 = mHandSquareSelectorNode->createChildSceneNode("Hand_node");
-    node2->setPosition(static_cast<Ogre::Real>(0.0),
+    // Create the nodes that will follow the mouse pointer.
+    Ogre::SceneNode *handNode = mSceneManager->getRootSceneNode()->createChildSceneNode("Hand_node");
+    handNode->setPosition(static_cast<Ogre::Real>(0.0),
                        static_cast<Ogre::Real>(0.0 / BLENDER_UNITS_PER_OGRE_UNIT),
                        static_cast<Ogre::Real>(3.0 / BLENDER_UNITS_PER_OGRE_UNIT));
-    node2->scale(Ogre::Vector3(static_cast<Ogre::Real>(1.0 / BLENDER_UNITS_PER_OGRE_UNIT),
+    handNode->scale(Ogre::Vector3(static_cast<Ogre::Real>(1.0 / BLENDER_UNITS_PER_OGRE_UNIT),
                                static_cast<Ogre::Real>(1.0 / BLENDER_UNITS_PER_OGRE_UNIT),
                                static_cast<Ogre::Real>(1.0 / BLENDER_UNITS_PER_OGRE_UNIT)));
 
@@ -195,7 +184,6 @@ void RenderManager::createScene(Ogre::Viewport* nViewport)
     mHandLight->setPosition(0.0f, 0.0f, KEEPER_HAND_WORLD_Z);
     mHandLight->setAttenuation(7, 1.0, 0.00, 0.3);
 
-    mHandSquareSelectorNode->setVisible(mHandSquareSelectorVisibility == 0);
     mHandKeeperMesh->setVisible(mHandKeeperHandVisibility == 0);
 }
 
@@ -1094,17 +1082,11 @@ void RenderManager::rrTemporaryDisplayCreaturesTextOverlay(Creature* creature, O
 
 void RenderManager::rrToggleHandSelectorVisibility()
 {
-    if((mHandSquareSelectorVisibility & 0x01) == 0)
-        mHandSquareSelectorVisibility |= 0x01;
-    else
-        mHandSquareSelectorVisibility &= ~0x01;
-
     if((mHandKeeperHandVisibility & 0x01) == 0)
         mHandKeeperHandVisibility |= 0x01;
     else
         mHandKeeperHandVisibility &= ~0x01;
 
-    mHandSquareSelectorNode->setVisible(mHandSquareSelectorVisibility == 0);
     mHandKeeperMesh->setVisible(mHandKeeperHandVisibility == 0);
 }
 
@@ -1224,11 +1206,6 @@ void RenderManager::moveCursor(float relX, float relY)
 void RenderManager::moveWorldCoords(Ogre::Real x, Ogre::Real y)
 {
     mHandLight->setPosition(x, y, KEEPER_HAND_WORLD_Z);
-}
-
-void RenderManager::setHoveredTile(int tileX, int tileY)
-{
-    mHandSquareSelectorNode->setPosition(static_cast<Ogre::Real>(tileX), static_cast<Ogre::Real>(tileY), 0.0f);
 }
 
 void RenderManager::entitySlapped()

--- a/source/render/RenderManager.h
+++ b/source/render/RenderManager.h
@@ -82,7 +82,6 @@ public:
     //!  moveWorldCoords sends the world coords where the map light is
     void moveCursor(float relX, float relY);
     void moveWorldCoords(Ogre::Real x, Ogre::Real y);
-    void setHoveredTile(int tileX, int tileY);
     void entitySlapped();
 
     static const Ogre::Real BLENDER_UNITS_PER_OGRE_UNIT;
@@ -166,7 +165,6 @@ private:
 
     //! For the keeper hand
     Ogre::Light* mHandLight;
-    Ogre::SceneNode* mHandSquareSelectorNode;
     Ogre::SceneNode* mHandKeeperMesh;
     Ogre::Radian mCurrentFOVy;
     Ogre::Real mFactorWidth;
@@ -175,8 +173,7 @@ private:
     //! \brief True if the creatures are currently displaying their text overlay
     bool mCreatureTextOverlayDisplayed;
 
-    //! Bit array to allow to display tile selector/hand (= 0) or not (!= 0)
-    uint32_t mHandSquareSelectorVisibility;
+    //! Bit array to allow to display tile hand (= 0) or not (!= 0)
     uint32_t mHandKeeperHandVisibility;
 };
 

--- a/source/render/RenderManager.h
+++ b/source/render/RenderManager.h
@@ -135,6 +135,9 @@ public:
 
 private:
 
+    //! \brief Correctly places entities in hand next to the keeper hand
+    void rrOrderHand(Player* localPlayer);
+
     //! \brief Colorize the material with the corresponding team id color.
     //! \note If the material (wall tiles only) is marked for digging, a yellow color is added
     //! to the given color.
@@ -164,8 +167,8 @@ private:
     Ogre::RTShader::ShaderGenerator* mShaderGenerator;
 
     //! For the keeper hand
-    Ogre::Light* mHandLight;
-    Ogre::SceneNode* mHandKeeperMesh;
+    Ogre::SceneNode* mHandKeeperNode;
+    Ogre::SceneNode* mHandKeeperPickupNode;
     Ogre::Radian mCurrentFOVy;
     Ogre::Real mFactorWidth;
     Ogre::Real mFactorHeight;

--- a/source/rooms/Room.cpp
+++ b/source/rooms/Room.cpp
@@ -79,7 +79,7 @@ void Room::removeFromGameMap()
 
 void Room::absorbRoom(Room *r)
 {
-    LogManager::getSingleton().logMessage(getGameMap()->serverStr() + "Room=" + getName() + " is absorbing room=" + r->getName());
+    OD_LOG_INF(getGameMap()->serverStr() + "Room=" + getName() + " is absorbing room=" + r->getName());
 
     mCentralActiveSpotTiles.insert(mCentralActiveSpotTiles.end(), r->mCentralActiveSpotTiles.begin(), r->mCentralActiveSpotTiles.end());
     r->mCentralActiveSpotTiles.clear();
@@ -629,7 +629,7 @@ void Room::repairRoom()
         if(!tile->isBuildableUpon(getSeat()))
             continue;
 
-        LogManager::getSingleton().logMessage("Repairing room=" + getName() + ", tile=" + Tile::displayAsString(tile));
+        OD_LOG_INF("Repairing room=" + getName() + ", tile=" + Tile::displayAsString(tile));
 
         mCoveredTiles.push_back(tile);
         TileData* tileData;

--- a/source/rooms/Room.cpp
+++ b/source/rooms/Room.cpp
@@ -102,7 +102,7 @@ void Room::absorbRoom(Room *r)
             creature->changeEatRoom(this);
         else
         {
-            OD_ASSERT_TRUE_MSG(false, "creature=" + creature->getName() + ", oldRoom=" + r->getName() + ", newRoom=" + getName());
+            OD_LOG_ERR("creature=" + creature->getName() + ", oldRoom=" + r->getName() + ", newRoom=" + getName());
         }
     }
     mCreaturesUsingRoom.insert(mCreaturesUsingRoom.end(), r->mCreaturesUsingRoom.begin(), r->mCreaturesUsingRoom.end());
@@ -531,7 +531,7 @@ void Room::importTileDataFromStream(std::istream& is, Tile* tile, TileData* tile
         Seat* seat = gameMap->getSeatById(seatId);
         if(seat == nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "room=" + getName() + ", seatId=" + Helper::toString(seatId));
+            OD_LOG_ERR("room=" + getName() + ", seatId=" + Helper::toString(seatId));
             continue;
         }
         tileData->mSeatsVision.push_back(seat);
@@ -733,13 +733,13 @@ bool Room::getRoomTilesDefault(std::vector<Tile*>& tiles, GameMap* gameMap, Play
         Tile* tile = gameMap->tileFromPacket(packet);
         if(tile == nullptr)
         {
-            OD_ASSERT_TRUE(false);
+            OD_LOG_ERR("unexpected null tile");
             return false;
         }
 
         if(!tile->isBuildableUpon(player->getSeat()))
         {
-            OD_ASSERT_TRUE_MSG(false, "tile=" + Tile::displayAsString(tile) + ", seatId=" + Helper::toString(player->getSeat()->getId()));
+            OD_LOG_ERR("tile=" + Tile::displayAsString(tile) + ", seatId=" + Helper::toString(player->getSeat()->getId()));
             continue;
         }
 
@@ -851,7 +851,7 @@ bool Room::buildRoomDefaultEditor(GameMap* gameMap, Room* room, ODPacket& packet
     Seat* seatRoom = gameMap->getSeatById(seatId);
     if(seatRoom == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "seatId=" + Helper::toString(seatId));
+        OD_LOG_ERR("seatId=" + Helper::toString(seatId));
         return false;
     }
 
@@ -865,14 +865,14 @@ bool Room::buildRoomDefaultEditor(GameMap* gameMap, Room* room, ODPacket& packet
         Tile* tile = gameMap->tileFromPacket(packet);
         if(tile == nullptr)
         {
-            OD_ASSERT_TRUE(false);
+            OD_LOG_ERR("unexpected null tile room=" + room->getName());
             return false;
         }
 
         // If the tile is not buildable, we change it
         if(tile->getCoveringBuilding() != nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "tile=" + Tile::displayAsString(tile) + ", seatId=" + Helper::toString(seatId));
+            OD_LOG_ERR("tile=" + Tile::displayAsString(tile) + ", seatId=" + Helper::toString(seatId));
             continue;
         }
 

--- a/source/rooms/Room.cpp
+++ b/source/rooms/Room.cpp
@@ -17,14 +17,17 @@
 
 #include "rooms/Room.h"
 
-#include "network/ODServer.h"
-#include "network/ServerNotification.h"
 #include "entities/Creature.h"
 #include "entities/RenderedMovableEntity.h"
 #include "entities/Tile.h"
 #include "game/Player.h"
 #include "game/Seat.h"
 #include "gamemap/GameMap.h"
+#include "modes/InputCommand.h"
+#include "modes/InputManager.h"
+#include "network/ODClient.h"
+#include "network/ODServer.h"
+#include "network/ServerNotification.h"
 #include "rooms/RoomManager.h"
 #include "rooms/RoomType.h"
 #include "utils/ConfigManager.h"
@@ -456,18 +459,6 @@ void Room::activeSpotCheckChange(ActiveSpotPlace place, const std::vector<Tile*>
     }
 }
 
-bool Room::canBeRepaired() const
-{
-    switch(getType())
-    {
-        case RoomType::dungeonTemple:
-        case RoomType::portal:
-            return false;
-        default:
-            return true;
-    }
-}
-
 RenderedMovableEntity* Room::notifyActiveSpotCreated(ActiveSpotPlace place, Tile* tile)
 {
     return nullptr;
@@ -584,17 +575,77 @@ void Room::restoreInitialEntityState()
     }
 }
 
-int Room::getCostRepair(std::vector<Tile*>& tiles)
+bool Room::canBeRepaired() const
 {
-    if(getCoveredTilesDestroyed().empty())
-        return 0;
+    switch(getType())
+    {
+        case RoomType::dungeonTemple:
+        case RoomType::portal:
+            return false;
+        default:
+            break;
+    }
 
+    for(Tile* tile : mCoveredTilesDestroyed)
+    {
+        // We check if the tiles can be repaired
+        if(!tile->isBuildableUpon(getSeat()))
+            continue;
+
+        return true;
+    }
+
+    return false;
+}
+
+int Room::getCostRepair()
+{
     if(!canBeRepaired())
         return 0;
 
-    tiles = getCoveredTilesDestroyed();
-    int nbTiles = static_cast<int>(tiles.size());
+    int nbTiles = 0;
+    for(Tile* tile : mCoveredTilesDestroyed)
+    {
+        // We check if the tiles can be repaired
+        if(!tile->isBuildableUpon(getSeat()))
+            continue;
+
+        ++nbTiles;
+    }
     return nbTiles * RoomManager::costPerTile(getType());
+}
+
+void Room::repairRoom()
+{
+    if(!canBeRepaired())
+        return;
+
+    while(!mCoveredTilesDestroyed.empty())
+    {
+        Tile* tile = mCoveredTilesDestroyed.back();
+        mCoveredTilesDestroyed.pop_back();
+
+        // We check if the tiles can be repaired
+        if(!tile->isBuildableUpon(getSeat()))
+            continue;
+
+        LogManager::getSingleton().logMessage("Repairing room=" + getName() + ", tile=" + Tile::displayAsString(tile));
+
+        mCoveredTiles.push_back(tile);
+        TileData* tileData;
+        if(mTileData.count(tile) > 0)
+            tileData = mTileData.at(tile);
+        else
+        {
+            tileData = createTileData(tile);
+            mTileData[tile] = tileData;
+        }
+        tileData->mHP = DEFAULT_TILE_HP;
+
+        tile->setCoveringBuilding(this);
+    }
+
+    updateActiveSpots();
 }
 
 bool Room::sortForMapSave(Room* r1, Room* r2)
@@ -608,8 +659,101 @@ bool Room::sortForMapSave(Room* r1, Room* r2)
     return seatId1 < seatId2;
 }
 
-void Room::buildRoomDefault(GameMap* gameMap, Room* room, const std::vector<Tile*>& tiles, Seat* seat)
+std::string Room::formatRoomPrice(RoomType type, uint32_t price)
 {
+    return RoomManager::getRoomNameFromRoomType(type) + " [" + Helper::toString(price)+ " gold]";
+}
+
+void Room::checkBuildRoomDefault(GameMap* gameMap, RoomType type, const InputManager& inputManager, InputCommand& inputCommand)
+{
+    Player* player = gameMap->getLocalPlayer();
+    int32_t pricePerTarget = RoomManager::costPerTile(type);
+    int32_t playerGold = static_cast<int32_t>(player->getSeat()->getGold());
+    if(inputManager.mCommandState == InputCommandState::infoOnly)
+    {
+        if(playerGold < pricePerTarget)
+        {
+            std::string txt = formatRoomPrice(type, pricePerTarget);
+            inputCommand.displayText(Ogre::ColourValue::Red, txt);
+        }
+        else
+        {
+            std::string txt = formatRoomPrice(type, pricePerTarget);
+            inputCommand.displayText(Ogre::ColourValue::White, txt);
+        }
+        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
+            inputManager.mYPos);
+        return;
+    }
+
+    std::vector<Tile*> buildableTiles = gameMap->getBuildableTilesForPlayerInArea(inputManager.mXPos,
+        inputManager.mYPos, inputManager.mLStartDragX, inputManager.mLStartDragY, player);
+
+    if(inputManager.mCommandState == InputCommandState::building)
+        inputCommand.selectTiles(buildableTiles);
+
+    if(buildableTiles.empty())
+    {
+        std::string txt = formatRoomPrice(type, 0);
+        inputCommand.displayText(Ogre::ColourValue::White, txt);
+        return;
+    }
+
+    int32_t priceTotal = static_cast<int32_t>(buildableTiles.size()) * pricePerTarget;
+    if(playerGold < priceTotal)
+    {
+        std::string txt = formatRoomPrice(type, priceTotal);
+        inputCommand.displayText(Ogre::ColourValue::Red, txt);
+        return;
+    }
+
+    std::string txt = formatRoomPrice(type, priceTotal);
+    inputCommand.displayText(Ogre::ColourValue::White, txt);
+
+    if(inputManager.mCommandState != InputCommandState::validated)
+        return;
+
+    ClientNotification *clientNotification = RoomManager::createRoomClientNotification(type);
+    uint32_t nbTiles = buildableTiles.size();
+    clientNotification->mPacket << nbTiles;
+    for(Tile* tile : buildableTiles)
+        gameMap->tileToPacket(clientNotification->mPacket, tile);
+
+    ODClient::getSingleton().queueClientNotification(clientNotification);
+}
+
+bool Room::getRoomTilesDefault(std::vector<Tile*>& tiles, GameMap* gameMap, Player* player, ODPacket& packet)
+{
+    uint32_t nbTiles;
+    OD_ASSERT_TRUE(packet >> nbTiles);
+
+    while(nbTiles > 0)
+    {
+        --nbTiles;
+        Tile* tile = gameMap->tileFromPacket(packet);
+        if(tile == nullptr)
+        {
+            OD_ASSERT_TRUE(false);
+            return false;
+        }
+
+        if(!tile->isBuildableUpon(player->getSeat()))
+        {
+            OD_ASSERT_TRUE_MSG(false, "tile=" + Tile::displayAsString(tile) + ", seatId=" + Helper::toString(player->getSeat()->getId()));
+            continue;
+        }
+
+        tiles.push_back(tile);
+    }
+
+    return true;
+}
+
+bool Room::buildRoomDefault(GameMap* gameMap, Room* room, Seat* seat, const std::vector<Tile*>& tiles)
+{
+    if(tiles.empty())
+        return false;
+
     room->setupRoom(gameMap->nextUniqueNameRoom(room->getMeshName()), seat, tiles);
     room->addToGameMap();
     room->createMesh();
@@ -656,24 +800,93 @@ void Room::buildRoomDefault(GameMap* gameMap, Room* room, const std::vector<Tile
 
     room->checkForRoomAbsorbtion();
     room->updateActiveSpots();
+
+    return true;
 }
 
-int Room::getRoomCostDefault(std::vector<Tile*>& tiles, GameMap* gameMap, RoomType type,
-    int tileX1, int tileY1, int tileX2, int tileY2, Player* player)
+void Room::checkBuildRoomDefaultEditor(GameMap* gameMap, RoomType type, const InputManager& inputManager, InputCommand& inputCommand)
 {
-    std::vector<Tile*> buildableTiles = gameMap->getBuildableTilesForPlayerInArea(tileX1,
-        tileY1, tileX2, tileY2, player);
-
-    if(buildableTiles.empty())
-        return RoomManager::costPerTile(type);
-
-    int nbTiles = 0;
-
-    for(Tile* tile : buildableTiles)
+    std::string txt = RoomManager::getRoomNameFromRoomType(type);
+    inputCommand.displayText(Ogre::ColourValue::White, txt);
+    if(inputManager.mCommandState == InputCommandState::infoOnly)
     {
-        tiles.push_back(tile);
-        ++nbTiles;
+        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
+            inputManager.mYPos);
+        return;
     }
 
-    return nbTiles * RoomManager::costPerTile(type);
+    std::vector<Tile*> tiles = gameMap->rectangularRegion(inputManager.mXPos,
+        inputManager.mYPos, inputManager.mLStartDragX, inputManager.mLStartDragY);
+
+    std::vector<Tile*> buildableTiles;
+    for(Tile* tile : tiles)
+    {
+        // We accept any tile if there is no building
+        if(tile->getIsBuilding())
+            continue;
+
+        buildableTiles.push_back(tile);
+    }
+    if(inputManager.mCommandState == InputCommandState::building)
+    {
+        inputCommand.selectTiles(buildableTiles);
+        return;
+    }
+
+    ClientNotification *clientNotification = RoomManager::createRoomClientNotificationEditor(type);
+    uint32_t nbTiles = buildableTiles.size();
+    int32_t seatId = inputManager.mSeatIdSelected;
+    clientNotification->mPacket << seatId;
+    clientNotification->mPacket << nbTiles;
+    for(Tile* tile : buildableTiles)
+        gameMap->tileToPacket(clientNotification->mPacket, tile);
+
+    ODClient::getSingleton().queueClientNotification(clientNotification);
+}
+
+bool Room::buildRoomDefaultEditor(GameMap* gameMap, Room* room, ODPacket& packet)
+{
+    int32_t seatId;
+    OD_ASSERT_TRUE(packet >> seatId);
+    Seat* seatRoom = gameMap->getSeatById(seatId);
+    if(seatRoom == nullptr)
+    {
+        OD_ASSERT_TRUE_MSG(false, "seatId=" + Helper::toString(seatId));
+        return false;
+    }
+
+    std::vector<Tile*> tiles;
+    uint32_t nbTiles;
+    OD_ASSERT_TRUE(packet >> nbTiles);
+
+    while(nbTiles > 0)
+    {
+        --nbTiles;
+        Tile* tile = gameMap->tileFromPacket(packet);
+        if(tile == nullptr)
+        {
+            OD_ASSERT_TRUE(false);
+            return false;
+        }
+
+        // If the tile is not buildable, we change it
+        if(tile->getCoveringBuilding() != nullptr)
+        {
+            OD_ASSERT_TRUE_MSG(false, "tile=" + Tile::displayAsString(tile) + ", seatId=" + Helper::toString(seatId));
+            continue;
+        }
+
+        tiles.push_back(tile);
+        if((tile->getType() != TileType::gold) &&
+        (tile->getType() != TileType::dirt))
+        {
+            tile->setType(TileType::dirt);
+        }
+        tile->setFullness(0.0);
+        tile->claimTile(seatRoom);
+        tile->computeTileVisual();
+    }
+
+
+    return buildRoomDefault(gameMap, room, seatRoom, tiles);
 }

--- a/source/rooms/RoomCrypt.cpp
+++ b/source/rooms/RoomCrypt.cpp
@@ -95,6 +95,11 @@ void RoomCrypt::notifyActiveSpotRemoved(ActiveSpotPlace place, Tile* tile)
 
 void RoomCrypt::absorbRoom(Room *r)
 {
+    if(r->getType() != getType())
+    {
+        OD_LOG_ERR("Trying to merge incompatible rooms: " + getName() + ", type=" + RoomManager::getRoomNameFromRoomType(getType()) + ", with " + r->getName() + ", type=" + RoomManager::getRoomNameFromRoomType(r->getType()));
+        return;
+    }
     RoomCrypt* rc = static_cast<RoomCrypt*>(r);
     mRottingCreatures.insert(rc->mRottingCreatures.begin(), rc->mRottingCreatures.end());
     rc->mRottingCreatures.clear();
@@ -155,9 +160,11 @@ void RoomCrypt::doUpkeep()
             mRottenPoints -= cryptPointsForSpawn;
             const std::string& className = configManager.getRoomConfigString("CryptSpawnClass");
             const CreatureDefinition* classToSpawn = getGameMap()->getClassDescription(className);
-            OD_ASSERT_TRUE_MSG(classToSpawn != nullptr, "className=" + className);
             if(classToSpawn == nullptr)
+            {
+                OD_LOG_ERR("className=" + className);
                 continue;
+            }
             // Create a new creature and copy over the class-based creature parameters.
             Creature* newCreature = new Creature(getGameMap(), true, classToSpawn, getSeat());
 
@@ -189,10 +196,11 @@ bool RoomCrypt::hasCarryEntitySpot(GameEntity* carriedEntity)
 
 Tile* RoomCrypt::askSpotForCarriedEntity(GameEntity* carriedEntity)
 {
-    OD_ASSERT_TRUE_MSG(carriedEntity->getObjectType() == GameEntityType::creature,
-        "room=" + getName() + ", entity=" + carriedEntity->getName());
     if(carriedEntity->getObjectType() != GameEntityType::creature)
+    {
+        OD_LOG_ERR("room=" + getName() + ", entity=" + carriedEntity->getName());
         return nullptr;
+    }
 
     Creature* creature = static_cast<Creature*>(carriedEntity);
     for(std::pair<Tile* const, std::pair<Creature*, int32_t> >& p : mRottingCreatures)
@@ -204,8 +212,7 @@ Tile* RoomCrypt::askSpotForCarriedEntity(GameEntity* carriedEntity)
             Tile* spot = p.first;
             Tile* t = getGameMap()->getTile(spot->getX() + OFFSET_TILE_X,
                 spot->getY() + OFFSET_TILE_Y);
-            OD_ASSERT_TRUE_MSG(t != nullptr, "room=" + getName() + ", spot="
-                + Tile::displayAsString(spot));
+            OD_ASSERT_TRUE_MSG(t != nullptr, "room=" + getName() + ", spot=" + Tile::displayAsString(spot));
             return t;
         }
     }
@@ -220,9 +227,9 @@ void RoomCrypt::notifyCarryingStateChanged(Creature* carrier, GameEntity* carrie
         {
             // We check if the carrier is at the expected destination
             Tile* carrierTile = carrier->getPositionTile();
-            OD_ASSERT_TRUE_MSG(carrierTile != nullptr, "carrier=" + carrier->getName());
             if(carrierTile == nullptr)
             {
+                OD_LOG_ERR("carrier=" + carrier->getName());
                 p.second.first = nullptr;
                 p.second.second = -1;
                 return;
@@ -239,14 +246,19 @@ void RoomCrypt::notifyCarryingStateChanged(Creature* carrier, GameEntity* carrie
             }
 
             // The carrier has brought the dead creature
-            OD_ASSERT_TRUE_MSG(carriedEntity->getObjectType() == GameEntityType::creature,
-                "room=" + getName() + ", entity=" + carriedEntity->getName());
+            if(carriedEntity->getObjectType() != GameEntityType::creature)
+            {
+                OD_LOG_ERR("room=" + getName() + ", entity=" + carriedEntity->getName());
+                return;
+            }
 
             Creature* deadCreature = static_cast<Creature*>(carriedEntity);
             Tile* tileDeadCreature = deadCreature->getPositionTile();
-            OD_ASSERT_TRUE_MSG(tileDeadCreature != nullptr, "deadCreature=" + deadCreature->getName());
             if(tileDeadCreature == nullptr)
+            {
+                OD_LOG_ERR("deadCreature=" + deadCreature->getName());
                 return;
+            }
             // Start rotting
             tileDeadCreature->removeEntity(deadCreature);
             deadCreature->setIsOnMap(false);

--- a/source/rooms/RoomCrypt.h
+++ b/source/rooms/RoomCrypt.h
@@ -21,6 +21,9 @@
 #include "rooms/Room.h"
 #include "rooms/RoomType.h"
 
+class InputCommand;
+class InputManager;
+
 class RoomCrypt: public Room
 {
 public:
@@ -40,9 +43,11 @@ public:
     virtual void exportToStream(std::ostream& os) const override;
     virtual void importFromStream(std::istream& is) override;
 
-    static int getRoomCost(std::vector<Tile*>& tiles, GameMap* gameMap, RoomType type,
-        int tileX1, int tileY1, int tileX2, int tileY2, Player* player);
-    static void buildRoom(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat);
+    static void checkBuildRoom(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoom(GameMap* gameMap, Player* player, ODPacket& packet);
+    static void checkBuildRoomEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoomEditor(GameMap* gameMap, ODPacket& packet);
+    static bool buildRoomOnTiles(GameMap* gameMap, Player* player, const std::vector<Tile*>& tiles);
     static Room* getRoomFromStream(GameMap* gameMap, std::istream& is);
 
 protected:

--- a/source/rooms/RoomDormitory.cpp
+++ b/source/rooms/RoomDormitory.cpp
@@ -37,11 +37,14 @@ RoomDormitory::RoomDormitory(GameMap* gameMap) :
 
 void RoomDormitory::absorbRoom(Room *r)
 {
-    RoomDormitory* oldRoom = static_cast<RoomDormitory*>(r);
-    if (oldRoom == nullptr)
+    if(r->getType() != getType())
+    {
+        OD_LOG_ERR("Trying to merge incompatible rooms: " + getName() + ", type=" + RoomManager::getRoomNameFromRoomType(getType()) + ", with " + r->getName() + ", type=" + RoomManager::getRoomNameFromRoomType(r->getType()));
         return;
+    }
 
     // We transfert the building objects
+    RoomDormitory* oldRoom = static_cast<RoomDormitory*>(r);
     mBedRoomObjectsInfo.insert(mBedRoomObjectsInfo.end(),
         oldRoom->mBedRoomObjectsInfo.begin(), oldRoom->mBedRoomObjectsInfo.end());
     oldRoom->mBedRoomObjectsInfo.clear();
@@ -59,7 +62,7 @@ bool RoomDormitory::removeCoveredTile(Tile* t)
 
     if(mTileData.count(t) <= 0)
     {
-        OD_ASSERT_TRUE_MSG(false, "room=" + getName() + ", tile=" + Tile::displayAsString(t));
+        OD_LOG_ERR("room=" + getName() + ", tile=" + Tile::displayAsString(t));
         return false;
     }
 
@@ -159,7 +162,11 @@ bool RoomDormitory::releaseTileForSleeping(Tile* t, Creature* c)
     }
 
     Tile* homeTile = c->getHomeTile();
-    OD_ASSERT_TRUE_MSG(homeTile != nullptr, "creatureName=" + c->getName());
+    if(homeTile == nullptr)
+    {
+        OD_LOG_ERR("creatureName=" + c->getName());
+        return false;
+    }
     c->setHomeTile(nullptr);
 
     // Make the building object delete itself and remove it from the map
@@ -297,13 +304,13 @@ void RoomDormitory::restoreInitialEntityState()
         Creature* creature = getGameMap()->getCreature(bedLoad.getCreatureName());
         if(creature == nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "creatureName=" + bedLoad.getCreatureName());
+            OD_LOG_ERR("creatureName=" + bedLoad.getCreatureName());
             continue;
         }
         Tile* tile = getGameMap()->getTile(bedLoad.getTileX(), bedLoad.getTileY());
         if(creature == nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "tile x=" + Helper::toString(bedLoad.getTileX())
+            OD_LOG_ERR("tile x=" + Helper::toString(bedLoad.getTileX())
                 + ", y=" + Helper::toString(bedLoad.getTileY()));
             continue;
         }

--- a/source/rooms/RoomDormitory.cpp
+++ b/source/rooms/RoomDormitory.cpp
@@ -18,6 +18,7 @@
 #include "rooms/RoomDormitory.h"
 
 #include "entities/Tile.h"
+#include "game/Player.h"
 #include "gamemap/GameMap.h"
 #include "entities/RenderedMovableEntity.h"
 #include "entities/Creature.h"
@@ -316,16 +317,46 @@ RoomDormitoryTileData* RoomDormitory::createTileData(Tile* tile)
     return new RoomDormitoryTileData;
 }
 
-int RoomDormitory::getRoomCost(std::vector<Tile*>& tiles, GameMap* gameMap, RoomType type,
-    int tileX1, int tileY1, int tileX2, int tileY2, Player* player)
+void RoomDormitory::checkBuildRoom(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand)
 {
-    return getRoomCostDefault(tiles, gameMap, type, tileX1, tileY1, tileX2, tileY2, player);
+    checkBuildRoomDefault(gameMap, RoomType::dormitory, inputManager, inputCommand);
 }
 
-void RoomDormitory::buildRoom(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat)
+bool RoomDormitory::buildRoom(GameMap* gameMap, Player* player, ODPacket& packet)
+{
+    std::vector<Tile*> tiles;
+    if(!getRoomTilesDefault(tiles, gameMap, player, packet))
+        return false;
+
+    int32_t pricePerTarget = RoomManager::costPerTile(RoomType::dormitory);
+    int32_t price = static_cast<int32_t>(tiles.size()) * pricePerTarget;
+    if(!gameMap->withdrawFromTreasuries(price, player->getSeat()))
+        return false;
+
+    RoomDormitory* room = new RoomDormitory(gameMap);
+    return buildRoomDefault(gameMap, room, player->getSeat(), tiles);
+}
+
+void RoomDormitory::checkBuildRoomEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand)
+{
+    checkBuildRoomDefaultEditor(gameMap, RoomType::dormitory, inputManager, inputCommand);
+}
+
+bool RoomDormitory::buildRoomEditor(GameMap* gameMap, ODPacket& packet)
 {
     RoomDormitory* room = new RoomDormitory(gameMap);
-    buildRoomDefault(gameMap, room, tiles, seat);
+    return buildRoomDefaultEditor(gameMap, room, packet);
+}
+
+bool RoomDormitory::buildRoomOnTiles(GameMap* gameMap, Player* player, const std::vector<Tile*>& tiles)
+{
+    int32_t pricePerTarget = RoomManager::costPerTile(RoomType::dormitory);
+    int32_t price = static_cast<int32_t>(tiles.size()) * pricePerTarget;
+    if(!gameMap->withdrawFromTreasuries(price, player->getSeat()))
+        return false;
+
+    RoomDormitory* room = new RoomDormitory(gameMap);
+    return buildRoomDefault(gameMap, room, player->getSeat(), tiles);
 }
 
 Room* RoomDormitory::getRoomFromStream(GameMap* gameMap, std::istream& is)

--- a/source/rooms/RoomDormitory.h
+++ b/source/rooms/RoomDormitory.h
@@ -149,9 +149,11 @@ public:
     bool releaseTileForSleeping(Tile *t, Creature *c);
     Tile* getLocationForBed(int xDim, int yDim);
 
-    static int getRoomCost(std::vector<Tile*>& tiles, GameMap* gameMap, RoomType type,
-        int tileX1, int tileY1, int tileX2, int tileY2, Player* player);
-    static void buildRoom(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat);
+    static void checkBuildRoom(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoom(GameMap* gameMap, Player* player, ODPacket& packet);
+    static bool buildRoomOnTiles(GameMap* gameMap, Player* player, const std::vector<Tile*>& tiles);
+    static void checkBuildRoomEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoomEditor(GameMap* gameMap, ODPacket& packet);
     static Room* getRoomFromStream(GameMap* gameMap, std::istream& is);
 
 protected:

--- a/source/rooms/RoomDungeonTemple.cpp
+++ b/source/rooms/RoomDungeonTemple.cpp
@@ -102,10 +102,11 @@ bool RoomDungeonTemple::hasCarryEntitySpot(GameEntity* carriedEntity)
 
 Tile* RoomDungeonTemple::askSpotForCarriedEntity(GameEntity* carriedEntity)
 {
-    OD_ASSERT_TRUE_MSG(carriedEntity->getObjectType() == GameEntityType::researchEntity,
-        "room=" + getName() + ", entity=" + carriedEntity->getName());
     if(carriedEntity->getObjectType() != GameEntityType::researchEntity)
+    {
+        OD_LOG_ERR("room=" + getName() + ", entity=" + carriedEntity->getName());
         return nullptr;
+    }
 
     // We accept any researchEntity
     return getCentralTile();
@@ -113,10 +114,11 @@ Tile* RoomDungeonTemple::askSpotForCarriedEntity(GameEntity* carriedEntity)
 
 void RoomDungeonTemple::notifyCarryingStateChanged(Creature* carrier, GameEntity* carriedEntity)
 {
-    OD_ASSERT_TRUE_MSG(carriedEntity->getObjectType() == GameEntityType::researchEntity,
-        "room=" + getName() + ", entity=" + carriedEntity->getName());
     if(carriedEntity->getObjectType() != GameEntityType::researchEntity)
+    {
+        OD_LOG_ERR("room=" + getName() + ", entity=" + carriedEntity->getName());
         return;
+    }
 
     // We check if the carrier is at the expected destination. If not on the wanted tile,
     // we don't accept the researchEntity
@@ -140,20 +142,20 @@ void RoomDungeonTemple::restoreInitialEntityState()
     // because it will empty the list
     if(mTempleObject == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "roomDungeonTemple=" + getName());
+        OD_LOG_ERR("roomDungeonTemple=" + getName());
         return;
     }
 
     Tile* tileTempleObject = mTempleObject->getPositionTile();
     if(tileTempleObject == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "roomDungeonTemple=" + getName() + ", mTempleObject=" + mTempleObject->getName());
+        OD_LOG_ERR("roomDungeonTemple=" + getName() + ", mTempleObject=" + mTempleObject->getName());
         return;
     }
     TileData* tileData = mTileData[tileTempleObject];
     if(tileData == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "roomDungeonTemple=" + getName() + ", tile=" + Tile::displayAsString(tileTempleObject));
+        OD_LOG_ERR("roomDungeonTemple=" + getName() + ", tile=" + Tile::displayAsString(tileTempleObject));
         return;
     }
 

--- a/source/rooms/RoomDungeonTemple.cpp
+++ b/source/rooms/RoomDungeonTemple.cpp
@@ -167,16 +167,26 @@ void RoomDungeonTemple::restoreInitialEntityState()
     Room::restoreInitialEntityState();
 }
 
-int RoomDungeonTemple::getRoomCost(std::vector<Tile*>& tiles, GameMap* gameMap, RoomType type,
-    int tileX1, int tileY1, int tileX2, int tileY2, Player* player)
+void RoomDungeonTemple::checkBuildRoom(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand)
 {
-    return getRoomCostDefault(tiles, gameMap, type, tileX1, tileY1, tileX2, tileY2, player);
+    // Not buildable in game mode
 }
 
-void RoomDungeonTemple::buildRoom(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat)
+bool RoomDungeonTemple::buildRoom(GameMap* gameMap, Player* player, ODPacket& packet)
+{
+    // Not buildable in game mode
+    return false;
+}
+
+void RoomDungeonTemple::checkBuildRoomEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand)
+{
+    checkBuildRoomDefaultEditor(gameMap, RoomType::dungeonTemple, inputManager, inputCommand);
+}
+
+bool RoomDungeonTemple::buildRoomEditor(GameMap* gameMap, ODPacket& packet)
 {
     RoomDungeonTemple* room = new RoomDungeonTemple(gameMap);
-    buildRoomDefault(gameMap, room, tiles, seat);
+    return buildRoomDefaultEditor(gameMap, room, packet);
 }
 
 Room* RoomDungeonTemple::getRoomFromStream(GameMap* gameMap, std::istream& is)

--- a/source/rooms/RoomDungeonTemple.h
+++ b/source/rooms/RoomDungeonTemple.h
@@ -38,9 +38,10 @@ public:
 
     virtual void restoreInitialEntityState() override;
 
-    static int getRoomCost(std::vector<Tile*>& tiles, GameMap* gameMap, RoomType type,
-        int tileX1, int tileY1, int tileX2, int tileY2, Player* player);
-    static void buildRoom(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat);
+    static void checkBuildRoom(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoom(GameMap* gameMap, Player* player, ODPacket& packet);
+    static void checkBuildRoomEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoomEditor(GameMap* gameMap, ODPacket& packet);
     static Room* getRoomFromStream(GameMap* gameMap, std::istream& is);
 
 protected:

--- a/source/rooms/RoomHatchery.h
+++ b/source/rooms/RoomHatchery.h
@@ -37,9 +37,11 @@ public:
     virtual void doUpkeep();
     virtual bool hasOpenCreatureSpot(Creature* c);
 
-    static int getRoomCost(std::vector<Tile*>& tiles, GameMap* gameMap, RoomType type,
-        int tileX1, int tileY1, int tileX2, int tileY2, Player* player);
-    static void buildRoom(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat);
+    static void checkBuildRoom(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoom(GameMap* gameMap, Player* player, ODPacket& packet);
+    static bool buildRoomOnTiles(GameMap* gameMap, Player* player, const std::vector<Tile*>& tiles);
+    static void checkBuildRoomEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoomEditor(GameMap* gameMap, ODPacket& packet);
     static Room* getRoomFromStream(GameMap* gameMap, std::istream& is);
 
 protected:

--- a/source/rooms/RoomLibrary.h
+++ b/source/rooms/RoomLibrary.h
@@ -61,9 +61,11 @@ public:
     virtual void removeCreatureUsingRoom(Creature* c) override;
     virtual void absorbRoom(Room *r) override;
 
-    static int getRoomCost(std::vector<Tile*>& tiles, GameMap* gameMap, RoomType type,
-        int tileX1, int tileY1, int tileX2, int tileY2, Player* player);
-    static void buildRoom(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat);
+    static void checkBuildRoom(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoom(GameMap* gameMap, Player* player, ODPacket& packet);
+    static bool buildRoomOnTiles(GameMap* gameMap, Player* player, const std::vector<Tile*>& tiles);
+    static void checkBuildRoomEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoomEditor(GameMap* gameMap, ODPacket& packet);
     static Room* getRoomFromStream(GameMap* gameMap, std::istream& is);
 
 protected:

--- a/source/rooms/RoomManager.cpp
+++ b/source/rooms/RoomManager.cpp
@@ -48,7 +48,7 @@ void RoomFunctions::checkBuildRoomFunc(GameMap* gameMap, RoomType type, const In
 {
     if(mCheckBuildRoomFunc == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "null mCheckBuildRoom function Room=" + Helper::toString(static_cast<uint32_t>(type)));
+        OD_LOG_ERR("null mCheckBuildRoom function Room=" + Helper::toString(static_cast<uint32_t>(type)));
         return;
     }
 
@@ -59,7 +59,7 @@ bool RoomFunctions::buildRoomFunc(GameMap* gameMap, RoomType type, Player* playe
 {
     if(mBuildRoomFunc == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "null mBuildRoomFunc function Room=" + Helper::toString(static_cast<uint32_t>(type)));
+        OD_LOG_ERR("null mBuildRoomFunc function Room=" + Helper::toString(static_cast<uint32_t>(type)));
         return false;
     }
 
@@ -70,7 +70,7 @@ void RoomFunctions::checkBuildRoomEditorFunc(GameMap* gameMap, RoomType type, co
 {
     if(mCheckBuildRoomEditorFunc == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "null mCheckBuildRoomEditorFund function Room=" + Helper::toString(static_cast<uint32_t>(type)));
+        OD_LOG_ERR("null mCheckBuildRoomEditorFund function Room=" + Helper::toString(static_cast<uint32_t>(type)));
         return;
     }
 
@@ -81,7 +81,7 @@ bool RoomFunctions::buildRoomEditorFunc(GameMap* gameMap, RoomType type, ODPacke
 {
     if(mBuildRoomEditorFunc == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "null mBuildRoomEditorFunc function Room=" + Helper::toString(static_cast<uint32_t>(type)));
+        OD_LOG_ERR("null mBuildRoomEditorFunc function Room=" + Helper::toString(static_cast<uint32_t>(type)));
         return false;
     }
 
@@ -92,7 +92,7 @@ Room* RoomFunctions::getRoomFromStreamFunc(GameMap* gameMap, RoomType type, std:
 {
     if(mGetRoomFromStreamFunc == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "null mGetRoomFromStreamFunc function Room=" + Helper::toString(static_cast<uint32_t>(type)));
+        OD_LOG_ERR("null mGetRoomFromStreamFunc function Room=" + Helper::toString(static_cast<uint32_t>(type)));
         return nullptr;
     }
 
@@ -104,7 +104,7 @@ void RoomManager::checkBuildRoom(GameMap* gameMap, RoomType type, const InputMan
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getRoomFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return;
     }
 
@@ -117,7 +117,7 @@ bool RoomManager::buildRoom(GameMap* gameMap, RoomType type, Player* player, ODP
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getRoomFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return false;
     }
 
@@ -130,7 +130,7 @@ void RoomManager::checkBuildRoomEditor(GameMap* gameMap, RoomType type, const In
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getRoomFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return;
     }
 
@@ -143,7 +143,7 @@ bool RoomManager::buildRoomEditor(GameMap* gameMap, RoomType type, ODPacket& pac
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getRoomFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return false;
     }
 
@@ -158,7 +158,7 @@ Room* RoomManager::getRoomFromStream(GameMap* gameMap, std::istream& is)
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getRoomFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return nullptr;
     }
 
@@ -171,7 +171,7 @@ const std::string& RoomManager::getRoomNameFromRoomType(RoomType type)
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getRoomFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return EMPTY_STRING;
     }
     RoomFunctions& roomFuncs = getRoomFunctions()[index];
@@ -188,7 +188,7 @@ RoomType RoomManager::getRoomTypeFromRoomName(const std::string& name)
             return static_cast<RoomType>(i);
     }
 
-    OD_ASSERT_TRUE_MSG(false, "Cannot find Room name=" + name);
+    OD_LOG_ERR("Cannot find Room name=" + name);
     return RoomType::nullRoomType;
 }
 
@@ -202,7 +202,7 @@ void RoomManager::registerRoom(RoomType type, const std::string& name,
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getRoomFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return;
     }
 
@@ -289,7 +289,7 @@ void RoomManager::sellRoomTiles(GameMap* gameMap, Player* player, ODPacket& pack
         Tile* tile = gameMap->tileFromPacket(packet);
         if(tile == nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "tile=" + Tile::displayAsString(tile));
+            OD_LOG_ERR("tile=" + Tile::displayAsString(tile));
             continue;
         }
         Room* room = tile->getCoveringRoom();
@@ -301,7 +301,7 @@ void RoomManager::sellRoomTiles(GameMap* gameMap, Player* player, ODPacket& pack
 
         if(!room->removeCoveredTile(tile))
         {
-            OD_ASSERT_TRUE_MSG(false, "room=" + room->getName() + ", tile=" + Tile::displayAsString(tile) + ", seatId=" + Helper::toString(player->getSeat()->getId()));
+            OD_LOG_ERR("room=" + room->getName() + ", tile=" + Tile::displayAsString(tile) + ", seatId=" + Helper::toString(player->getSeat()->getId()));
             continue;
         }
 
@@ -421,7 +421,7 @@ void RoomManager::sellRoomTilesEditor(GameMap* gameMap, ODPacket& packet)
         Tile* tile = gameMap->tileFromPacket(packet);
         if(tile == nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "tile=" + Tile::displayAsString(tile));
+            OD_LOG_ERR("tile=" + Tile::displayAsString(tile));
             continue;
         }
         Room* room = tile->getCoveringRoom();
@@ -430,7 +430,7 @@ void RoomManager::sellRoomTilesEditor(GameMap* gameMap, ODPacket& packet)
 
         if(!room->removeCoveredTile(tile))
         {
-            OD_ASSERT_TRUE_MSG(false, "room=" + room->getName() + ", tile=" + Tile::displayAsString(tile));
+            OD_LOG_ERR("room=" + room->getName() + ", tile=" + Tile::displayAsString(tile));
             continue;
         }
 

--- a/source/rooms/RoomManager.cpp
+++ b/source/rooms/RoomManager.cpp
@@ -225,7 +225,6 @@ void RoomManager::checkSellRoomTiles(GameMap* gameMap, const InputManager& input
         Tile* tile = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
         if((tile == nullptr) || (!tile->getIsBuilding()) || (tile->getSeat() != player->getSeat()))
         {
-            inputCommand.unselectAllTiles();
             std::string txt = formatSellRoom(0);
             inputCommand.displayText(Ogre::ColourValue::White, txt);
             inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos, inputManager.mYPos);
@@ -264,6 +263,8 @@ void RoomManager::checkSellRoomTiles(GameMap* gameMap, const InputManager& input
         inputCommand.displayText(Ogre::ColourValue::White, txt);
         return;
     }
+
+    inputCommand.unselectAllTiles();
 
     ClientNotification *clientNotification = new ClientNotification(
         ClientNotificationType::askSellRoomTiles);
@@ -366,7 +367,6 @@ void RoomManager::checkSellRoomTilesEditor(GameMap* gameMap, const InputManager&
         Tile* tile = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
         if((tile == nullptr) || (!tile->getIsBuilding()))
         {
-            inputCommand.unselectAllTiles();
             inputCommand.displayText(Ogre::ColourValue::White, "Remove tiles");
             inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos, inputManager.mYPos);
             return;
@@ -396,6 +396,8 @@ void RoomManager::checkSellRoomTilesEditor(GameMap* gameMap, const InputManager&
         inputCommand.displayText(Ogre::ColourValue::White, "Remove tiles");
         return;
     }
+
+    inputCommand.unselectAllTiles();
 
     ClientNotification *clientNotification = new ClientNotification(
         ClientNotificationType::editorAskDestroyRoomTiles);

--- a/source/rooms/RoomManager.cpp
+++ b/source/rooms/RoomManager.cpp
@@ -223,7 +223,7 @@ void RoomManager::checkSellRoomTiles(GameMap* gameMap, const InputManager& input
         // We do not differentiate between room and trap (because there is no way to know on client side).
         // Note that price = 0 doesn't mean that the building is not a room
         Tile* tile = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
-        if((tile == nullptr) || (!tile->getIsBuilding()) || (tile->getSeat() != player->getSeat()))
+        if((tile == nullptr) || (!tile->getIsRoom()) || (tile->getSeat() != player->getSeat()))
         {
             std::string txt = formatSellRoom(0);
             inputCommand.displayText(Ogre::ColourValue::White, txt);
@@ -246,7 +246,7 @@ void RoomManager::checkSellRoomTiles(GameMap* gameMap, const InputManager& input
     uint32_t priceTotal = 0;
     for(Tile* tile : tiles)
     {
-        if(!tile->getIsBuilding())
+        if(!tile->getIsRoom())
             continue;
 
         if(tile->getSeat() != player->getSeat())
@@ -365,7 +365,7 @@ void RoomManager::checkSellRoomTilesEditor(GameMap* gameMap, const InputManager&
         // We do not differentiate between room and trap (because there is no way to know on client side).
         // Note that price = 0 doesn't mean that the building is not a room
         Tile* tile = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
-        if((tile == nullptr) || (!tile->getIsBuilding()))
+        if((tile == nullptr) || (!tile->getIsRoom()))
         {
             inputCommand.displayText(Ogre::ColourValue::White, "Remove tiles");
             inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos, inputManager.mYPos);
@@ -384,7 +384,7 @@ void RoomManager::checkSellRoomTilesEditor(GameMap* gameMap, const InputManager&
         inputManager.mYPos, inputManager.mLStartDragX, inputManager.mLStartDragY);
     for(Tile* tile : tiles)
     {
-        if(!tile->getIsBuilding())
+        if(!tile->getIsRoom())
             continue;
 
         sellTiles.push_back(tile);

--- a/source/rooms/RoomPortal.cpp
+++ b/source/rooms/RoomPortal.cpp
@@ -195,7 +195,7 @@ void RoomPortal::spawnCreature()
     // Create a new creature and copy over the class-based creature parameters.
     Creature* newCreature = new Creature(getGameMap(), true, classToSpawn, getSeat(), Ogre::Vector3(xPos, yPos, 0.0f));
 
-    LogManager::getSingleton().logMessage("RoomPortal name=" + getName()
+    OD_LOG_INF("RoomPortal name=" + getName()
         + "spawns a creature class=" + classToSpawn->getClassName()
         + ", name=" + newCreature->getName() + ", seatId=" + Helper::toString(getSeat()->getId()));
 

--- a/source/rooms/RoomPortal.cpp
+++ b/source/rooms/RoomPortal.cpp
@@ -262,16 +262,26 @@ void RoomPortal::restoreInitialEntityState()
     Room::restoreInitialEntityState();
 }
 
-int RoomPortal::getRoomCost(std::vector<Tile*>& tiles, GameMap* gameMap, RoomType type,
-    int tileX1, int tileY1, int tileX2, int tileY2, Player* player)
+void RoomPortal::checkBuildRoom(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand)
 {
-    return getRoomCostDefault(tiles, gameMap, type, tileX1, tileY1, tileX2, tileY2, player);
+    // Not buildable on game mode
 }
 
-void RoomPortal::buildRoom(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat)
+bool RoomPortal::buildRoom(GameMap* gameMap, Player* player, ODPacket& packet)
+{
+    // Not buildable on game mode
+    return false;
+}
+
+void RoomPortal::checkBuildRoomEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand)
+{
+    return checkBuildRoomDefaultEditor(gameMap, RoomType::portal, inputManager, inputCommand);
+}
+
+bool RoomPortal::buildRoomEditor(GameMap* gameMap, ODPacket& packet)
 {
     RoomPortal* room = new RoomPortal(gameMap);
-    buildRoomDefault(gameMap, room, tiles, seat);
+    return buildRoomDefaultEditor(gameMap, room, packet);
 }
 
 Room* RoomPortal::getRoomFromStream(GameMap* gameMap, std::istream& is)

--- a/source/rooms/RoomPortal.cpp
+++ b/source/rooms/RoomPortal.cpp
@@ -49,6 +49,11 @@ RoomPortal::RoomPortal(GameMap* gameMap) :
 
 void RoomPortal::absorbRoom(Room *r)
 {
+    if(r->getType() != getType())
+    {
+        OD_LOG_ERR("Trying to merge incompatible rooms: " + getName() + ", type=" + RoomManager::getRoomNameFromRoomType(getType()) + ", with " + r->getName() + ", type=" + RoomManager::getRoomNameFromRoomType(r->getType()));
+        return;
+    }
     RoomPortal* oldRoom = static_cast<RoomPortal*>(r);
     mClaimedValue += oldRoom->mClaimedValue;
     // We keep the number of creatures increased by this portal
@@ -235,20 +240,20 @@ void RoomPortal::restoreInitialEntityState()
     // because it will empty the list
     if(mPortalObject == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "roomPortal=" + getName());
+        OD_LOG_ERR("roomPortal=" + getName());
         return;
     }
 
     Tile* tilePortalObject = mPortalObject->getPositionTile();
     if(tilePortalObject == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "roomPortal=" + getName() + ", mPortalObject=" + mPortalObject->getName());
+        OD_LOG_ERR("roomPortal=" + getName() + ", mPortalObject=" + mPortalObject->getName());
         return;
     }
     TileData* tileData = mTileData[tilePortalObject];
     if(tileData == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "roomPortal=" + getName() + ", tile=" + Tile::displayAsString(tilePortalObject));
+        OD_LOG_ERR("roomPortal=" + getName() + ", tile=" + Tile::displayAsString(tilePortalObject));
         return;
     }
 

--- a/source/rooms/RoomPortal.h
+++ b/source/rooms/RoomPortal.h
@@ -67,9 +67,10 @@ public:
 
     virtual void restoreInitialEntityState() override;
 
-    static int getRoomCost(std::vector<Tile*>& tiles, GameMap* gameMap, RoomType type,
-        int tileX1, int tileY1, int tileX2, int tileY2, Player* player);
-    static void buildRoom(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat);
+    static void checkBuildRoom(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoom(GameMap* gameMap, Player* player, ODPacket& packet);
+    static void checkBuildRoomEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoomEditor(GameMap* gameMap, ODPacket& packet);
     static Room* getRoomFromStream(GameMap* gameMap, std::istream& is);
 
 protected:

--- a/source/rooms/RoomPortalWave.cpp
+++ b/source/rooms/RoomPortalWave.cpp
@@ -864,16 +864,26 @@ bool RoomPortalWave::findBestDiggablePath(Tile* tileStart, Tile* tileDest, Creat
     }
 }
 
-int RoomPortalWave::getRoomCost(std::vector<Tile*>& tiles, GameMap* gameMap, RoomType type,
-    int tileX1, int tileY1, int tileX2, int tileY2, Player* player)
+void RoomPortalWave::checkBuildRoom(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand)
 {
-    return getRoomCostDefault(tiles, gameMap, type, tileX1, tileY1, tileX2, tileY2, player);
+    // Not buildable on game mode
 }
 
-void RoomPortalWave::buildRoom(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat)
+bool RoomPortalWave::buildRoom(GameMap* gameMap, Player* player, ODPacket& packet)
+{
+    // Not buildable on game mode
+    return false;
+}
+
+void RoomPortalWave::checkBuildRoomEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand)
+{
+    checkBuildRoomDefaultEditor(gameMap, RoomType::portalWave, inputManager, inputCommand);
+}
+
+bool RoomPortalWave::buildRoomEditor(GameMap* gameMap, ODPacket& packet)
 {
     RoomPortalWave* room = new RoomPortalWave(gameMap);
-    buildRoomDefault(gameMap, room, tiles, seat);
+    return buildRoomDefaultEditor(gameMap, room, packet);
 }
 
 Room* RoomPortalWave::getRoomFromStream(GameMap* gameMap, std::istream& is)

--- a/source/rooms/RoomPortalWave.cpp
+++ b/source/rooms/RoomPortalWave.cpp
@@ -300,7 +300,7 @@ void RoomPortalWave::spawnWave(RoomPortalWaveData* roomPortalWaveData, uint32_t 
         const CreatureDefinition* classToSpawn = getGameMap()->getClassDescription(p.first);
         if(classToSpawn == nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "RoomPortalWave=" + getName() + ", wrong creature class=" + p.first);
+            OD_LOG_ERR("RoomPortalWave=" + getName() + ", wrong creature class=" + p.first);
             continue;
         }
 
@@ -371,7 +371,7 @@ void RoomPortalWave::importFromStream(std::istream& is)
     OD_ASSERT_TRUE(is >> str);
     if(str != "[Waves]")
     {
-        OD_ASSERT_TRUE_MSG(false, "RoomPortalWave=" + getName() + ", str=" + str);
+        OD_LOG_ERR("RoomPortalWave=" + getName() + ", str=" + str);
         return;
     }
     while(true)
@@ -382,7 +382,7 @@ void RoomPortalWave::importFromStream(std::istream& is)
 
         if(str != "[Wave]")
         {
-            OD_ASSERT_TRUE_MSG(false, "RoomPortalWave=" + getName() + ", str=" + str);
+            OD_LOG_ERR("RoomPortalWave=" + getName() + ", str=" + str);
             return;
         }
 
@@ -390,7 +390,7 @@ void RoomPortalWave::importFromStream(std::istream& is)
         OD_ASSERT_TRUE(is >> str);
         if(str != "SpawnTurnMin")
         {
-            OD_ASSERT_TRUE_MSG(false, "RoomPortalWave=" + getName() + ", str=" + str);
+            OD_LOG_ERR("RoomPortalWave=" + getName() + ", str=" + str);
             delete roomPortalWaveData;
             return;
         }
@@ -399,7 +399,7 @@ void RoomPortalWave::importFromStream(std::istream& is)
         OD_ASSERT_TRUE(is >> str);
         if(str != "SpawnTurnMax")
         {
-            OD_ASSERT_TRUE_MSG(false, "RoomPortalWave=" + getName() + ", str=" + str);
+            OD_LOG_ERR("RoomPortalWave=" + getName() + ", str=" + str);
             delete roomPortalWaveData;
             return;
         }
@@ -408,7 +408,7 @@ void RoomPortalWave::importFromStream(std::istream& is)
         OD_ASSERT_TRUE(is >> str);
         if(str != "[Creatures]")
         {
-            OD_ASSERT_TRUE_MSG(false, "RoomPortalWave=" + getName() + ", str=" + str);
+            OD_LOG_ERR("RoomPortalWave=" + getName() + ", str=" + str);
             delete roomPortalWaveData;
             return;
         }
@@ -429,7 +429,7 @@ void RoomPortalWave::importFromStream(std::istream& is)
         OD_ASSERT_TRUE(is >> str);
         if(str != "[/Wave]")
         {
-            OD_ASSERT_TRUE_MSG(false, "RoomPortalWave=" + getName() + ", str=" + str);
+            OD_LOG_ERR("RoomPortalWave=" + getName() + ", str=" + str);
             delete roomPortalWaveData;
             return;
         }
@@ -444,20 +444,20 @@ void RoomPortalWave::restoreInitialEntityState()
     // because it will empty the list
     if(mPortalObject == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "RoomPortalWave=" + getName());
+        OD_LOG_ERR("RoomPortalWave=" + getName());
         return;
     }
 
     Tile* tilePortalObject = mPortalObject->getPositionTile();
     if(tilePortalObject == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "RoomPortalWave=" + getName() + ", mPortalObject=" + mPortalObject->getName());
+        OD_LOG_ERR("RoomPortalWave=" + getName() + ", mPortalObject=" + mPortalObject->getName());
         return;
     }
     TileData* tileData = mTileData[tilePortalObject];
     if(tileData == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "RoomPortalWave=" + getName() + ", tile=" + Tile::displayAsString(tilePortalObject));
+        OD_LOG_ERR("RoomPortalWave=" + getName() + ", tile=" + Tile::displayAsString(tilePortalObject));
         return;
     }
 
@@ -489,14 +489,14 @@ bool RoomPortalWave::handleSearchFoe()
 {
     if(mPortalObject == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "room=" + getName());
+        OD_LOG_ERR("room=" + getName());
         return false;
     }
 
     Tile* tileStart = mPortalObject->getPositionTile();
     if(tileStart == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "room=" + getName());
+        OD_LOG_ERR("room=" + getName());
         return false;
     }
 
@@ -574,14 +574,14 @@ bool RoomPortalWave::handleDigging()
 
     if(mPortalObject == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "room=" + getName());
+        OD_LOG_ERR("room=" + getName());
         return false;
     }
 
     Tile* tileStart = mPortalObject->getPositionTile();
     if(tileStart == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "room=" + getName());
+        OD_LOG_ERR("room=" + getName());
         return false;
     }
 
@@ -803,7 +803,7 @@ bool RoomPortalWave::findBestDiggablePath(Tile* tileStart, Tile* tileDest, Creat
             tile = getGameMap()->getTile(tile->getX() - rotations.back().first, tile->getY() - rotations.back().second);
             if(tile == nullptr)
             {
-                OD_ASSERT_TRUE_MSG(false, "room=" + getName());
+                OD_LOG_ERR("room=" + getName());
                 return false;
             }
 

--- a/source/rooms/RoomPortalWave.cpp
+++ b/source/rooms/RoomPortalWave.cpp
@@ -308,7 +308,7 @@ void RoomPortalWave::spawnWave(RoomPortalWaveData* roomPortalWaveData, uint32_t 
         newCreature->setLevel(p.second);
         newCreature->setHP(newCreature->getMaxHp());
 
-        LogManager::getSingleton().logMessage("RoomPortalWave name=" + getName()
+        OD_LOG_INF("RoomPortalWave name=" + getName()
             + "spawns a creature class=" + classToSpawn->getClassName()
             + ", name=" + newCreature->getName() + ", seatId=" + Helper::toString(getSeat()->getId()));
 

--- a/source/rooms/RoomPortalWave.h
+++ b/source/rooms/RoomPortalWave.h
@@ -85,9 +85,10 @@ public:
 
     void addRoomPortalWaveData(RoomPortalWaveData* roomPortalWaveData);
 
-    static int getRoomCost(std::vector<Tile*>& tiles, GameMap* gameMap, RoomType type,
-        int tileX1, int tileY1, int tileX2, int tileY2, Player* player);
-    static void buildRoom(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat);
+    static void checkBuildRoom(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoom(GameMap* gameMap, Player* player, ODPacket& packet);
+    static void checkBuildRoomEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoomEditor(GameMap* gameMap, ODPacket& packet);
     static Room* getRoomFromStream(GameMap* gameMap, std::istream& is);
 
 protected:

--- a/source/rooms/RoomTrainingHall.cpp
+++ b/source/rooms/RoomTrainingHall.cpp
@@ -166,9 +166,11 @@ void RoomTrainingHall::refreshCreaturesDummies()
         {
             // We move to the good tile
             std::list<Tile*> pathToDummy = getGameMap()->path(creature, tileDummy);
-            OD_ASSERT_TRUE(!pathToDummy.empty());
             if(pathToDummy.empty())
+            {
+                OD_LOG_ERR("unexpected empty pathToDummy");
                 continue;
+            }
 
             std::vector<Ogre::Vector3> path;
             Creature::tileToVector3(pathToDummy, path, true, 0.0);
@@ -206,9 +208,11 @@ bool RoomTrainingHall::addCreatureUsingRoom(Creature* creature)
     {
         // We move to the good tile
         std::list<Tile*> pathToDummy = getGameMap()->path(creature, tileDummy);
-        OD_ASSERT_TRUE(!pathToDummy.empty());
         if(pathToDummy.empty())
+        {
+            OD_LOG_ERR("unexpected empty pathToDummy");
             return true;
+        }
 
         std::vector<Ogre::Vector3> path;
         Creature::tileToVector3(pathToDummy, path, true, 0.0);
@@ -227,9 +231,11 @@ void RoomTrainingHall::removeCreatureUsingRoom(Creature* c)
     if(mCreaturesDummies.count(c) > 0)
     {
         Tile* tileDummy = mCreaturesDummies[c];
-        OD_ASSERT_TRUE(tileDummy != nullptr);
         if(tileDummy == nullptr)
+        {
+            OD_LOG_ERR("unexpected null tileDummy");
             return;
+        }
         mUnusedDummies.push_back(tileDummy);
         mCreaturesDummies.erase(c);
     }
@@ -252,20 +258,27 @@ void RoomTrainingHall::doUpkeep()
         Tile* tileDummy = p.second;
         Tile* tileCreature = creature->getPositionTile();
         if(tileCreature == nullptr)
+        {
+            OD_LOG_ERR("unexpected null tileCreature");
             continue;
+        }
 
         Ogre::Real wantedX = static_cast<Ogre::Real>(tileDummy->getX());
         Ogre::Real wantedY = static_cast<Ogre::Real>(tileDummy->getY()) - OFFSET_CREATURE;
 
         RenderedMovableEntity* ro = getBuildingObjectFromTile(tileDummy);
-        OD_ASSERT_TRUE(ro != nullptr);
         if(ro == nullptr)
+        {
+            OD_LOG_ERR("unexpected null building object");
             continue;
+        }
         // We consider that the creature is in the good place if it is in the expected tile and not moving
         Tile* expectedDest = getGameMap()->getTile(Helper::round(wantedX), Helper::round(wantedY));
-        OD_ASSERT_TRUE_MSG(expectedDest != nullptr, "room=" + getName() + ", creature=" + creature->getName());
         if(expectedDest == nullptr)
+        {
+            OD_LOG_ERR("room=" + getName() + ", creature=" + creature->getName());
             continue;
+        }
         if((tileCreature == expectedDest) &&
            !creature->isMoving())
         {

--- a/source/rooms/RoomTrainingHall.cpp
+++ b/source/rooms/RoomTrainingHall.cpp
@@ -21,6 +21,7 @@
 #include "entities/CreatureDefinition.h"
 #include "entities/RenderedMovableEntity.h"
 #include "entities/Tile.h"
+#include "game/Player.h"
 #include "gamemap/GameMap.h"
 #include "rooms/RoomManager.h"
 #include "utils/ConfigManager.h"
@@ -297,16 +298,46 @@ void RoomTrainingHall::doUpkeep()
     }
 }
 
-int RoomTrainingHall::getRoomCost(std::vector<Tile*>& tiles, GameMap* gameMap, RoomType type,
-    int tileX1, int tileY1, int tileX2, int tileY2, Player* player)
+void RoomTrainingHall::checkBuildRoom(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand)
 {
-    return getRoomCostDefault(tiles, gameMap, type, tileX1, tileY1, tileX2, tileY2, player);
+    checkBuildRoomDefault(gameMap, RoomType::trainingHall, inputManager, inputCommand);
 }
 
-void RoomTrainingHall::buildRoom(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat)
+bool RoomTrainingHall::buildRoom(GameMap* gameMap, Player* player, ODPacket& packet)
+{
+    std::vector<Tile*> tiles;
+    if(!getRoomTilesDefault(tiles, gameMap, player, packet))
+        return false;
+
+    int32_t pricePerTarget = RoomManager::costPerTile(RoomType::trainingHall);
+    int32_t price = static_cast<int32_t>(tiles.size()) * pricePerTarget;
+    if(!gameMap->withdrawFromTreasuries(price, player->getSeat()))
+        return false;
+
+    RoomTrainingHall* room = new RoomTrainingHall(gameMap);
+    return buildRoomDefault(gameMap, room, player->getSeat(), tiles);
+}
+
+bool RoomTrainingHall::buildRoomOnTiles(GameMap* gameMap, Player* player, const std::vector<Tile*>& tiles)
+{
+    int32_t pricePerTarget = RoomManager::costPerTile(RoomType::trainingHall);
+    int32_t price = static_cast<int32_t>(tiles.size()) * pricePerTarget;
+    if(!gameMap->withdrawFromTreasuries(price, player->getSeat()))
+        return false;
+
+    RoomTrainingHall* room = new RoomTrainingHall(gameMap);
+    return buildRoomDefault(gameMap, room, player->getSeat(), tiles);
+}
+
+void RoomTrainingHall::checkBuildRoomEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand)
+{
+    checkBuildRoomDefaultEditor(gameMap, RoomType::trainingHall, inputManager, inputCommand);
+}
+
+bool RoomTrainingHall::buildRoomEditor(GameMap* gameMap, ODPacket& packet)
 {
     RoomTrainingHall* room = new RoomTrainingHall(gameMap);
-    buildRoomDefault(gameMap, room, tiles, seat);
+    return buildRoomDefaultEditor(gameMap, room, packet);
 }
 
 Room* RoomTrainingHall::getRoomFromStream(GameMap* gameMap, std::istream& is)

--- a/source/rooms/RoomTrainingHall.h
+++ b/source/rooms/RoomTrainingHall.h
@@ -40,9 +40,11 @@ public:
     virtual void removeCreatureUsingRoom(Creature* c);
     virtual void absorbRoom(Room *r);
 
-    static int getRoomCost(std::vector<Tile*>& tiles, GameMap* gameMap, RoomType type,
-        int tileX1, int tileY1, int tileX2, int tileY2, Player* player);
-    static void buildRoom(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat);
+    static void checkBuildRoom(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoom(GameMap* gameMap, Player* player, ODPacket& packet);
+    static bool buildRoomOnTiles(GameMap* gameMap, Player* player, const std::vector<Tile*>& tiles);
+    static void checkBuildRoomEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoomEditor(GameMap* gameMap, ODPacket& packet);
     static Room* getRoomFromStream(GameMap* gameMap, std::istream& is);
 
 protected:

--- a/source/rooms/RoomTreasury.cpp
+++ b/source/rooms/RoomTreasury.cpp
@@ -78,7 +78,7 @@ bool RoomTreasury::removeCoveredTile(Tile* t)
         int value = roomTreasuryTileData->mGoldInTile;
         if(value > 0)
         {
-            LogManager::getSingleton().logMessage("Room " + getName()
+            OD_LOG_INF("Room " + getName()
                 + ", tile=" + Tile::displayAsString(t) + " releases gold amount = "
                 + Helper::toString(value));
             TreasuryObject* obj = new TreasuryObject(getGameMap(), true, value);

--- a/source/rooms/RoomTreasury.cpp
+++ b/source/rooms/RoomTreasury.cpp
@@ -328,13 +328,7 @@ bool RoomTreasury::buildRoom(GameMap* gameMap, Player* player, ODPacket& packet)
     if(!getRoomTilesDefault(tiles, gameMap, player, packet))
         return false;
 
-    int32_t pricePerTarget = RoomManager::costPerTile(RoomType::treasury);
-    int32_t price = static_cast<int32_t>(tiles.size()) * pricePerTarget;
-    // First treasury tile is free
-    std::vector<Room*> treasuriesOwned = gameMap->getRoomsByTypeAndSeat(RoomType::treasury, player->getSeat());
-    if(treasuriesOwned.empty())
-        price -= pricePerTarget;
-
+    int32_t price = getRoomCostForPlayer(gameMap, player, tiles);
     if(!gameMap->withdrawFromTreasuries(price, player->getSeat()))
         return false;
 
@@ -391,8 +385,7 @@ bool RoomTreasury::buildRoom(GameMap* gameMap, Player* player, ODPacket& packet)
 
 bool RoomTreasury::buildRoomOnTiles(GameMap* gameMap, Player* player, const std::vector<Tile*>& tiles)
 {
-    int32_t pricePerTarget = RoomManager::costPerTile(RoomType::treasury);
-    int32_t price = static_cast<int32_t>(tiles.size()) * pricePerTarget;
+    int32_t price = getRoomCostForPlayer(gameMap, player, tiles);
     if(!gameMap->withdrawFromTreasuries(price, player->getSeat()))
         return false;
 
@@ -414,4 +407,16 @@ bool RoomTreasury::buildRoomEditor(GameMap* gameMap, ODPacket& packet)
 Room* RoomTreasury::getRoomFromStream(GameMap* gameMap, std::istream& is)
 {
     return new RoomTreasury(gameMap);
+}
+
+int32_t RoomTreasury::getRoomCostForPlayer(GameMap* gameMap, Player* player, const std::vector<Tile*>& tiles)
+{
+    int32_t pricePerTarget = RoomManager::costPerTile(RoomType::treasury);
+    int32_t price = static_cast<int32_t>(tiles.size()) * pricePerTarget;
+    // First treasury tile is free
+    std::vector<Room*> treasuriesOwned = gameMap->getRoomsByTypeAndSeat(RoomType::treasury, player->getSeat());
+    if(treasuriesOwned.empty())
+        price -= pricePerTarget;
+
+    return price;
 }

--- a/source/rooms/RoomTreasury.cpp
+++ b/source/rooms/RoomTreasury.cpp
@@ -259,13 +259,13 @@ RoomTreasuryTileData* RoomTreasury::createTileData(Tile* tile)
 void RoomTreasury::checkBuildRoom(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand)
 {
     Player* player = gameMap->getLocalPlayer();
-    std::vector<Room*> treasuriesOwned = gameMap->getRoomsByTypeAndSeat(RoomType::treasury, player->getSeat());
+    int nbTreasuries = player->getSeat()->getNbTreasuries();
     int32_t pricePerTarget = RoomManager::costPerTile(RoomType::treasury);
     int32_t playerGold = static_cast<int32_t>(player->getSeat()->getGold());
     if(inputManager.mCommandState == InputCommandState::infoOnly)
     {
         // First treasury tile is free
-        if(treasuriesOwned.empty())
+        if(nbTreasuries <= 0)
             pricePerTarget = 0;
 
         if(playerGold < pricePerTarget)
@@ -297,7 +297,7 @@ void RoomTreasury::checkBuildRoom(GameMap* gameMap, const InputManager& inputMan
 
     int32_t priceTotal = static_cast<int32_t>(buildableTiles.size()) * pricePerTarget;
     // First treasury tile is free
-    if(treasuriesOwned.empty())
+    if(nbTreasuries <= 0)
         priceTotal -= pricePerTarget;
 
     if(playerGold < priceTotal)

--- a/source/rooms/RoomTreasury.h
+++ b/source/rooms/RoomTreasury.h
@@ -68,9 +68,11 @@ public:
     Tile* askSpotForCarriedEntity(GameEntity* carriedEntity);
     void notifyCarryingStateChanged(Creature* carrier, GameEntity* carriedEntity);
 
-    static int getRoomCost(std::vector<Tile*>& tiles, GameMap* gameMap, RoomType type,
-        int tileX1, int tileY1, int tileX2, int tileY2, Player* player);
-    static void buildRoom(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat);
+    static void checkBuildRoom(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoom(GameMap* gameMap, Player* player, ODPacket& packet);
+    static bool buildRoomOnTiles(GameMap* gameMap, Player* player, const std::vector<Tile*>& tiles);
+    static void checkBuildRoomEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoomEditor(GameMap* gameMap, ODPacket& packet);
     static Room* getRoomFromStream(GameMap* gameMap, std::istream& is);
 
 protected:

--- a/source/rooms/RoomTreasury.h
+++ b/source/rooms/RoomTreasury.h
@@ -74,6 +74,7 @@ public:
     static void checkBuildRoomEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
     static bool buildRoomEditor(GameMap* gameMap, ODPacket& packet);
     static Room* getRoomFromStream(GameMap* gameMap, std::istream& is);
+    static int32_t getRoomCostForPlayer(GameMap* gameMap, Player* player, const std::vector<Tile*>& tiles);
 
 protected:
     RoomTreasuryTileData* createTileData(Tile* tile) override;

--- a/source/rooms/RoomWorkshop.h
+++ b/source/rooms/RoomWorkshop.h
@@ -61,9 +61,11 @@ public:
     virtual void exportToStream(std::ostream& os) const override;
     virtual void importFromStream(std::istream& is) override;
 
-    static int getRoomCost(std::vector<Tile*>& tiles, GameMap* gameMap, RoomType type,
-        int tileX1, int tileY1, int tileX2, int tileY2, Player* player);
-    static void buildRoom(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat);
+    static void checkBuildRoom(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoom(GameMap* gameMap, Player* player, ODPacket& packet);
+    static bool buildRoomOnTiles(GameMap* gameMap, Player* player, const std::vector<Tile*>& tiles);
+    static void checkBuildRoomEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildRoomEditor(GameMap* gameMap, ODPacket& packet);
     static Room* getRoomFromStream(GameMap* gameMap, std::istream& is);
 
 protected:

--- a/source/sound/MusicPlayer.cpp
+++ b/source/sound/MusicPlayer.cpp
@@ -156,8 +156,7 @@ MusicPlayer::MusicPlayer(const std::string& musicFilesPath, Ogre::StringVectorPt
     mCurrentTrack(std::string()),
     mIsPlaying(false)
 {
-    LogManager& logMgr = LogManager::getSingleton();
-    logMgr.logMessage("Loading music...");
+    OD_LOG_INF("Loading music...");
 
     /* Create sound objects for all files, Sound objects should be deleted
      * automatically by the sound manager.
@@ -165,7 +164,7 @@ MusicPlayer::MusicPlayer(const std::string& musicFilesPath, Ogre::StringVectorPt
     for(const std::string& trackName : *musicFilesList)
     {
         std::unique_ptr<ODMusic> track(new ODMusic());
-        logMgr.logMessage("Loading: " + trackName);
+        OD_LOG_INF("Loading: " + trackName);
 
         if(track->loadFromFile(musicFilesPath + trackName))
         {
@@ -175,11 +174,11 @@ MusicPlayer::MusicPlayer(const std::string& musicFilesPath, Ogre::StringVectorPt
 
     if(mTracks.empty())
     {
-        logMgr.logMessage("No music files loaded... no music will be played");
+        OD_LOG_INF("No music files loaded... no music will be played");
     }
     else
     {
-        logMgr.logMessage("Music loading done");
+        OD_LOG_INF("Music loading done");
         mLoaded = true;
     }
 }

--- a/source/spawnconditions/SpawnCondition.cpp
+++ b/source/spawnconditions/SpawnCondition.cpp
@@ -48,7 +48,7 @@ SpawnCondition* SpawnCondition::load(std::istream& defFile)
         if(condition != nullptr)
         {
             // The previous line was a valid condition so we should have had an ending tag
-            OD_ASSERT_TRUE_MSG(false, "nextParam=" + nextParam);
+            OD_LOG_ERR("nextParam=" + nextParam);
             return condition;
         }
         if (nextParam == "Room")
@@ -58,7 +58,7 @@ SpawnCondition* SpawnCondition::load(std::istream& defFile)
             RoomType roomType = RoomManager::getRoomTypeFromRoomName(nextParam);
             if(roomType == RoomType::nullRoomType)
             {
-                OD_ASSERT_TRUE_MSG(false, "nextParam=" + nextParam);
+                OD_LOG_ERR("nextParam=" + nextParam);
                 break;
             }
             if(!(defFile >> nextParam))
@@ -78,7 +78,7 @@ SpawnCondition* SpawnCondition::load(std::istream& defFile)
             const CreatureDefinition* creatureDefinition = ConfigManager::getSingleton().getCreatureDefinition(nextParam);
             if(creatureDefinition == nullptr)
             {
-                OD_ASSERT_TRUE_MSG(false, "nextParam=" + nextParam);
+                OD_LOG_ERR("nextParam=" + nextParam);
                 return nullptr;
             }
             if(!(defFile >> nextParam))
@@ -103,6 +103,6 @@ SpawnCondition* SpawnCondition::load(std::istream& defFile)
             condition = new SpawnConditionGold(nbGoldMin, pointsPerAdditional100Gold);
         }
     }
-    OD_ASSERT_TRUE(false);
+    OD_LOG_ERR("Couldn't read spawn condition");
     return nullptr;
 }

--- a/source/spells/Spell.cpp
+++ b/source/spells/Spell.cpp
@@ -176,6 +176,11 @@ std::string Spell::getSpellStreamFormat()
     return "typeSpell\t" + format;
 }
 
+std::string Spell::formatSpellPrice(SpellType type, uint32_t price)
+{
+    return SpellManager::getSpellNameFromSpellType(type) + " [" + Helper::toString(price)+ " Mana]";
+}
+
 void Spell::exportHeadersToStream(std::ostream& os) const
 {
     RenderedMovableEntity::exportHeadersToStream(os);

--- a/source/spells/Spell.h
+++ b/source/spells/Spell.h
@@ -28,7 +28,7 @@ enum class SpellType;
 /*! \class Spell
  *  \brief Defines a spell. To be usable in game, a spell must register by creating a global class SpellManagerRegister.
  *         A Spell have to have the following static functions (otherwise, it won't be registrable):
- *         - getSpellCost
+ *         - checkSpellCast
  *         - castSpell
  *         - getSpellFromStream
  *         - getSpellFromPacket
@@ -64,6 +64,8 @@ public:
 
     static std::string getSpellStreamFormat();
 
+protected:
+    static std::string formatSpellPrice(SpellType type, uint32_t price);
 private:
     //! \brief Number of turns the spell should be displayed before automatic deletion.
     //! If < 0, the Spell will not be removed automatically

--- a/source/spells/SpellCallToWar.h
+++ b/source/spells/SpellCallToWar.h
@@ -22,6 +22,8 @@
 #include "spells/SpellType.h"
 
 class GameMap;
+class InputCommand;
+class InputManager;
 
 class SpellCallToWar : public Spell
 {
@@ -36,10 +38,8 @@ public:
 
     void slap() override;
 
-    static int getSpellCost(std::vector<EntityBase*>& targets, GameMap* gameMap, SpellType type,
-        int tileX1, int tileY1, int tileX2, int tileY2, Player* player);
-
-    static void castSpell(GameMap* gameMap, const std::vector<EntityBase*>& targets, Player* player);
+    static void checkSpellCast(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool castSpell(GameMap* gameMap, Player* player, ODPacket& packet);
 
     static Spell* getSpellFromStream(GameMap* gameMap, std::istream &is);
     static Spell* getSpellFromPacket(GameMap* gameMap, ODPacket &is);

--- a/source/spells/SpellCreatureExplosion.cpp
+++ b/source/spells/SpellCreatureExplosion.cpp
@@ -18,44 +18,67 @@
 #include "spells/SpellCreatureExplosion.h"
 
 #include "creatureeffect/CreatureEffectExplosion.h"
-
 #include "entities/Creature.h"
 #include "entities/Tile.h"
-
 #include "game/Player.h"
 #include "game/Seat.h"
-
 #include "gamemap/GameMap.h"
-
+#include "modes/InputCommand.h"
+#include "modes/InputManager.h"
+#include "network/ODClient.h"
 #include "spells/SpellType.h"
 #include "spells/SpellManager.h"
-
 #include "utils/ConfigManager.h"
 #include "utils/Helper.h"
 #include "utils/LogManager.h"
 
 static SpellManagerRegister<SpellCreatureExplosion> reg(SpellType::creatureExplosion, "creatureExplosion");
 
-int SpellCreatureExplosion::getSpellCost(std::vector<EntityBase*>& targets, GameMap* gameMap, SpellType type,
-    int tileX1, int tileY1, int tileX2, int tileY2, Player* player)
+void SpellCreatureExplosion::checkSpellCast(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand)
 {
+    Player* player = gameMap->getLocalPlayer();
     int32_t priceTotal = 0;
-    int32_t pricePerTile = ConfigManager::getSingleton().getSpellConfigInt32("CreatureHealPrice");
+    int32_t pricePerTarget = ConfigManager::getSingleton().getSpellConfigInt32("CreatureExplosionPrice");
     int32_t playerMana = static_cast<int32_t>(player->getSeat()->getMana());
-    if(playerMana < pricePerTile)
-        return pricePerTile;
-
-    std::vector<EntityBase*> creatures;
-    gameMap->playerSelects(creatures, tileX1, tileY1, tileX2, tileY2, SelectionTileAllowed::groundClaimedAllied,
-        SelectionEntityWanted::creatureAliveEnemy, player);
-
-    if(creatures.empty())
-        return pricePerTile;
-
-    std::random_shuffle(creatures.begin(), creatures.end());
-    for(EntityBase* target : creatures)
+    if(inputManager.mCommandState == InputCommandState::infoOnly)
     {
-        if(playerMana < pricePerTile)
+        if(playerMana < pricePerTarget)
+        {
+            std::string txt = formatSpellPrice(SpellType::creatureExplosion, pricePerTarget);
+            inputCommand.displayText(Ogre::ColourValue::Red, txt);
+        }
+        else
+        {
+            std::string txt = formatSpellPrice(SpellType::creatureExplosion, pricePerTarget);
+            inputCommand.displayText(Ogre::ColourValue::White, txt);
+        }
+        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
+            inputManager.mYPos);
+        return;
+    }
+
+    if(inputManager.mCommandState == InputCommandState::building)
+    {
+        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mLStartDragX,
+            inputManager.mLStartDragY);
+    }
+
+    std::vector<EntityBase*> targets;
+    gameMap->playerSelects(targets, inputManager.mXPos, inputManager.mYPos, inputManager.mLStartDragX, inputManager.mLStartDragY,
+        SelectionTileAllowed::groundClaimedAllied, SelectionEntityWanted::creatureAliveEnemy, player);
+
+    if(targets.empty())
+    {
+        std::string txt = formatSpellPrice(SpellType::creatureExplosion, 0);
+        inputCommand.displayText(Ogre::ColourValue::White, txt);
+        return;
+    }
+
+    std::random_shuffle(targets.begin(), targets.end());
+    std::vector<Creature*> creatures;
+    for(EntityBase* target : targets)
+    {
+        if(playerMana < pricePerTarget)
             break;
 
         if(target->getObjectType() != GameEntityType::creature)
@@ -69,48 +92,95 @@ int SpellCreatureExplosion::getSpellCost(std::vector<EntityBase*>& targets, Game
             continue;
         }
 
-        targets.push_back(target);
+        Creature* creature = static_cast<Creature*>(target);
+        creatures.push_back(creature);
 
-        priceTotal += pricePerTile;
-        playerMana -= pricePerTile;
+        priceTotal += pricePerTarget;
+        playerMana -= pricePerTarget;
     }
 
-    return priceTotal;
+    std::string txt = formatSpellPrice(SpellType::creatureExplosion, priceTotal);
+    inputCommand.displayText(Ogre::ColourValue::White, txt);
+
+    if(inputManager.mCommandState != InputCommandState::validated)
+        return;
+
+    inputCommand.unselectAllTiles();
+
+    ClientNotification *clientNotification = SpellManager::createSpellClientNotification(SpellType::creatureExplosion);
+    uint32_t nbCreatures = creatures.size();
+    clientNotification->mPacket << nbCreatures;
+    for(Creature* creature : creatures)
+        clientNotification->mPacket << creature->getName();
+
+    ODClient::getSingleton().queueClientNotification(clientNotification);
 }
 
-void SpellCreatureExplosion::castSpell(GameMap* gameMap, const std::vector<EntityBase*>& targets, Player* player)
+bool SpellCreatureExplosion::castSpell(GameMap* gameMap, Player* player, ODPacket& packet)
 {
-    player->setSpellCooldownTurns(SpellType::creatureExplosion, ConfigManager::getSingleton().getSpellConfigUInt32("CreatureExplosionCooldown"));
-    for(EntityBase* target : targets)
+    uint32_t nbCreatures;
+    OD_ASSERT_TRUE(packet >> nbCreatures);
+    std::vector<Creature*> creatures;
+    while(nbCreatures > 0)
     {
-        if(target->getObjectType() != GameEntityType::creature)
+        --nbCreatures;
+        std::string creatureName;
+        OD_ASSERT_TRUE(packet >> creatureName);
+
+        // We check that the creatures are valid targets
+        Creature* creature = gameMap->getCreature(creatureName);
+        if(creature == nullptr)
         {
-            static bool logMsg = false;
-            if(!logMsg)
-            {
-                logMsg = true;
-                OD_ASSERT_TRUE_MSG(false, "Wrong target name=" + target->getName() + ", type=" + Helper::toString(static_cast<int32_t>(target->getObjectType())));
-            }
+            OD_ASSERT_TRUE_MSG(false, "creatureName=" + creatureName);
             continue;
         }
 
-        Creature* creature = static_cast<Creature*>(target);
-        if(creature->getHP() <= 0)
+        if(creature->getSeat()->isAlliedSeat(player->getSeat()))
         {
-            static bool logMsg = false;
-            if(!logMsg)
-            {
-                logMsg = true;
-                OD_ASSERT_TRUE_MSG(false, "Dead creature target name=" + creature->getName());
-            }
+            OD_ASSERT_TRUE_MSG(false, "creatureName=" + creatureName);
             continue;
         }
 
-        CreatureEffectExplosion* effect = new CreatureEffectExplosion(ConfigManager::getSingleton().getSpellConfigUInt32("CreatureExplosionDuration"),
-            ConfigManager::getSingleton().getSpellConfigDouble("CreatureExplosionValue"),
-            "SpellCreatureExplosion");
+        Tile* pos = creature->getPositionTile();
+        if(pos == nullptr)
+        {
+            OD_ASSERT_TRUE_MSG(false, "creatureName=" + creatureName);
+            continue;
+        }
+
+        // That can happen if the creature is not in perfect synchronization and is not on a claimed tile on the server gamemap
+        if(!pos->isClaimedForSeat(player->getSeat()))
+        {
+            LogManager::getSingleton().logMessage("WARNING : " + creatureName + ", tile=" + Tile::displayAsString(pos));
+            continue;
+        }
+
+        creatures.push_back(creature);
+    }
+
+    if(creatures.empty())
+        return false;
+
+    int32_t pricePerTarget = ConfigManager::getSingleton().getSpellConfigInt32("CreatureExplosionPrice");
+    int32_t playerMana = static_cast<int32_t>(player->getSeat()->getMana());
+    int32_t nbTargets = playerMana / pricePerTarget;
+    int32_t priceTotal = nbTargets * pricePerTarget;
+
+    if(creatures.size() > static_cast<uint32_t>(nbTargets))
+        creatures.resize(nbTargets);
+
+    if(!player->getSeat()->takeMana(priceTotal))
+        return false;
+
+    uint32_t duration = ConfigManager::getSingleton().getSpellConfigUInt32("CreatureExplosionDuration");
+    double value = ConfigManager::getSingleton().getSpellConfigDouble("CreatureExplosionValue");
+    for(Creature* creature : creatures)
+    {
+        CreatureEffectExplosion* effect = new CreatureEffectExplosion(duration, value, "SpellCreatureExplosion");
         creature->addCreatureEffect(effect);
     }
+
+    return true;
 }
 
 Spell* SpellCreatureExplosion::getSpellFromStream(GameMap* gameMap, std::istream &is)

--- a/source/spells/SpellCreatureExplosion.cpp
+++ b/source/spells/SpellCreatureExplosion.cpp
@@ -151,7 +151,7 @@ bool SpellCreatureExplosion::castSpell(GameMap* gameMap, Player* player, ODPacke
         // That can happen if the creature is not in perfect synchronization and is not on a claimed tile on the server gamemap
         if(!pos->isClaimedForSeat(player->getSeat()))
         {
-            LogManager::getSingleton().logMessage("WARNING : " + creatureName + ", tile=" + Tile::displayAsString(pos));
+            OD_LOG_INF("WARNING : " + creatureName + ", tile=" + Tile::displayAsString(pos));
             continue;
         }
 

--- a/source/spells/SpellCreatureExplosion.cpp
+++ b/source/spells/SpellCreatureExplosion.cpp
@@ -87,7 +87,7 @@ void SpellCreatureExplosion::checkSpellCast(GameMap* gameMap, const InputManager
             if(!logMsg)
             {
                 logMsg = true;
-                OD_ASSERT_TRUE_MSG(false, "Wrong target name=" + target->getName() + ", type=" + Helper::toString(static_cast<int32_t>(target->getObjectType())));
+                OD_LOG_ERR("Wrong target name=" + target->getName() + ", type=" + Helper::toString(static_cast<int32_t>(target->getObjectType())));
             }
             continue;
         }
@@ -131,20 +131,20 @@ bool SpellCreatureExplosion::castSpell(GameMap* gameMap, Player* player, ODPacke
         Creature* creature = gameMap->getCreature(creatureName);
         if(creature == nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "creatureName=" + creatureName);
+            OD_LOG_ERR("creatureName=" + creatureName);
             continue;
         }
 
         if(creature->getSeat()->isAlliedSeat(player->getSeat()))
         {
-            OD_ASSERT_TRUE_MSG(false, "creatureName=" + creatureName);
+            OD_LOG_ERR("creatureName=" + creatureName);
             continue;
         }
 
         Tile* pos = creature->getPositionTile();
         if(pos == nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "creatureName=" + creatureName);
+            OD_LOG_ERR("creatureName=" + creatureName);
             continue;
         }
 
@@ -185,12 +185,12 @@ bool SpellCreatureExplosion::castSpell(GameMap* gameMap, Player* player, ODPacke
 
 Spell* SpellCreatureExplosion::getSpellFromStream(GameMap* gameMap, std::istream &is)
 {
-    OD_ASSERT_TRUE_MSG(false, "SpellCreatureExplosion cannot be read from stream");
+    OD_LOG_ERR("SpellCreatureExplosion cannot be read from stream");
     return nullptr;
 }
 
 Spell* SpellCreatureExplosion::getSpellFromPacket(GameMap* gameMap, ODPacket &is)
 {
-    OD_ASSERT_TRUE_MSG(false, "SpellCreatureExplosion cannot be read from packet");
+    OD_LOG_ERR("SpellCreatureExplosion cannot be read from packet");
     return nullptr;
 }

--- a/source/spells/SpellCreatureHeal.cpp
+++ b/source/spells/SpellCreatureHeal.cpp
@@ -151,7 +151,7 @@ bool SpellCreatureHeal::castSpell(GameMap* gameMap, Player* player, ODPacket& pa
         // That can happen if the creature is not in perfect synchronization and is not on a claimed tile on the server gamemap
         if(!pos->isClaimedForSeat(player->getSeat()))
         {
-            LogManager::getSingleton().logMessage("WARNING : " + creatureName + ", tile=" + Tile::displayAsString(pos));
+            OD_LOG_INF("WARNING : " + creatureName + ", tile=" + Tile::displayAsString(pos));
             continue;
         }
 

--- a/source/spells/SpellCreatureHeal.cpp
+++ b/source/spells/SpellCreatureHeal.cpp
@@ -87,7 +87,7 @@ void SpellCreatureHeal::checkSpellCast(GameMap* gameMap, const InputManager& inp
             if(!logMsg)
             {
                 logMsg = true;
-                OD_ASSERT_TRUE_MSG(false, "Wrong target name=" + target->getName() + ", type=" + Helper::toString(static_cast<int32_t>(target->getObjectType())));
+                OD_LOG_ERR("Wrong target name=" + target->getName() + ", type=" + Helper::toString(static_cast<int32_t>(target->getObjectType())));
             }
             continue;
         }
@@ -131,20 +131,20 @@ bool SpellCreatureHeal::castSpell(GameMap* gameMap, Player* player, ODPacket& pa
         Creature* creature = gameMap->getCreature(creatureName);
         if(creature == nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "creatureName=" + creatureName);
+            OD_LOG_ERR("creatureName=" + creatureName);
             continue;
         }
 
         if(!creature->getSeat()->isAlliedSeat(player->getSeat()))
         {
-            OD_ASSERT_TRUE_MSG(false, "creatureName=" + creatureName);
+            OD_LOG_ERR("creatureName=" + creatureName);
             continue;
         }
 
         Tile* pos = creature->getPositionTile();
         if(pos == nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "creatureName=" + creatureName);
+            OD_LOG_ERR("creatureName=" + creatureName);
             continue;
         }
 
@@ -185,12 +185,12 @@ bool SpellCreatureHeal::castSpell(GameMap* gameMap, Player* player, ODPacket& pa
 
 Spell* SpellCreatureHeal::getSpellFromStream(GameMap* gameMap, std::istream &is)
 {
-    OD_ASSERT_TRUE_MSG(false, "SpellCreatureHeal cannot be read from stream");
+    OD_LOG_ERR("SpellCreatureHeal cannot be read from stream");
     return nullptr;
 }
 
 Spell* SpellCreatureHeal::getSpellFromPacket(GameMap* gameMap, ODPacket &is)
 {
-    OD_ASSERT_TRUE_MSG(false, "SpellCreatureHeal cannot be read from packet");
+    OD_LOG_ERR("SpellCreatureHeal cannot be read from packet");
     return nullptr;
 }

--- a/source/spells/SpellCreatureHeal.cpp
+++ b/source/spells/SpellCreatureHeal.cpp
@@ -18,44 +18,67 @@
 #include "spells/SpellCreatureHeal.h"
 
 #include "creatureeffect/CreatureEffectHeal.h"
-
 #include "entities/Creature.h"
 #include "entities/Tile.h"
-
 #include "game/Player.h"
 #include "game/Seat.h"
-
 #include "gamemap/GameMap.h"
-
+#include "modes/InputCommand.h"
+#include "modes/InputManager.h"
+#include "network/ODClient.h"
 #include "spells/SpellType.h"
 #include "spells/SpellManager.h"
-
 #include "utils/ConfigManager.h"
 #include "utils/Helper.h"
 #include "utils/LogManager.h"
 
 static SpellManagerRegister<SpellCreatureHeal> reg(SpellType::creatureHeal, "creatureHeal");
 
-int SpellCreatureHeal::getSpellCost(std::vector<EntityBase*>& targets, GameMap* gameMap, SpellType type,
-    int tileX1, int tileY1, int tileX2, int tileY2, Player* player)
+void SpellCreatureHeal::checkSpellCast(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand)
 {
+    Player* player = gameMap->getLocalPlayer();
     int32_t priceTotal = 0;
-    int32_t pricePerTile = ConfigManager::getSingleton().getSpellConfigInt32("CreatureHealPrice");
+    int32_t pricePerTarget = ConfigManager::getSingleton().getSpellConfigInt32("CreatureHealPrice");
     int32_t playerMana = static_cast<int32_t>(player->getSeat()->getMana());
-    if(playerMana < pricePerTile)
-        return pricePerTile;
-
-    std::vector<EntityBase*> creatures;
-    gameMap->playerSelects(creatures, tileX1, tileY1, tileX2, tileY2, SelectionTileAllowed::groundClaimedAllied,
-        SelectionEntityWanted::creatureAliveOwned, player);
-
-    if(creatures.empty())
-        return pricePerTile;
-
-    std::random_shuffle(creatures.begin(), creatures.end());
-    for(EntityBase* target : creatures)
+    if(inputManager.mCommandState == InputCommandState::infoOnly)
     {
-        if(playerMana < pricePerTile)
+        if(playerMana < pricePerTarget)
+        {
+            std::string txt = formatSpellPrice(SpellType::creatureHeal, pricePerTarget);
+            inputCommand.displayText(Ogre::ColourValue::Red, txt);
+        }
+        else
+        {
+            std::string txt = formatSpellPrice(SpellType::creatureHeal, pricePerTarget);
+            inputCommand.displayText(Ogre::ColourValue::White, txt);
+        }
+        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
+            inputManager.mYPos);
+        return;
+    }
+
+    if(inputManager.mCommandState == InputCommandState::building)
+    {
+        inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mLStartDragX,
+            inputManager.mLStartDragY);
+    }
+
+    std::vector<EntityBase*> targets;
+    gameMap->playerSelects(targets, inputManager.mXPos, inputManager.mYPos, inputManager.mLStartDragX, inputManager.mLStartDragY,
+        SelectionTileAllowed::groundClaimedAllied, SelectionEntityWanted::creatureAliveOwned, player);
+
+    if(targets.empty())
+    {
+        std::string txt = formatSpellPrice(SpellType::creatureHeal, 0);
+        inputCommand.displayText(Ogre::ColourValue::White, txt);
+        return;
+    }
+
+    std::random_shuffle(targets.begin(), targets.end());
+    std::vector<Creature*> creatures;
+    for(EntityBase* target : targets)
+    {
+        if(playerMana < pricePerTarget)
             break;
 
         if(target->getObjectType() != GameEntityType::creature)
@@ -69,53 +92,95 @@ int SpellCreatureHeal::getSpellCost(std::vector<EntityBase*>& targets, GameMap* 
             continue;
         }
 
-        // Only hurt creatures can be healed
         Creature* creature = static_cast<Creature*>(target);
-        if(!creature->isHurt())
-            continue;
+        creatures.push_back(creature);
 
-        targets.push_back(target);
-
-        priceTotal += pricePerTile;
-        playerMana -= pricePerTile;
+        priceTotal += pricePerTarget;
+        playerMana -= pricePerTarget;
     }
 
-    return priceTotal;
+    std::string txt = formatSpellPrice(SpellType::creatureHeal, priceTotal);
+    inputCommand.displayText(Ogre::ColourValue::White, txt);
+
+    if(inputManager.mCommandState != InputCommandState::validated)
+        return;
+
+    inputCommand.unselectAllTiles();
+
+    ClientNotification *clientNotification = SpellManager::createSpellClientNotification(SpellType::creatureHeal);
+    uint32_t nbCreatures = creatures.size();
+    clientNotification->mPacket << nbCreatures;
+    for(Creature* creature : creatures)
+        clientNotification->mPacket << creature->getName();
+
+    ODClient::getSingleton().queueClientNotification(clientNotification);
 }
 
-void SpellCreatureHeal::castSpell(GameMap* gameMap, const std::vector<EntityBase*>& targets, Player* player)
+bool SpellCreatureHeal::castSpell(GameMap* gameMap, Player* player, ODPacket& packet)
 {
-    player->setSpellCooldownTurns(SpellType::creatureHeal, ConfigManager::getSingleton().getSpellConfigUInt32("CreatureHealCooldown"));
-    for(EntityBase* target : targets)
+    uint32_t nbCreatures;
+    OD_ASSERT_TRUE(packet >> nbCreatures);
+    std::vector<Creature*> creatures;
+    while(nbCreatures > 0)
     {
-        if(target->getObjectType() != GameEntityType::creature)
+        --nbCreatures;
+        std::string creatureName;
+        OD_ASSERT_TRUE(packet >> creatureName);
+
+        // We check that the creatures are valid targets
+        Creature* creature = gameMap->getCreature(creatureName);
+        if(creature == nullptr)
         {
-            static bool logMsg = false;
-            if(!logMsg)
-            {
-                logMsg = true;
-                OD_ASSERT_TRUE_MSG(false, "Wrong target name=" + target->getName() + ", type=" + Helper::toString(static_cast<int32_t>(target->getObjectType())));
-            }
+            OD_ASSERT_TRUE_MSG(false, "creatureName=" + creatureName);
             continue;
         }
 
-        Creature* creature = static_cast<Creature*>(target);
-        if(creature->getHP() <= 0)
+        if(!creature->getSeat()->isAlliedSeat(player->getSeat()))
         {
-            static bool logMsg = false;
-            if(!logMsg)
-            {
-                logMsg = true;
-                OD_ASSERT_TRUE_MSG(false, "Dead creature target name=" + creature->getName());
-            }
+            OD_ASSERT_TRUE_MSG(false, "creatureName=" + creatureName);
             continue;
         }
 
-        CreatureEffectHeal* effect = new CreatureEffectHeal(ConfigManager::getSingleton().getSpellConfigUInt32("CreatureHealDuration"),
-            ConfigManager::getSingleton().getSpellConfigDouble("CreatureHealValue"),
-            "SpellCreatureHeal");
+        Tile* pos = creature->getPositionTile();
+        if(pos == nullptr)
+        {
+            OD_ASSERT_TRUE_MSG(false, "creatureName=" + creatureName);
+            continue;
+        }
+
+        // That can happen if the creature is not in perfect synchronization and is not on a claimed tile on the server gamemap
+        if(!pos->isClaimedForSeat(player->getSeat()))
+        {
+            LogManager::getSingleton().logMessage("WARNING : " + creatureName + ", tile=" + Tile::displayAsString(pos));
+            continue;
+        }
+
+        creatures.push_back(creature);
+    }
+
+    if(creatures.empty())
+        return false;
+
+    int32_t pricePerTarget = ConfigManager::getSingleton().getSpellConfigInt32("CreatureHealPrice");
+    int32_t playerMana = static_cast<int32_t>(player->getSeat()->getMana());
+    int32_t nbTargets = playerMana / pricePerTarget;
+    int32_t priceTotal = nbTargets * pricePerTarget;
+
+    if(creatures.size() > static_cast<uint32_t>(nbTargets))
+        creatures.resize(nbTargets);
+
+    if(!player->getSeat()->takeMana(priceTotal))
+        return false;
+
+    uint32_t duration = ConfigManager::getSingleton().getSpellConfigUInt32("CreatureHealDuration");
+    double value = ConfigManager::getSingleton().getSpellConfigDouble("CreatureHealValue");
+    for(Creature* creature : creatures)
+    {
+        CreatureEffectHeal* effect = new CreatureEffectHeal(duration, value, "SpellCreatureHeal");
         creature->addCreatureEffect(effect);
     }
+
+    return true;
 }
 
 Spell* SpellCreatureHeal::getSpellFromStream(GameMap* gameMap, std::istream &is)

--- a/source/spells/SpellCreatureHeal.h
+++ b/source/spells/SpellCreatureHeal.h
@@ -22,14 +22,14 @@
 #include "spells/SpellType.h"
 
 class GameMap;
+class InputCommand;
+class InputManager;
 
 class SpellCreatureHeal : public Spell
 {
 public:
-    static int getSpellCost(std::vector<EntityBase*>& targets, GameMap* gameMap, SpellType type,
-        int tileX1, int tileY1, int tileX2, int tileY2, Player* player);
-
-    static void castSpell(GameMap* gameMap, const std::vector<EntityBase*>& targets, Player* player);
+    static void checkSpellCast(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool castSpell(GameMap* gameMap, Player* player, ODPacket& packet);
 
     static Spell* getSpellFromStream(GameMap* gameMap, std::istream &is);
     static Spell* getSpellFromPacket(GameMap* gameMap, ODPacket &is);

--- a/source/spells/SpellManager.cpp
+++ b/source/spells/SpellManager.cpp
@@ -17,37 +17,38 @@
 
 #include "spells/SpellManager.h"
 
+#include "ODApplication.h"
+#include "game/Player.h"
+#include "gamemap/GameMap.h"
+#include "modes/InputCommand.h"
+#include "network/ClientNotification.h"
 #include "network/ODPacket.h"
-
 #include "spells/SpellType.h"
-
 #include "utils/Helper.h"
 #include "utils/LogManager.h"
 
 const std::string EMPTY_STRING;
 
-int SpellFunctions::getSpellCostFunc(std::vector<EntityBase*>& targets, GameMap* gameMap, SpellType type,
-    int tileX1, int tileY1, int tileX2, int tileY2, Player* player) const
+void SpellFunctions::checkSpellCastFunc(GameMap* gameMap, SpellType type, const InputManager& inputManager, InputCommand& inputCommand) const
 {
-    if(mGetSpellCostFunc == nullptr)
+    if(mCheckSpellCastFunc == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "null mGetSpellCostFunc function spell=" + Helper::toString(static_cast<uint32_t>(type)));
-        return 0;
+        OD_ASSERT_TRUE_MSG(false, "null mCheckSpellCastFunc function spell=" + Helper::toString(static_cast<uint32_t>(type)));
+        return;
     }
 
-    return mGetSpellCostFunc(targets, gameMap, type, tileX1, tileY1, tileX2, tileY2, player);
+    mCheckSpellCastFunc(gameMap, inputManager, inputCommand);
 }
 
-void SpellFunctions::castSpellFunc(GameMap* gameMap, SpellType type, const std::vector<EntityBase*>& targets,
-    Player* player) const
+bool SpellFunctions::castSpellFunc(GameMap* gameMap, SpellType type, Player* player, ODPacket& packet) const
 {
     if(mCastSpellFunc == nullptr)
     {
         OD_ASSERT_TRUE_MSG(false, "null mCastSpellFunc function spell=" + Helper::toString(static_cast<uint32_t>(type)));
-        return;
+        return false;
     }
 
-    mCastSpellFunc(gameMap, targets, player);
+    return mCastSpellFunc(gameMap, player, packet);
 }
 
 Spell* SpellFunctions::getSpellFromStreamFunc(GameMap* gameMap, SpellType type, std::istream& is) const
@@ -79,22 +80,7 @@ std::vector<SpellFunctions>& getSpellFunctions()
     return spellList;
 }
 
-int SpellManager::getSpellCost(std::vector<EntityBase*>& targets, GameMap* gameMap, SpellType type,
-    int tileX1, int tileY1, int tileX2, int tileY2, Player* player)
-{
-    uint32_t index = static_cast<uint32_t>(type);
-    if(index >= getSpellFunctions().size())
-    {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
-        return 0;
-    }
-
-    SpellFunctions& spellFuncs = getSpellFunctions()[index];
-    return spellFuncs.getSpellCostFunc(targets, gameMap, type, tileX1, tileY1, tileX2, tileY2, player);
-}
-
-void SpellManager::castSpell(GameMap* gameMap, SpellType type, const std::vector<EntityBase*>& targets,
-    Player* player)
+void SpellManager::checkSpellCast(GameMap* gameMap, SpellType type, const InputManager& inputManager, InputCommand& inputCommand)
 {
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getSpellFunctions().size())
@@ -103,8 +89,32 @@ void SpellManager::castSpell(GameMap* gameMap, SpellType type, const std::vector
         return;
     }
 
+    Player* player = gameMap->getLocalPlayer();
+    uint32_t cooldown = player->getSpellCooldownTurns(type);
+    if(cooldown > 0)
+    {
+        double remainingTime = static_cast<double>(cooldown) / ODApplication::turnsPerSecond;
+        std::string errorStr = getSpellNameFromSpellType(type)
+            + " (" + Helper::toString(remainingTime, 2)+ " s)";
+
+        inputCommand.displayText(Ogre::ColourValue::Red, errorStr);
+        return;
+    }
     SpellFunctions& spellFuncs = getSpellFunctions()[index];
-    spellFuncs.castSpellFunc(gameMap, type, targets, player);
+    spellFuncs.checkSpellCastFunc(gameMap, type, inputManager, inputCommand);
+}
+
+bool SpellManager::castSpell(GameMap* gameMap, SpellType type, Player* player, ODPacket& packet)
+{
+    uint32_t index = static_cast<uint32_t>(type);
+    if(index >= getSpellFunctions().size())
+    {
+        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        return false;
+    }
+
+    SpellFunctions& spellFuncs = getSpellFunctions()[index];
+    return spellFuncs.castSpellFunc(gameMap, type, player, packet);
 }
 
 Spell* SpellManager::getSpellFromStream(GameMap* gameMap, std::istream& is)
@@ -164,7 +174,7 @@ SpellType SpellManager::getSpellTypeFromSpellName(const std::string& name)
 }
 
 void SpellManager::registerSpell(SpellType type, const std::string& name,
-    SpellFunctions::GetSpellCostFunc getSpellCostFunc,
+    SpellFunctions::CheckSpellCastFunc checkSpellCastFunc,
     SpellFunctions::CastSpellFunc castSpellFunc,
     SpellFunctions::GetSpellFromStreamFunc getSpellFromStreamFunc,
     SpellFunctions::GetSpellFromPacketFunc getSpellFromPacketFunc)
@@ -178,8 +188,15 @@ void SpellManager::registerSpell(SpellType type, const std::string& name,
 
     SpellFunctions& spellFuncs = getSpellFunctions()[index];
     spellFuncs.mName = name;
-    spellFuncs.mGetSpellCostFunc = getSpellCostFunc;
+    spellFuncs.mCheckSpellCastFunc = checkSpellCastFunc;
     spellFuncs.mCastSpellFunc = castSpellFunc;
     spellFuncs.mGetSpellFromStreamFunc = getSpellFromStreamFunc;
     spellFuncs.mGetSpellFromPacketFunc = getSpellFromPacketFunc;
+}
+
+ClientNotification* SpellManager::createSpellClientNotification(SpellType type)
+{
+    ClientNotification *clientNotification = new ClientNotification(ClientNotificationType::askCastSpell);
+    clientNotification->mPacket << type;
+    return clientNotification;
 }

--- a/source/spells/SpellManager.cpp
+++ b/source/spells/SpellManager.cpp
@@ -33,7 +33,7 @@ void SpellFunctions::checkSpellCastFunc(GameMap* gameMap, SpellType type, const 
 {
     if(mCheckSpellCastFunc == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "null mCheckSpellCastFunc function spell=" + Helper::toString(static_cast<uint32_t>(type)));
+        OD_LOG_ERR("null mCheckSpellCastFunc function spell=" + Helper::toString(static_cast<uint32_t>(type)));
         return;
     }
 
@@ -44,7 +44,7 @@ bool SpellFunctions::castSpellFunc(GameMap* gameMap, SpellType type, Player* pla
 {
     if(mCastSpellFunc == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "null mCastSpellFunc function spell=" + Helper::toString(static_cast<uint32_t>(type)));
+        OD_LOG_ERR("null mCastSpellFunc function spell=" + Helper::toString(static_cast<uint32_t>(type)));
         return false;
     }
 
@@ -55,7 +55,7 @@ Spell* SpellFunctions::getSpellFromStreamFunc(GameMap* gameMap, SpellType type, 
 {
     if(mGetSpellFromStreamFunc == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "null mGetSpellFromStreamFunc function spell=" + Helper::toString(static_cast<uint32_t>(type)));
+        OD_LOG_ERR("null mGetSpellFromStreamFunc function spell=" + Helper::toString(static_cast<uint32_t>(type)));
         return nullptr;
     }
 
@@ -66,7 +66,7 @@ Spell* SpellFunctions::getSpellFromPacketFunc(GameMap* gameMap, SpellType type, 
 {
     if(mGetSpellFromPacketFunc == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "null mGetSpellFromPacketFunc function spell=" + Helper::toString(static_cast<uint32_t>(type)));
+        OD_LOG_ERR("null mGetSpellFromPacketFunc function spell=" + Helper::toString(static_cast<uint32_t>(type)));
         return nullptr;
     }
 
@@ -85,7 +85,7 @@ void SpellManager::checkSpellCast(GameMap* gameMap, SpellType type, const InputM
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getSpellFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return;
     }
 
@@ -109,7 +109,7 @@ bool SpellManager::castSpell(GameMap* gameMap, SpellType type, Player* player, O
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getSpellFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return false;
     }
 
@@ -124,7 +124,7 @@ Spell* SpellManager::getSpellFromStream(GameMap* gameMap, std::istream& is)
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getSpellFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return nullptr;
     }
 
@@ -139,7 +139,7 @@ Spell* SpellManager::getSpellFromPacket(GameMap* gameMap, ODPacket& is)
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getSpellFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return nullptr;
     }
 
@@ -152,7 +152,7 @@ const std::string& SpellManager::getSpellNameFromSpellType(SpellType type)
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getSpellFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return EMPTY_STRING;
     }
     SpellFunctions& spellFuncs = getSpellFunctions()[index];
@@ -169,7 +169,7 @@ SpellType SpellManager::getSpellTypeFromSpellName(const std::string& name)
             return static_cast<SpellType>(i);
     }
 
-    OD_ASSERT_TRUE_MSG(false, "Cannot find spell name=" + name);
+    OD_LOG_ERR("Cannot find spell name=" + name);
     return SpellType::nullSpellType;
 }
 
@@ -182,7 +182,7 @@ void SpellManager::registerSpell(SpellType type, const std::string& name,
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getSpellFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return;
     }
 

--- a/source/spells/SpellSummonWorker.cpp
+++ b/source/spells/SpellSummonWorker.cpp
@@ -157,7 +157,7 @@ bool SpellSummonWorker::summonWorkersOnTiles(GameMap* gameMap, Player* player, c
         pricePerWorker *= std::pow(2, nbWorkers - nbFreeWorkers);
 
     int32_t playerMana = static_cast<int32_t>(player->getSeat()->getMana());
-    int32_t manaCost = pricePerWorker;
+    int32_t priceTotal = 0;
 
     std::vector<Tile*> tilesSummon;
     for(Tile* tile : tiles)
@@ -169,16 +169,16 @@ bool SpellSummonWorker::summonWorkersOnTiles(GameMap* gameMap, Player* player, c
             continue;
         }
 
-        if(playerMana < manaCost)
-            break;
+        int32_t newPrice = priceTotal + pricePerWorker;
+        if(newPrice > playerMana)
+                break;
 
         tilesSummon.push_back(tile);
-        ++nbWorkers;
-        manaCost += pricePerWorker;
+        priceTotal = newPrice;
         pricePerWorker *= 2;
     }
 
-    if(!player->getSeat()->takeMana(manaCost))
+    if(!player->getSeat()->takeMana(priceTotal))
         return false;
 
     for(Tile* tile : tilesSummon)

--- a/source/spells/SpellSummonWorker.cpp
+++ b/source/spells/SpellSummonWorker.cpp
@@ -77,7 +77,7 @@ void SpellSummonWorker::checkSpellCast(GameMap* gameMap, const InputManager& inp
             if(!logMsg)
             {
                 logMsg = true;
-                OD_ASSERT_TRUE_MSG(false, "Wrong target name=" + target->getName() + ", type=" + Helper::toString(static_cast<int32_t>(target->getObjectType())));
+                OD_LOG_ERR("Wrong target name=" + target->getName() + ", type=" + Helper::toString(static_cast<int32_t>(target->getObjectType())));
             }
             continue;
         }
@@ -146,7 +146,7 @@ bool SpellSummonWorker::summonWorkersOnTiles(GameMap* gameMap, Player* player, c
 
     if (classToSpawn == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "No worker creature definition, class=nullptr, player=" + player->getNick());
+        OD_LOG_ERR("No worker creature definition, class=nullptr, player=" + player->getNick());
         return false;
     }
 
@@ -215,12 +215,12 @@ int32_t SpellSummonWorker::getNextWorkerPriceForPlayer(GameMap* gameMap, Player*
 
 Spell* SpellSummonWorker::getSpellFromStream(GameMap* gameMap, std::istream &is)
 {
-    OD_ASSERT_TRUE_MSG(false, "SpellSummonWorker cannot be read from stream");
+    OD_LOG_ERR("SpellSummonWorker cannot be read from stream");
     return nullptr;
 }
 
 Spell* SpellSummonWorker::getSpellFromPacket(GameMap* gameMap, ODPacket &is)
 {
-    OD_ASSERT_TRUE_MSG(false, "SpellSummonWorker cannot be read from packet");
+    OD_LOG_ERR("SpellSummonWorker cannot be read from packet");
     return nullptr;
 }

--- a/source/spells/SpellSummonWorker.cpp
+++ b/source/spells/SpellSummonWorker.cpp
@@ -184,7 +184,7 @@ bool SpellSummonWorker::summonWorkersOnTiles(GameMap* gameMap, Player* player, c
     for(Tile* tile : tilesSummon)
     {
         Creature* newCreature = new Creature(gameMap, true, classToSpawn, player->getSeat());
-        LogManager::getSingleton().logMessage("Spawning a creature class=" + classToSpawn->getClassName()
+        OD_LOG_INF("Spawning a creature class=" + classToSpawn->getClassName()
             + ", name=" + newCreature->getName() + ", seatId=" + Helper::toString(player->getSeat()->getId()));
 
         newCreature->addToGameMap();

--- a/source/spells/SpellSummonWorker.h
+++ b/source/spells/SpellSummonWorker.h
@@ -21,14 +21,16 @@
 #include "spells/Spell.h"
 
 class GameMap;
+class InputCommand;
+class InputManager;
 
 class SpellSummonWorker : public Spell
 {
 public:
-    static int getSpellCost(std::vector<EntityBase*>& targets, GameMap* gameMap, SpellType type,
-        int tileX1, int tileY1, int tileX2, int tileY2, Player* player);
-
-    static void castSpell(GameMap* gameMap, const std::vector<EntityBase*>& targets, Player* player);
+    static void checkSpellCast(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool castSpell(GameMap* gameMap, Player* player, ODPacket& packet);
+    static bool summonWorkersOnTiles(GameMap* gameMap, Player* player, const std::vector<Tile*>& tiles);
+    static int32_t getNextWorkerPriceForPlayer(GameMap* gameMap, Player* player);
 
     static Spell* getSpellFromStream(GameMap* gameMap, std::istream &is);
     static Spell* getSpellFromPacket(GameMap* gameMap, ODPacket &is);

--- a/source/traps/Trap.cpp
+++ b/source/traps/Trap.cpp
@@ -653,6 +653,8 @@ bool Trap::buildTrapDefault(GameMap* gameMap, Trap* trap, Seat* seat, const std:
     trap->addToGameMap();
     trap->createMesh();
 
+    trap->updateActiveSpots();
+
     if((seat->getPlayer() != nullptr) &&
        (seat->getPlayer()->getIsHuman()))
     {
@@ -692,8 +694,6 @@ bool Trap::buildTrapDefault(GameMap* gameMap, Trap* trap, Seat* seat, const std:
             ODServer::getSingleton().sendAsyncMsg(serverNotification);
         }
     }
-
-    trap->updateActiveSpots();
 
     return true;
 }

--- a/source/traps/Trap.cpp
+++ b/source/traps/Trap.cpp
@@ -529,7 +529,7 @@ void Trap::importTileDataFromStream(std::istream& is, Tile* tile, TileData* tile
             OD_LOG_ERR("trap=" + getName() + ", seatId=" + Helper::toString(seatId));
             continue;
         }
-        trapTileData->mSeatsVision.push_back(seat);
+        trapTileData->seatSawTriggering(seat);
     }
 }
 

--- a/source/traps/Trap.cpp
+++ b/source/traps/Trap.cpp
@@ -310,16 +310,18 @@ bool Trap::hasCarryEntitySpot(GameEntity* carriedEntity)
 
 Tile* Trap::askSpotForCarriedEntity(GameEntity* carriedEntity)
 {
-    OD_ASSERT_TRUE_MSG(carriedEntity->getObjectType() == GameEntityType::craftedTrap,
-        "Trap=" + getName() + ", entity=" + carriedEntity->getName());
     if(carriedEntity->getObjectType() != GameEntityType::craftedTrap)
+    {
+        OD_LOG_ERR("Trap=" + getName() + ", entity=" + carriedEntity->getName());
         return nullptr;
+    }
 
     CraftedTrap* craftedTrap = static_cast<CraftedTrap*>(carriedEntity);
-    OD_ASSERT_TRUE_MSG(craftedTrap->getTrapType() == getType(),
-        "Trap=" + getName() + ", entity=" + carriedEntity->getName());
     if(craftedTrap->getTrapType() != getType())
+    {
+        OD_LOG_ERR("Trap=" + getName() + ", entity=" + carriedEntity->getName());
         return nullptr;
+    }
 
     for(Tile* tile : mCoveredTiles)
     {
@@ -359,9 +361,9 @@ void Trap::notifyCarryingStateChanged(Creature* carrier, GameEntity* carriedEnti
 
         // We check if the carrier is at the expected destination
         Tile* carrierTile = carrier->getPositionTile();
-        OD_ASSERT_TRUE_MSG(carrierTile != nullptr, "carrier=" + carrier->getName());
         if(carrierTile == nullptr)
         {
+            OD_LOG_ERR("carrier=" + carrier->getName());
             trapTileData->setCarriedCraftedTrap(nullptr);
             return;
         }
@@ -396,7 +398,7 @@ bool Trap::isAttackable(Tile* tile, Seat* seat) const
     // We check if the trap is hidden for this seat
     if(mTileData.count(tile) <= 0)
     {
-        OD_ASSERT_TRUE_MSG(false, "name=" + getName() + ", tile=" + Tile::displayAsString(tile));
+        OD_LOG_ERR("name=" + getName() + ", tile=" + Tile::displayAsString(tile));
         return false;
     }
 
@@ -423,7 +425,7 @@ void Trap::restoreInitialEntityState()
         TrapEntity* trapEntity = trapTileData->getTrapEntity();
         if(trapEntity == nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "tile=" + Tile::displayAsString(p.first));
+            OD_LOG_ERR("tile=" + Tile::displayAsString(p.first));
             continue;
         }
 
@@ -524,7 +526,7 @@ void Trap::importTileDataFromStream(std::istream& is, Tile* tile, TileData* tile
         Seat* seat = gameMap->getSeatById(seatId);
         if(seat == nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "trap=" + getName() + ", seatId=" + Helper::toString(seatId));
+            OD_LOG_ERR("trap=" + getName() + ", seatId=" + Helper::toString(seatId));
             continue;
         }
         trapTileData->mSeatsVision.push_back(seat);
@@ -540,7 +542,7 @@ bool Trap::isTileVisibleForSeat(Tile* tile, Seat* seat) const
 {
     if(mTileData.count(tile) <= 0)
     {
-        OD_ASSERT_TRUE_MSG(false, "trap=" + getName() + ", tile=" + Tile::displayAsString(tile));
+        OD_LOG_ERR("trap=" + getName() + ", tile=" + Tile::displayAsString(tile));
         return false;
     }
 
@@ -563,7 +565,7 @@ void Trap::claimForSeat(Seat* seat, Tile* tile, double danceRate)
 {
     if(mTileData.count(tile) <= 0)
     {
-        OD_ASSERT_TRUE_MSG(false, "trap=" + getName() + ", tile=" + Tile::displayAsString(tile));
+        OD_LOG_ERR("trap=" + getName() + ", tile=" + Tile::displayAsString(tile));
         return;
     }
 
@@ -651,13 +653,13 @@ bool Trap::getTrapTilesDefault(std::vector<Tile*>& tiles, GameMap* gameMap, Play
         Tile* tile = gameMap->tileFromPacket(packet);
         if(tile == nullptr)
         {
-            OD_ASSERT_TRUE(false);
+            OD_LOG_ERR("unexpected null tile");
             return false;
         }
 
         if(!tile->isBuildableUpon(player->getSeat()))
         {
-            OD_ASSERT_TRUE_MSG(false, "tile=" + Tile::displayAsString(tile) + ", seatId=" + Helper::toString(player->getSeat()->getId()));
+            OD_LOG_ERR("tile=" + Tile::displayAsString(tile) + ", seatId=" + Helper::toString(player->getSeat()->getId()));
             continue;
         }
 
@@ -768,7 +770,7 @@ bool Trap::buildTrapDefaultEditor(GameMap* gameMap, Trap* trap, ODPacket& packet
     Seat* seatTrap = gameMap->getSeatById(seatId);
     if(seatTrap == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "seatId=" + Helper::toString(seatId));
+        OD_LOG_ERR("seatId=" + Helper::toString(seatId));
         return false;
     }
 
@@ -782,14 +784,14 @@ bool Trap::buildTrapDefaultEditor(GameMap* gameMap, Trap* trap, ODPacket& packet
         Tile* tile = gameMap->tileFromPacket(packet);
         if(tile == nullptr)
         {
-            OD_ASSERT_TRUE(false);
+            OD_LOG_ERR("unexpected null tile");
             return false;
         }
 
         // If the tile is not buildable, we change it
         if(tile->getCoveringBuilding() != nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "tile=" + Tile::displayAsString(tile) + ", seatId=" + Helper::toString(seatId));
+            OD_LOG_ERR("tile=" + Tile::displayAsString(tile) + ", seatId=" + Helper::toString(seatId));
             continue;
         }
 

--- a/source/traps/Trap.h
+++ b/source/traps/Trap.h
@@ -140,6 +140,10 @@ public:
     inline void setRemoveTrap(bool removeTrap)
     { mRemoveTrap = removeTrap; }
 
+    void fireSeatsSawTriggering();
+    void seatSawTriggering(Seat* seat);
+    void seatsSawTriggering(const std::vector<Seat*>& seats);
+
     double mClaimedValue;
 
 private:

--- a/source/traps/Trap.h
+++ b/source/traps/Trap.h
@@ -27,12 +27,14 @@
 class CraftedTrap;
 class Creature;
 class GameMap;
+class InputCommand;
+class InputManager;
+class ODPacket;
 class Player;
+class RenderedMovableEntity;
 class Seat;
 class Tile;
 class TrapEntity;
-class RenderedMovableEntity;
-class ODPacket;
 
 enum class TrapType;
 
@@ -207,9 +209,17 @@ public:
 
     static std::string getTrapStreamFormat();
 
-    static void buildTrapDefault(GameMap* gameMap, Trap* trap, const std::vector<Tile*>& tiles, Seat* seat);
-    static int getTrapCostDefault(std::vector<Tile*>& tiles, GameMap* gameMap, TrapType type,
-        int tileX1, int tileY1, int tileX2, int tileY2, Player* player);
+    static std::string formatTrapPrice(TrapType type, uint32_t price);
+
+    //! \brief Computes the trap cost by checking the buildable tiles according to the given inputManager
+    //! and updates the inputCommand with (price/buildable tiles)
+    //! Note that traps that use checkBuildTrapDefault should also use buildTrapDefault and vice-versa
+    //! to make sure everything works if the data sent/received are changed
+    static void checkBuildTrapDefault(GameMap* gameMap, TrapType type, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool getTrapTilesDefault(std::vector<Tile*>& tiles, GameMap* gameMap, Player* player, ODPacket& packet);
+    static bool buildTrapDefault(GameMap* gameMap, Trap* trap, Seat* seat, const std::vector<Tile*>& tiles);
+    static void checkBuildTrapDefaultEditor(GameMap* gameMap, TrapType type, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildTrapDefaultEditor(GameMap* gameMap, Trap* trap, ODPacket& packet);
 
 protected:
     virtual TrapTileData* createTileData(Tile* tile) override;

--- a/source/traps/TrapBoulder.h
+++ b/source/traps/TrapBoulder.h
@@ -47,9 +47,11 @@ public:
 
     virtual TrapEntity* getTrapEntity(Tile* tile);
 
-    static int getTrapCost(std::vector<Tile*>& tiles, GameMap* gameMap, TrapType type,
-        int tileX1, int tileY1, int tileX2, int tileY2, Player* player);
-    static void buildTrap(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat);
+    static void checkBuildTrap(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildTrap(GameMap* gameMap, Player* player, ODPacket& packet);
+    static void checkBuildTrapEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildTrapEditor(GameMap* gameMap, ODPacket& packet);
+    static bool buildTrapOnTiles(GameMap* gameMap, Player* player, const std::vector<Tile*>& tiles);
     static Trap* getTrapFromStream(GameMap* gameMap, std::istream& is);
 };
 

--- a/source/traps/TrapCannon.h
+++ b/source/traps/TrapCannon.h
@@ -45,9 +45,11 @@ public:
 
     virtual TrapEntity* getTrapEntity(Tile* tile);
 
-    static int getTrapCost(std::vector<Tile*>& tiles, GameMap* gameMap, TrapType type,
-        int tileX1, int tileY1, int tileX2, int tileY2, Player* player);
-    static void buildTrap(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat);
+    static void checkBuildTrap(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildTrap(GameMap* gameMap, Player* player, ODPacket& packet);
+    static void checkBuildTrapEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildTrapEditor(GameMap* gameMap, ODPacket& packet);
+    static bool buildTrapOnTiles(GameMap* gameMap, Player* player, const std::vector<Tile*>& tiles);
     static Trap* getTrapFromStream(GameMap* gameMap, std::istream& is);
 
 private:

--- a/source/traps/TrapDoor.cpp
+++ b/source/traps/TrapDoor.cpp
@@ -82,7 +82,7 @@ void TrapDoor::doUpkeep()
         {
             if(mTileData.count(tile) <= 0)
             {
-                OD_ASSERT_TRUE_MSG(false, "trap=" + getName() + ", tile=" + Tile::displayAsString(tile));
+                OD_LOG_ERR("trap=" + getName() + ", tile=" + Tile::displayAsString(tile));
                 return;
             }
 
@@ -210,7 +210,7 @@ void TrapDoor::checkBuildTrapEditor(GameMap* gameMap, const InputManager& inputM
     Seat* seat = gameMap->getSeatById(inputManager.mSeatIdSelected);
     if(seat == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "seatId=" + Helper::toString(inputManager.mSeatIdSelected));
+        OD_LOG_ERR("seatId=" + Helper::toString(inputManager.mSeatIdSelected));
         return;
     }
 
@@ -269,7 +269,7 @@ bool TrapDoor::buildTrapEditor(GameMap* gameMap, ODPacket& packet)
     Seat* seatTrap = gameMap->getSeatById(seatId);
     if(seatTrap == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "seatId=" + Helper::toString(seatId));
+        OD_LOG_ERR("seatId=" + Helper::toString(seatId));
         return false;
     }
 
@@ -280,7 +280,7 @@ bool TrapDoor::buildTrapEditor(GameMap* gameMap, ODPacket& packet)
     // If the tile is not buildable, we change it
     if(tile->getCoveringBuilding() != nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "tile=" + Tile::displayAsString(tile) + ", seatId=" + Helper::toString(seatId));
+        OD_LOG_ERR("tile=" + Tile::displayAsString(tile) + ", seatId=" + Helper::toString(seatId));
         return false;
     }
 

--- a/source/traps/TrapDoor.h
+++ b/source/traps/TrapDoor.h
@@ -58,15 +58,17 @@ public:
 
     virtual bool canCreatureGoThroughTile(const Creature* creature, Tile* tile) const override;
 
-    //! Returns true is tiles North and South (or east and west) are suitable to have a door on the
+    //! Returns true if tiles North and South (or east and west) are suitable to have a door on the
     //! given tile
     static bool canDoorBeOnTile(GameMap* gameMap, Tile* tile);
 
     virtual bool permitsVision(Tile* tile) override;
 
-    static int getTrapCost(std::vector<Tile*>& tiles, GameMap* gameMap, TrapType type,
-        int tileX1, int tileY1, int tileX2, int tileY2, Player* player);
-    static void buildTrap(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat);
+    static void checkBuildTrap(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildTrap(GameMap* gameMap, Player* player, ODPacket& packet);
+    static void checkBuildTrapEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildTrapEditor(GameMap* gameMap, ODPacket& packet);
+    static bool buildTrapOnTile(GameMap* gameMap, Player* player, Tile* tile);
     static Trap* getTrapFromStream(GameMap* gameMap, std::istream& is);
 
 private:

--- a/source/traps/TrapManager.cpp
+++ b/source/traps/TrapManager.cpp
@@ -223,7 +223,7 @@ void TrapManager::checkSellTrapTiles(GameMap* gameMap, const InputManager& input
         // We do not differentiate between Trap and trap (because there is no way to know on client side).
         // Note that price = 0 doesn't mean that the building is not a Trap
         Tile* tile = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
-        if((tile == nullptr) || (!tile->getIsBuilding()) || (tile->getSeat() != player->getSeat()))
+        if((tile == nullptr) || (!tile->getIsTrap()) || (tile->getSeat() != player->getSeat()))
         {
             std::string txt = formatSellTrap(0);
             inputCommand.displayText(Ogre::ColourValue::White, txt);
@@ -246,7 +246,7 @@ void TrapManager::checkSellTrapTiles(GameMap* gameMap, const InputManager& input
     uint32_t priceTotal = 0;
     for(Tile* tile : tiles)
     {
-        if(!tile->getIsBuilding())
+        if(!tile->getIsTrap())
             continue;
 
         if(tile->getSeat() != player->getSeat())
@@ -365,7 +365,7 @@ void TrapManager::checkSellTrapTilesEditor(GameMap* gameMap, const InputManager&
         // We do not differentiate between Trap and trap (because there is no way to know on client side).
         // Note that price = 0 doesn't mean that the building is not a Trap
         Tile* tile = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
-        if((tile == nullptr) || (!tile->getIsBuilding()))
+        if((tile == nullptr) || (!tile->getIsTrap()))
         {
             inputCommand.displayText(Ogre::ColourValue::White, "Remove tiles");
             inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos, inputManager.mYPos);
@@ -384,7 +384,7 @@ void TrapManager::checkSellTrapTilesEditor(GameMap* gameMap, const InputManager&
         inputManager.mYPos, inputManager.mLStartDragX, inputManager.mLStartDragY);
     for(Tile* tile : tiles)
     {
-        if(!tile->getIsBuilding())
+        if(!tile->getIsTrap())
             continue;
 
         sellTiles.push_back(tile);

--- a/source/traps/TrapManager.cpp
+++ b/source/traps/TrapManager.cpp
@@ -48,7 +48,7 @@ void TrapFunctions::checkBuildTrapFunc(GameMap* gameMap, TrapType type, const In
 {
     if(mCheckBuildTrapFunc == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "null mCheckBuildTrap function Trap=" + Helper::toString(static_cast<uint32_t>(type)));
+        OD_LOG_ERR("null mCheckBuildTrap function Trap=" + Helper::toString(static_cast<uint32_t>(type)));
         return;
     }
 
@@ -59,7 +59,7 @@ bool TrapFunctions::buildTrapFunc(GameMap* gameMap, TrapType type, Player* playe
 {
     if(mBuildTrapFunc == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "null mBuildTrapFunc function Trap=" + Helper::toString(static_cast<uint32_t>(type)));
+        OD_LOG_ERR("null mBuildTrapFunc function Trap=" + Helper::toString(static_cast<uint32_t>(type)));
         return false;
     }
 
@@ -70,7 +70,7 @@ void TrapFunctions::checkBuildTrapEditorFunc(GameMap* gameMap, TrapType type, co
 {
     if(mCheckBuildTrapEditorFunc == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "null mCheckBuildTrapEditorFund function Trap=" + Helper::toString(static_cast<uint32_t>(type)));
+        OD_LOG_ERR("null mCheckBuildTrapEditorFund function Trap=" + Helper::toString(static_cast<uint32_t>(type)));
         return;
     }
 
@@ -81,7 +81,7 @@ bool TrapFunctions::buildTrapEditorFunc(GameMap* gameMap, TrapType type, ODPacke
 {
     if(mBuildTrapEditorFunc == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "null mBuildTrapEditorFunc function Trap=" + Helper::toString(static_cast<uint32_t>(type)));
+        OD_LOG_ERR("null mBuildTrapEditorFunc function Trap=" + Helper::toString(static_cast<uint32_t>(type)));
         return false;
     }
 
@@ -92,7 +92,7 @@ Trap* TrapFunctions::getTrapFromStreamFunc(GameMap* gameMap, TrapType type, std:
 {
     if(mGetTrapFromStreamFunc == nullptr)
     {
-        OD_ASSERT_TRUE_MSG(false, "null mGetTrapFromStreamFunc function Trap=" + Helper::toString(static_cast<uint32_t>(type)));
+        OD_LOG_ERR("null mGetTrapFromStreamFunc function Trap=" + Helper::toString(static_cast<uint32_t>(type)));
         return nullptr;
     }
 
@@ -104,7 +104,7 @@ void TrapManager::checkBuildTrap(GameMap* gameMap, TrapType type, const InputMan
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getTrapFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return;
     }
 
@@ -117,7 +117,7 @@ bool TrapManager::buildTrap(GameMap* gameMap, TrapType type, Player* player, ODP
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getTrapFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return false;
     }
 
@@ -130,7 +130,7 @@ void TrapManager::checkBuildTrapEditor(GameMap* gameMap, TrapType type, const In
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getTrapFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return;
     }
 
@@ -143,7 +143,7 @@ bool TrapManager::buildTrapEditor(GameMap* gameMap, TrapType type, ODPacket& pac
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getTrapFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return false;
     }
 
@@ -158,7 +158,7 @@ Trap* TrapManager::getTrapFromStream(GameMap* gameMap, std::istream& is)
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getTrapFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return nullptr;
     }
 
@@ -171,7 +171,7 @@ const std::string& TrapManager::getTrapNameFromTrapType(TrapType type)
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getTrapFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return EMPTY_STRING;
     }
     TrapFunctions& trapFuncs = getTrapFunctions()[index];
@@ -188,7 +188,7 @@ TrapType TrapManager::getTrapTypeFromTrapName(const std::string& name)
             return static_cast<TrapType>(i);
     }
 
-    OD_ASSERT_TRUE_MSG(false, "Cannot find Trap name=" + name);
+    OD_LOG_ERR("Cannot find Trap name=" + name);
     return TrapType::nullTrapType;
 }
 
@@ -202,7 +202,7 @@ void TrapManager::registerTrap(TrapType type, const std::string& name,
     uint32_t index = static_cast<uint32_t>(type);
     if(index >= getTrapFunctions().size())
     {
-        OD_ASSERT_TRUE_MSG(false, "type=" + Helper::toString(index));
+        OD_LOG_ERR("type=" + Helper::toString(index));
         return;
     }
 
@@ -289,7 +289,7 @@ void TrapManager::sellTrapTiles(GameMap* gameMap, Seat* seatSell, ODPacket& pack
         Tile* tile = gameMap->tileFromPacket(packet);
         if(tile == nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "tile=" + Tile::displayAsString(tile));
+            OD_LOG_ERR("tile=" + Tile::displayAsString(tile));
             continue;
         }
         Trap* trap = tile->getCoveringTrap();
@@ -301,7 +301,7 @@ void TrapManager::sellTrapTiles(GameMap* gameMap, Seat* seatSell, ODPacket& pack
 
         if(!trap->removeCoveredTile(tile))
         {
-            OD_ASSERT_TRUE_MSG(false, "trap=" + trap->getName() + ", tile=" + Tile::displayAsString(tile) + ", seatId=" + Helper::toString(seatSell->getId()));
+            OD_LOG_ERR("trap=" + trap->getName() + ", tile=" + Tile::displayAsString(tile) + ", seatId=" + Helper::toString(seatSell->getId()));
             continue;
         }
 
@@ -421,7 +421,7 @@ void TrapManager::sellTrapTilesEditor(GameMap* gameMap, ODPacket& packet)
         Tile* tile = gameMap->tileFromPacket(packet);
         if(tile == nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "tile=" + Tile::displayAsString(tile));
+            OD_LOG_ERR("tile=" + Tile::displayAsString(tile));
             continue;
         }
         Trap* trap = tile->getCoveringTrap();
@@ -430,7 +430,7 @@ void TrapManager::sellTrapTilesEditor(GameMap* gameMap, ODPacket& packet)
 
         if(!trap->removeCoveredTile(tile))
         {
-            OD_ASSERT_TRUE_MSG(false, "trap=" + trap->getName() + ", tile=" + Tile::displayAsString(tile));
+            OD_LOG_ERR("trap=" + trap->getName() + ", tile=" + Tile::displayAsString(tile));
             continue;
         }
 
@@ -500,7 +500,7 @@ int TrapManager::costPerTile(TrapType t)
 
         default:
         {
-            OD_ASSERT_TRUE_MSG(false, "Unknown enum for getting trap cost " + getTrapNameFromTrapType(t));
+            OD_LOG_ERR("Unknown enum for getting trap cost " + getTrapNameFromTrapType(t));
             return 0;
         }
     }
@@ -535,7 +535,7 @@ int32_t TrapManager::getNeededWorkshopPointsPerTrap(TrapType trapType)
         case TrapType::doorWooden:
             return ConfigManager::getSingleton().getTrapConfigInt32("WoodenDoorPointsPerTile");
         default:
-            OD_ASSERT_TRUE_MSG(false, "Asked for wrong trap type=" + getTrapNameFromTrapType(trapType));
+            OD_LOG_ERR("Asked for wrong trap type=" + getTrapNameFromTrapType(trapType));
             break;
     }
     // We shouldn't go here

--- a/source/traps/TrapManager.cpp
+++ b/source/traps/TrapManager.cpp
@@ -225,7 +225,6 @@ void TrapManager::checkSellTrapTiles(GameMap* gameMap, const InputManager& input
         Tile* tile = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
         if((tile == nullptr) || (!tile->getIsBuilding()) || (tile->getSeat() != player->getSeat()))
         {
-            inputCommand.unselectAllTiles();
             std::string txt = formatSellTrap(0);
             inputCommand.displayText(Ogre::ColourValue::White, txt);
             inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos, inputManager.mYPos);
@@ -247,10 +246,8 @@ void TrapManager::checkSellTrapTiles(GameMap* gameMap, const InputManager& input
     uint32_t priceTotal = 0;
     for(Tile* tile : tiles)
     {
-        // FIXME: ATM, building is not refreshed when building a trap on client side. For this reason,
-        // we accept any tile as soon as it is claimed by the correct seat
-//        if(!tile->getIsBuilding())
-//            continue;
+        if(!tile->getIsBuilding())
+            continue;
 
         if(tile->getSeat() != player->getSeat())
             continue;
@@ -266,6 +263,8 @@ void TrapManager::checkSellTrapTiles(GameMap* gameMap, const InputManager& input
         inputCommand.displayText(Ogre::ColourValue::White, txt);
         return;
     }
+
+    inputCommand.unselectAllTiles();
 
     ClientNotification *clientNotification = new ClientNotification(
         ClientNotificationType::askSellTrapTiles);
@@ -368,7 +367,6 @@ void TrapManager::checkSellTrapTilesEditor(GameMap* gameMap, const InputManager&
         Tile* tile = gameMap->getTile(inputManager.mXPos, inputManager.mYPos);
         if((tile == nullptr) || (!tile->getIsBuilding()))
         {
-            inputCommand.unselectAllTiles();
             inputCommand.displayText(Ogre::ColourValue::White, "Remove tiles");
             inputCommand.selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos, inputManager.mYPos);
             return;
@@ -386,10 +384,8 @@ void TrapManager::checkSellTrapTilesEditor(GameMap* gameMap, const InputManager&
         inputManager.mYPos, inputManager.mLStartDragX, inputManager.mLStartDragY);
     for(Tile* tile : tiles)
     {
-        // FIXME: ATM, building is not refreshed when building a trap on client side. For this reason,
-        // we accept any tile as soon as it is claimed by the correct seat
-//        if(!tile->getIsBuilding())
-//            continue;
+        if(!tile->getIsBuilding())
+            continue;
 
         sellTiles.push_back(tile);
     }
@@ -400,6 +396,8 @@ void TrapManager::checkSellTrapTilesEditor(GameMap* gameMap, const InputManager&
         inputCommand.displayText(Ogre::ColourValue::White, "Remove tiles");
         return;
     }
+
+    inputCommand.unselectAllTiles();
 
     ClientNotification *clientNotification = new ClientNotification(
         ClientNotificationType::editorAskDestroyTrapTiles);

--- a/source/traps/TrapSpike.h
+++ b/source/traps/TrapSpike.h
@@ -48,9 +48,11 @@ public:
 
     virtual TrapEntity* getTrapEntity(Tile* tile);
 
-    static int getTrapCost(std::vector<Tile*>& tiles, GameMap* gameMap, TrapType type,
-        int tileX1, int tileY1, int tileX2, int tileY2, Player* player);
-    static void buildTrap(GameMap* gameMap, const std::vector<Tile*>& tiles, Seat* seat);
+    static void checkBuildTrap(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildTrap(GameMap* gameMap, Player* player, ODPacket& packet);
+    static void checkBuildTrapEditor(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
+    static bool buildTrapEditor(GameMap* gameMap, ODPacket& packet);
+    static bool buildTrapOnTiles(GameMap* gameMap, Player* player, const std::vector<Tile*>& tiles);
     static Trap* getTrapFromStream(GameMap* gameMap, std::istream& is);
 
 };

--- a/source/utils/ConfigManager.cpp
+++ b/source/utils/ConfigManager.cpp
@@ -67,67 +67,67 @@ ConfigManager::ConfigManager(const std::string& configPath) :
         "Bed", 1, 2, Ogre::Vector3(0.04, 0.04, 0.04));
     if(!loadGlobalConfig(configPath))
     {
-        OD_ASSERT_TRUE(false);
+        OD_LOG_ERR("Couldn't read loadCreatureDefinitions");
         exit(1);
     }
     std::string fileName = configPath + mFilenameCreatureDefinition;
     if(!loadCreatureDefinitions(fileName))
     {
-        OD_ASSERT_TRUE(false);
+        OD_LOG_ERR("Couldn't read loadCreatureDefinitions");
         exit(1);
     }
     fileName = configPath + mFilenameEquipmentDefinition;
     if(!loadEquipements(fileName))
     {
-        OD_ASSERT_TRUE(false);
+        OD_LOG_ERR("Couldn't read loadEquipements");
         exit(1);
     }
     fileName = configPath + mFilenameSpawnConditions;
     if(!loadSpawnConditions(fileName))
     {
-        OD_ASSERT_TRUE(false);
+        OD_LOG_ERR("Couldn't read loadSpawnConditions");
         exit(1);
     }
     fileName = configPath + mFilenameFactions;
     if(!loadFactions(fileName))
     {
-        OD_ASSERT_TRUE(false);
+        OD_LOG_ERR("Couldn't read loadFactions");
         exit(1);
     }
     fileName = configPath + mFilenameRooms;
     if(!loadRooms(fileName))
     {
-        OD_ASSERT_TRUE(false);
+        OD_LOG_ERR("Couldn't read loadRooms");
         exit(1);
     }
     fileName = configPath + mFilenameTraps;
     if(!loadTraps(fileName))
     {
-        OD_ASSERT_TRUE(false);
+        OD_LOG_ERR("Couldn't read loadTraps");
         exit(1);
     }
     fileName = configPath + mFilenameSpells;
     if(!loadSpellConfig(fileName))
     {
-        OD_ASSERT_TRUE(false);
+        OD_LOG_ERR("Couldn't read loadSpellConfig");
         exit(1);
     }
     fileName = configPath + mFilenameCreaturesMood;
     if(!loadCreaturesMood(fileName))
     {
-        OD_ASSERT_TRUE(false);
+        OD_LOG_ERR("Couldn't read loadCreaturesMood");
         exit(1);
     }
     fileName = configPath + mFilenameResearches;
     if(!loadResearches(fileName))
     {
-        OD_ASSERT_TRUE(false);
+        OD_LOG_ERR("Couldn't read loadResearches");
         exit(1);
     }
     fileName = configPath + mFilenameTilesets;
     if(!loadTilesets(fileName))
     {
-        OD_ASSERT_TRUE(false);
+        OD_LOG_ERR("Couldn't read loadTilesets");
         exit(1);
     }
 }
@@ -185,7 +185,7 @@ bool ConfigManager::loadGlobalConfig(const std::string& configPath)
     std::string fileName = configPath + "global.cfg";
     if(!Helper::readFileWithoutComments(fileName, configFile))
     {
-        OD_ASSERT_TRUE_MSG(false, "Couldn't read " + fileName);
+        OD_LOG_ERR("Couldn't read " + fileName);
         return false;
     }
 
@@ -226,7 +226,7 @@ bool ConfigManager::loadGlobalConfig(const std::string& configPath)
 
     if(paramsOk != 0x07)
     {
-        OD_ASSERT_TRUE_MSG(false, "Not enough parameters for config file paramsOk=" + Helper::toString(paramsOk));
+        OD_LOG_ERR("Not enough parameters for config file paramsOk=" + Helper::toString(paramsOk));
         return false;
     }
 
@@ -247,7 +247,7 @@ bool ConfigManager::loadGlobalConfigDefinitionFiles(std::stringstream& configFil
 
         if(nextParam != "[ConfigFile]")
         {
-            OD_ASSERT_TRUE_MSG(false, "Wrong parameter read nextParam=" + nextParam);
+            OD_LOG_ERR("Wrong parameter read nextParam=" + nextParam);
             return false;
         }
 
@@ -281,7 +281,7 @@ bool ConfigManager::loadGlobalConfigDefinitionFiles(std::stringstream& configFil
 
         if(paramsOk != 0x03)
         {
-            OD_ASSERT_TRUE_MSG(false, "Missing parameters paramsOk=" + Helper::toString(paramsOk));
+            OD_LOG_ERR("Missing parameters paramsOk=" + Helper::toString(paramsOk));
             return false;
         }
 
@@ -339,7 +339,7 @@ bool ConfigManager::loadGlobalConfigDefinitionFiles(std::stringstream& configFil
 
     if(filesOk != 0x3FF)
     {
-        OD_ASSERT_TRUE_MSG(false, "Missing parameter file filesOk=" + Helper::toString(filesOk));
+        OD_LOG_ERR("Missing parameter file filesOk=" + Helper::toString(filesOk));
         return false;
     }
 
@@ -359,7 +359,7 @@ bool ConfigManager::loadGlobalConfigSeatColors(std::stringstream& configFile)
 
         if(nextParam != "[SeatColor]")
         {
-            OD_ASSERT_TRUE_MSG(false, "Wrong parameter read nextParam=" + nextParam);
+            OD_LOG_ERR("Wrong parameter read nextParam=" + nextParam);
             return false;
         }
 
@@ -389,7 +389,7 @@ bool ConfigManager::loadGlobalConfigSeatColors(std::stringstream& configFile)
                 double v = Helper::toDouble(nextParam);
                 if(v < 0.0 || v > 1.0)
                 {
-                    OD_ASSERT_TRUE_MSG(false, "Wrong parameter read nextParam=" + nextParam);
+                    OD_LOG_ERR("Wrong parameter read nextParam=" + nextParam);
                     return false;
                 }
                 colourValue.r = v;
@@ -403,7 +403,7 @@ bool ConfigManager::loadGlobalConfigSeatColors(std::stringstream& configFile)
                 double v = Helper::toDouble(nextParam);
                 if(v < 0.0 || v > 1.0)
                 {
-                    OD_ASSERT_TRUE_MSG(false, "Wrong parameter read nextParam=" + nextParam);
+                    OD_LOG_ERR("Wrong parameter read nextParam=" + nextParam);
                     return false;
                 }
                 colourValue.g = v;
@@ -417,7 +417,7 @@ bool ConfigManager::loadGlobalConfigSeatColors(std::stringstream& configFile)
                 double v = Helper::toDouble(nextParam);
                 if(v < 0.0 || v > 1.0)
                 {
-                    OD_ASSERT_TRUE_MSG(false, "Wrong parameter read nextParam=" + nextParam);
+                    OD_LOG_ERR("Wrong parameter read nextParam=" + nextParam);
                     return false;
                 }
                 colourValue.b = v;
@@ -428,7 +428,7 @@ bool ConfigManager::loadGlobalConfigSeatColors(std::stringstream& configFile)
 
         if(paramsOk != 0x0F)
         {
-            OD_ASSERT_TRUE_MSG(false, "Missing parameters paramsOk=" + Helper::toString(paramsOk));
+            OD_LOG_ERR("Missing parameters paramsOk=" + Helper::toString(paramsOk));
             return false;
         }
 
@@ -523,7 +523,7 @@ bool ConfigManager::loadGlobalGameConfig(std::stringstream& configFile)
 
     if(paramsOk != 0x01)
     {
-        OD_ASSERT_TRUE_MSG(false, "Missing parameters paramsOk=" + Helper::toString(paramsOk));
+        OD_LOG_ERR("Missing parameters paramsOk=" + Helper::toString(paramsOk));
         return false;
     }
 
@@ -536,7 +536,7 @@ bool ConfigManager::loadCreatureDefinitions(const std::string& fileName)
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
-        OD_ASSERT_TRUE_MSG(false, "Couldn't read " + fileName);
+        OD_LOG_ERR("Couldn't read " + fileName);
         return false;
     }
 
@@ -545,7 +545,7 @@ bool ConfigManager::loadCreatureDefinitions(const std::string& fileName)
     defFile >> nextParam;
     if (nextParam != "[CreatureDefinitions]")
     {
-        OD_ASSERT_TRUE_MSG(false, "Invalid Creature classes start format. Line was " + nextParam);
+        OD_LOG_ERR("Invalid Creature classes start format. Line was " + nextParam);
         return false;
     }
 
@@ -563,7 +563,7 @@ bool ConfigManager::loadCreatureDefinitions(const std::string& fileName)
         // Seek the [Creature] tag
         if (nextParam != "[Creature]")
         {
-            OD_ASSERT_TRUE_MSG(false, "Invalid Creature classes start format. Line was " + nextParam);
+            OD_LOG_ERR("Invalid Creature classes start format. Line was " + nextParam);
             return false;
         }
 
@@ -571,7 +571,7 @@ bool ConfigManager::loadCreatureDefinitions(const std::string& fileName)
         CreatureDefinition* creatureDef = CreatureDefinition::load(defFile, mCreatureDefs);
         if (creatureDef == nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "Invalid Creature classes start format");
+            OD_LOG_ERR("Invalid Creature classes start format");
             return false;
         }
         mCreatureDefs.emplace(creatureDef->getClassName(), creatureDef);
@@ -586,7 +586,7 @@ bool ConfigManager::loadEquipements(const std::string& fileName)
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
-        OD_ASSERT_TRUE_MSG(false, "Couldn't read " + fileName);
+        OD_LOG_ERR("Couldn't read " + fileName);
         return false;
     }
 
@@ -595,7 +595,7 @@ bool ConfigManager::loadEquipements(const std::string& fileName)
     defFile >> nextParam;
     if (nextParam != "[EquipmentDefinitions]")
     {
-        OD_ASSERT_TRUE_MSG(false, "Invalid weapon start format. Line was " + nextParam);
+        OD_LOG_ERR("Invalid weapon start format. Line was " + nextParam);
         return false;
     }
 
@@ -612,7 +612,7 @@ bool ConfigManager::loadEquipements(const std::string& fileName)
 
         if (nextParam != "[Equipment]")
         {
-            OD_ASSERT_TRUE_MSG(false, "Invalid Weapon definition format. Line was " + nextParam);
+            OD_LOG_ERR("Invalid Weapon definition format. Line was " + nextParam);
             return false;
         }
 
@@ -620,7 +620,7 @@ bool ConfigManager::loadEquipements(const std::string& fileName)
         Weapon* weapon = Weapon::load(defFile);
         if (weapon == nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "Invalid Weapon definition format");
+            OD_LOG_ERR("Invalid Weapon definition format");
             return false;
         }
         mWeapons.push_back(weapon);
@@ -635,7 +635,7 @@ bool ConfigManager::loadSpawnConditions(const std::string& fileName)
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
-        OD_ASSERT_TRUE_MSG(false, "Couldn't read " + fileName);
+        OD_LOG_ERR("Couldn't read " + fileName);
         return false;
     }
 
@@ -644,7 +644,7 @@ bool ConfigManager::loadSpawnConditions(const std::string& fileName)
     defFile >> nextParam;
     if (nextParam != "[SpawnConditions]")
     {
-        OD_ASSERT_TRUE_MSG(false, "Invalid creature spawn condition start format. Line was " + nextParam);
+        OD_LOG_ERR("Invalid creature spawn condition start format. Line was " + nextParam);
         return false;
     }
 
@@ -668,7 +668,7 @@ bool ConfigManager::loadSpawnConditions(const std::string& fileName)
 
         if (nextParam != "[SpawnCondition]")
         {
-            OD_ASSERT_TRUE_MSG(false, "Invalid creature spawn condition format. Line was " + nextParam);
+            OD_LOG_ERR("Invalid creature spawn condition format. Line was " + nextParam);
             return false;
         }
 
@@ -676,14 +676,14 @@ bool ConfigManager::loadSpawnConditions(const std::string& fileName)
                 break;
         if (nextParam != "CreatureClass")
         {
-            OD_ASSERT_TRUE_MSG(false, "Invalid creature spawn condition format. Line was " + nextParam);
+            OD_LOG_ERR("Invalid creature spawn condition format. Line was " + nextParam);
             return false;
         }
         defFile >> nextParam;
         const CreatureDefinition* creatureDefinition = getCreatureDefinition(nextParam);
         if(creatureDefinition == nullptr)
         {
-            OD_ASSERT_TRUE_MSG(false, "nextParam=" + nextParam);
+            OD_LOG_ERR("nextParam=" + nextParam);
             return false;
         }
 
@@ -697,7 +697,7 @@ bool ConfigManager::loadSpawnConditions(const std::string& fileName)
 
             if (nextParam != "[Condition]")
             {
-                OD_ASSERT_TRUE_MSG(false, "Invalid creature spawn condition format. nextParam=" + nextParam);
+                OD_LOG_ERR("Invalid creature spawn condition format. nextParam=" + nextParam);
                 return false;
             }
 
@@ -705,7 +705,7 @@ bool ConfigManager::loadSpawnConditions(const std::string& fileName)
             SpawnCondition* def = SpawnCondition::load(defFile);
             if (def == nullptr)
             {
-                OD_ASSERT_TRUE_MSG(false, "Invalid creature spawn condition format");
+                OD_LOG_ERR("Invalid creature spawn condition format");
                 return false;
             }
             mCreatureSpawnConditions[creatureDefinition].push_back(def);
@@ -721,7 +721,7 @@ bool ConfigManager::loadFactions(const std::string& fileName)
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
-        OD_ASSERT_TRUE_MSG(false, "Couldn't read " + fileName);
+        OD_LOG_ERR("Couldn't read " + fileName);
         return false;
     }
 
@@ -730,7 +730,7 @@ bool ConfigManager::loadFactions(const std::string& fileName)
     defFile >> nextParam;
     if (nextParam != "[Factions]")
     {
-        OD_ASSERT_TRUE_MSG(false, "Invalid factions start format. Line was " + nextParam);
+        OD_LOG_ERR("Invalid factions start format. Line was " + nextParam);
         return false;
     }
 
@@ -744,7 +744,7 @@ bool ConfigManager::loadFactions(const std::string& fileName)
 
         if (nextParam != "[Faction]")
         {
-            OD_ASSERT_TRUE_MSG(false, "Invalid faction. Line was " + nextParam);
+            OD_LOG_ERR("Invalid faction. Line was " + nextParam);
             return false;
         }
 
@@ -768,7 +768,7 @@ bool ConfigManager::loadFactions(const std::string& fileName)
             }
             if(factionName.empty())
             {
-                OD_ASSERT_TRUE_MSG(false, "Empty or missing faction name is not allowed");
+                OD_LOG_ERR("Empty or missing faction name is not allowed");
                 return false;
             }
 
@@ -779,13 +779,13 @@ bool ConfigManager::loadFactions(const std::string& fileName)
             }
             if(workerClass.empty())
             {
-                OD_ASSERT_TRUE_MSG(false, "Empty or missing WorkerClass name is not allowed");
+                OD_LOG_ERR("Empty or missing WorkerClass name is not allowed");
                 return false;
             }
 
             if (nextParam != "[SpawnPool]")
             {
-                OD_ASSERT_TRUE_MSG(false, "Invalid faction. Line was " + nextParam);
+                OD_LOG_ERR("Invalid faction. Line was " + nextParam);
                 return false;
             }
 
@@ -812,9 +812,11 @@ bool ConfigManager::loadFactions(const std::string& fileName)
 
                 // We check if the creature definition exists
                 const CreatureDefinition* creatureDefinition = getCreatureDefinition(nextParam);
-                OD_ASSERT_TRUE_MSG(creatureDefinition != nullptr, "factionName=" + factionName + ", class=" + nextParam);
                 if(creatureDefinition == nullptr)
+                {
+                    OD_LOG_ERR("factionName=" + factionName + ", class=" + nextParam);
                     continue;
+                }
 
                 mFactionSpawnPool[factionName].push_back(nextParam);
             }
@@ -830,7 +832,7 @@ bool ConfigManager::loadRooms(const std::string& fileName)
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
-        OD_ASSERT_TRUE_MSG(false, "Couldn't read " + fileName);
+        OD_LOG_ERR("Couldn't read " + fileName);
         return false;
     }
 
@@ -839,7 +841,7 @@ bool ConfigManager::loadRooms(const std::string& fileName)
     defFile >> nextParam;
     if (nextParam != "[Rooms]")
     {
-        OD_ASSERT_TRUE_MSG(false, "Invalid factions start format. Line was " + nextParam);
+        OD_LOG_ERR("Invalid factions start format. Line was " + nextParam);
         return false;
     }
 
@@ -863,7 +865,7 @@ bool ConfigManager::loadTraps(const std::string& fileName)
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
-        OD_ASSERT_TRUE_MSG(false, "Couldn't read " + fileName);
+        OD_LOG_ERR("Couldn't read " + fileName);
         return false;
     }
 
@@ -872,7 +874,7 @@ bool ConfigManager::loadTraps(const std::string& fileName)
     defFile >> nextParam;
     if (nextParam != "[Traps]")
     {
-        OD_ASSERT_TRUE_MSG(false, "Invalid Traps start format. Line was " + nextParam);
+        OD_LOG_ERR("Invalid Traps start format. Line was " + nextParam);
         return false;
     }
 
@@ -896,7 +898,7 @@ bool ConfigManager::loadSpellConfig(const std::string& fileName)
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
-        OD_ASSERT_TRUE_MSG(false, "Couldn't read " + fileName);
+        OD_LOG_ERR("Couldn't read " + fileName);
         return false;
     }
 
@@ -905,7 +907,7 @@ bool ConfigManager::loadSpellConfig(const std::string& fileName)
     defFile >> nextParam;
     if (nextParam != "[Spells]")
     {
-        OD_ASSERT_TRUE_MSG(false, "Invalid Spells start format. Line was " + nextParam);
+        OD_LOG_ERR("Invalid Spells start format. Line was " + nextParam);
         return false;
     }
 
@@ -929,7 +931,7 @@ bool ConfigManager::loadCreaturesMood(const std::string& fileName)
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
-        OD_ASSERT_TRUE_MSG(false, "Couldn't read " + fileName);
+        OD_LOG_ERR("Couldn't read " + fileName);
         return false;
     }
 
@@ -938,7 +940,7 @@ bool ConfigManager::loadCreaturesMood(const std::string& fileName)
     defFile >> nextParam;
     if (nextParam != "[CreaturesMood]")
     {
-        OD_ASSERT_TRUE_MSG(false, "Invalid creature spawn condition start format. Line was " + nextParam);
+        OD_LOG_ERR("Invalid creature spawn condition start format. Line was " + nextParam);
         return false;
     }
 
@@ -990,7 +992,7 @@ bool ConfigManager::loadCreaturesMood(const std::string& fileName)
 
         if (nextParam != "[CreatureMood]")
         {
-            OD_ASSERT_TRUE_MSG(false, "Invalid CreatureMood format. Line was " + nextParam);
+            OD_LOG_ERR("Invalid CreatureMood format. Line was " + nextParam);
             return false;
         }
 
@@ -998,7 +1000,7 @@ bool ConfigManager::loadCreaturesMood(const std::string& fileName)
                 break;
         if (nextParam != "CreatureMoodName")
         {
-            OD_ASSERT_TRUE_MSG(false, "Invalid CreatureMoodName format. Line was " + nextParam);
+            OD_LOG_ERR("Invalid CreatureMoodName format. Line was " + nextParam);
             return false;
         }
         std::string moodModifierName;
@@ -1015,7 +1017,7 @@ bool ConfigManager::loadCreaturesMood(const std::string& fileName)
 
             if (nextParam != "[MoodModifier]")
             {
-                OD_ASSERT_TRUE_MSG(false, "Invalid CreatureMood MoodModifier format. nextParam=" + nextParam);
+                OD_LOG_ERR("Invalid CreatureMood MoodModifier format. nextParam=" + nextParam);
                 return false;
             }
 
@@ -1023,7 +1025,7 @@ bool ConfigManager::loadCreaturesMood(const std::string& fileName)
             CreatureMood* def = CreatureMood::load(defFile);
             if (def == nullptr)
             {
-                OD_ASSERT_TRUE_MSG(false, "Invalid CreatureMood MoodModifier definition");
+                OD_LOG_ERR("Invalid CreatureMood MoodModifier definition");
                 return false;
             }
             moodModifiers.push_back(def);
@@ -1050,7 +1052,7 @@ bool ConfigManager::loadResearches(const std::string& fileName)
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
-        OD_ASSERT_TRUE_MSG(false, "Couldn't read " + fileName);
+        OD_LOG_ERR("Couldn't read " + fileName);
         return false;
     }
 
@@ -1059,7 +1061,7 @@ bool ConfigManager::loadResearches(const std::string& fileName)
     defFile >> nextParam;
     if (nextParam != "[Researches]")
     {
-        OD_ASSERT_TRUE_MSG(false, "Invalid Researches start format. Line was " + nextParam);
+        OD_LOG_ERR("Invalid Researches start format. Line was " + nextParam);
         return false;
     }
 
@@ -1195,7 +1197,7 @@ bool ConfigManager::loadTilesets(const std::string& fileName)
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
-        OD_ASSERT_TRUE_MSG(false, "Couldn't read " + fileName);
+        OD_LOG_ERR("Couldn't read " + fileName);
         return false;
     }
 
@@ -1203,7 +1205,7 @@ bool ConfigManager::loadTilesets(const std::string& fileName)
     defFile >> nextParam;
     if (nextParam != "[Tilesets]")
     {
-        OD_ASSERT_TRUE_MSG(false, "Invalid Tilesets start format. Line was " + nextParam);
+        OD_LOG_ERR("Invalid Tilesets start format. Line was " + nextParam);
         return false;
     }
 
@@ -1218,14 +1220,14 @@ bool ConfigManager::loadTilesets(const std::string& fileName)
 
         if (nextParam != "[Tileset]")
         {
-            OD_ASSERT_TRUE_MSG(false, "Expecting TileSet tag but got=" + nextParam);
+            OD_LOG_ERR("Expecting TileSet tag but got=" + nextParam);
             return false;
         }
 
         defFile >> nextParam;
         if (nextParam != "Name")
         {
-            OD_ASSERT_TRUE_MSG(false, "Expecting Name tag but got=" + nextParam);
+            OD_LOG_ERR("Expecting Name tag but got=" + nextParam);
             return false;
         }
 
@@ -1235,7 +1237,7 @@ bool ConfigManager::loadTilesets(const std::string& fileName)
         defFile >> nextParam;
         if (nextParam != "Scale")
         {
-            OD_ASSERT_TRUE_MSG(false, "Expecting Scale tag but got=" + nextParam);
+            OD_LOG_ERR("Expecting Scale tag but got=" + nextParam);
             return false;
         }
 
@@ -1250,7 +1252,7 @@ bool ConfigManager::loadTilesets(const std::string& fileName)
         defFile >> nextParam;
         if(nextParam != "[TileLink]")
         {
-            OD_ASSERT_TRUE_MSG(false, "Expecting TileLink tag but got=" + nextParam);
+            OD_LOG_ERR("Expecting TileLink tag but got=" + nextParam);
             return false;
         }
 
@@ -1263,7 +1265,7 @@ bool ConfigManager::loadTilesets(const std::string& fileName)
             TileVisual tileVisual1 = Tile::tileVisualFromString(nextParam);
             if(tileVisual1 == TileVisual::nullTileVisual)
             {
-                OD_ASSERT_TRUE_MSG(false, "Wrong TileVisual1 in tileset=" + nextParam);
+                OD_LOG_ERR("Wrong TileVisual1 in tileset=" + nextParam);
                 return false;
             }
 
@@ -1271,7 +1273,7 @@ bool ConfigManager::loadTilesets(const std::string& fileName)
             TileVisual tileVisual2 = Tile::tileVisualFromString(nextParam);
             if(tileVisual2 == TileVisual::nullTileVisual)
             {
-                OD_ASSERT_TRUE_MSG(false, "Wrong TileVisual2 in tileset=" + nextParam);
+                OD_LOG_ERR("Wrong TileVisual2 in tileset=" + nextParam);
                 return false;
             }
 
@@ -1303,7 +1305,7 @@ bool ConfigManager::loadTilesets(const std::string& fileName)
     // At least the default tileset should be defined
     if(mTileSets.count(DEFAULT_TILESET_NAME) <= 0)
     {
-        OD_ASSERT_TRUE_MSG(false, "No tileset defined with name=" + DEFAULT_TILESET_NAME);
+        OD_LOG_ERR("No tileset defined with name=" + DEFAULT_TILESET_NAME);
         return false;
     }
     return true;
@@ -1317,7 +1319,7 @@ bool ConfigManager::loadTilesetValues(std::istream& defFile, TileVisual tileVisu
     defFile >> nextParam;
     if (nextParam != beginTag)
     {
-        OD_ASSERT_TRUE_MSG(false, "Expecting " + beginTag + " tag but got=" + nextParam);
+        OD_LOG_ERR("Expecting " + beginTag + " tag but got=" + nextParam);
         return false;
     }
     while(true)
@@ -1349,7 +1351,7 @@ bool ConfigManager::loadTilesetValues(std::istream& defFile, TileVisual tileVisu
 
         if(index >= tileValues.size())
         {
-            OD_ASSERT_TRUE_MSG(false, "Tileset index too high in tileset=" + endTag + ", index=" + indexStr);
+            OD_LOG_ERR("Tileset index too high in tileset=" + endTag + ", index=" + indexStr);
             return false;
         }
 
@@ -1361,7 +1363,7 @@ const std::string& ConfigManager::getRoomConfigString(const std::string& param) 
 {
     if(mRoomsConfig.count(param) <= 0)
     {
-        OD_ASSERT_TRUE_MSG(false, "Unknown parameter param=" + param);
+        OD_LOG_ERR("Unknown parameter param=" + param);
         return EMPTY_STRING;
     }
 
@@ -1372,7 +1374,7 @@ uint32_t ConfigManager::getRoomConfigUInt32(const std::string& param) const
 {
     if(mRoomsConfig.count(param) <= 0)
     {
-        OD_ASSERT_TRUE_MSG(false, "Unknown parameter param=" + param);
+        OD_LOG_ERR("Unknown parameter param=" + param);
         return 0;
     }
 
@@ -1383,7 +1385,7 @@ int32_t ConfigManager::getRoomConfigInt32(const std::string& param) const
 {
     if(mRoomsConfig.count(param) <= 0)
     {
-        OD_ASSERT_TRUE_MSG(false, "Unknown parameter param=" + param);
+        OD_LOG_ERR("Unknown parameter param=" + param);
         return 0;
     }
 
@@ -1394,7 +1396,7 @@ double ConfigManager::getRoomConfigDouble(const std::string& param) const
 {
     if(mRoomsConfig.count(param) <= 0)
     {
-        OD_ASSERT_TRUE_MSG(false, "Unknown parameter param=" + param);
+        OD_LOG_ERR("Unknown parameter param=" + param);
         return 0.0;
     }
 
@@ -1405,7 +1407,7 @@ const std::string& ConfigManager::getTrapConfigString(const std::string& param) 
 {
     if(mTrapsConfig.count(param) <= 0)
     {
-        OD_ASSERT_TRUE_MSG(false, "Unknown parameter param=" + param);
+        OD_LOG_ERR("Unknown parameter param=" + param);
         return EMPTY_STRING;
     }
 
@@ -1416,7 +1418,7 @@ uint32_t ConfigManager::getTrapConfigUInt32(const std::string& param) const
 {
     if(mTrapsConfig.count(param) <= 0)
     {
-        OD_ASSERT_TRUE_MSG(false, "Unknown parameter param=" + param);
+        OD_LOG_ERR("Unknown parameter param=" + param);
         return 0;
     }
 
@@ -1427,7 +1429,7 @@ int32_t ConfigManager::getTrapConfigInt32(const std::string& param) const
 {
     if(mTrapsConfig.count(param) <= 0)
     {
-        OD_ASSERT_TRUE_MSG(false, "Unknown parameter param=" + param);
+        OD_LOG_ERR("Unknown parameter param=" + param);
         return 0;
     }
 
@@ -1438,7 +1440,7 @@ double ConfigManager::getTrapConfigDouble(const std::string& param) const
 {
     if(mTrapsConfig.count(param) <= 0)
     {
-        OD_ASSERT_TRUE_MSG(false, "Unknown parameter param=" + param);
+        OD_LOG_ERR("Unknown parameter param=" + param);
         return 0.0;
     }
 
@@ -1449,7 +1451,7 @@ const std::string& ConfigManager::getSpellConfigString(const std::string& param)
 {
     if(mSpellConfig.count(param) <= 0)
     {
-        OD_ASSERT_TRUE_MSG(false, "Unknown parameter param=" + param);
+        OD_LOG_ERR("Unknown parameter param=" + param);
         return EMPTY_STRING;
     }
 
@@ -1460,7 +1462,7 @@ uint32_t ConfigManager::getSpellConfigUInt32(const std::string& param) const
 {
     if(mSpellConfig.count(param) <= 0)
     {
-        OD_ASSERT_TRUE_MSG(false, "Unknown parameter param=" + param);
+        OD_LOG_ERR("Unknown parameter param=" + param);
         return 0;
     }
 
@@ -1471,7 +1473,7 @@ int32_t ConfigManager::getSpellConfigInt32(const std::string& param) const
 {
     if(mSpellConfig.count(param) <= 0)
     {
-        OD_ASSERT_TRUE_MSG(false, "Unknown parameter param=" + param);
+        OD_LOG_ERR("Unknown parameter param=" + param);
         return 0;
     }
 
@@ -1482,7 +1484,7 @@ double ConfigManager::getSpellConfigDouble(const std::string& param) const
 {
     if(mSpellConfig.count(param) <= 0)
     {
-        OD_ASSERT_TRUE_MSG(false, "Unknown parameter param=" + param);
+        OD_LOG_ERR("Unknown parameter param=" + param);
         return 0.0;
     }
 
@@ -1568,7 +1570,7 @@ const TileSet* ConfigManager::getTileSet(const std::string& tileSetName) const
     if(mTileSets.count(tileSetName) > 0)
         return mTileSets.at(tileSetName);
 
-    OD_ASSERT_TRUE_MSG(false, "Cannot find requested tileset name=" + tileSetName);
+    OD_LOG_ERR("Cannot find requested tileset name=" + tileSetName);
     // We return the default tileset
     return mTileSets.at(DEFAULT_TILESET_NAME);
 }

--- a/source/utils/ConfigManager.cpp
+++ b/source/utils/ConfigManager.cpp
@@ -532,7 +532,7 @@ bool ConfigManager::loadGlobalGameConfig(std::stringstream& configFile)
 
 bool ConfigManager::loadCreatureDefinitions(const std::string& fileName)
 {
-    LogManager::getSingleton().logMessage("Load creature definition file: " + fileName);
+    OD_LOG_INF("Load creature definition file: " + fileName);
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
@@ -582,7 +582,7 @@ bool ConfigManager::loadCreatureDefinitions(const std::string& fileName)
 
 bool ConfigManager::loadEquipements(const std::string& fileName)
 {
-    LogManager::getSingleton().logMessage("Load weapon definition file: " + fileName);
+    OD_LOG_INF("Load weapon definition file: " + fileName);
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
@@ -631,7 +631,7 @@ bool ConfigManager::loadEquipements(const std::string& fileName)
 
 bool ConfigManager::loadSpawnConditions(const std::string& fileName)
 {
-    LogManager::getSingleton().logMessage("Load creature spawn conditions file: " + fileName);
+    OD_LOG_INF("Load creature spawn conditions file: " + fileName);
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
@@ -717,7 +717,7 @@ bool ConfigManager::loadSpawnConditions(const std::string& fileName)
 
 bool ConfigManager::loadFactions(const std::string& fileName)
 {
-    LogManager::getSingleton().logMessage("Load factions file: " + fileName);
+    OD_LOG_INF("Load factions file: " + fileName);
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
@@ -826,7 +826,7 @@ bool ConfigManager::loadFactions(const std::string& fileName)
 
 bool ConfigManager::loadRooms(const std::string& fileName)
 {
-    LogManager::getSingleton().logMessage("Load Rooms file: " + fileName);
+    OD_LOG_INF("Load Rooms file: " + fileName);
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
@@ -859,7 +859,7 @@ bool ConfigManager::loadRooms(const std::string& fileName)
 
 bool ConfigManager::loadTraps(const std::string& fileName)
 {
-    LogManager::getSingleton().logMessage("Load traps file: " + fileName);
+    OD_LOG_INF("Load traps file: " + fileName);
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
@@ -892,7 +892,7 @@ bool ConfigManager::loadTraps(const std::string& fileName)
 
 bool ConfigManager::loadSpellConfig(const std::string& fileName)
 {
-    LogManager::getSingleton().logMessage("Load Spell config file: " + fileName);
+    OD_LOG_INF("Load Spell config file: " + fileName);
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
@@ -925,7 +925,7 @@ bool ConfigManager::loadSpellConfig(const std::string& fileName)
 
 bool ConfigManager::loadCreaturesMood(const std::string& fileName)
 {
-    LogManager::getSingleton().logMessage("Load creature spawn conditions file: " + fileName);
+    OD_LOG_INF("Load creature spawn conditions file: " + fileName);
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
@@ -1046,7 +1046,7 @@ bool ConfigManager::loadResearches(const std::string& fileName)
     int32_t pointsSpellCreatureHeal = 0;
     int32_t pointsSpellCreatureExplosion = 0;
 
-    LogManager::getSingleton().logMessage("Load Researches file: " + fileName);
+    OD_LOG_INF("Load Researches file: " + fileName);
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {
@@ -1191,7 +1191,7 @@ bool ConfigManager::loadResearches(const std::string& fileName)
 
 bool ConfigManager::loadTilesets(const std::string& fileName)
 {
-    LogManager::getSingleton().logMessage("Load Tilesets file: " + fileName);
+    OD_LOG_INF("Load Tilesets file: " + fileName);
     std::stringstream defFile;
     if(!Helper::readFileWithoutComments(fileName, defFile))
     {

--- a/source/utils/Helper.cpp
+++ b/source/utils/Helper.cpp
@@ -22,6 +22,8 @@
 
 #include "utils/Helper.h"
 
+#include "utils/LogManager.h"
+
 #include <boost/filesystem.hpp>
 #include <fstream>
 
@@ -130,7 +132,7 @@ namespace Helper
         std::ifstream baseLevelFile(fileName.c_str(), std::ifstream::in);
         if (!baseLevelFile.good())
         {
-            std::cerr << "ERROR: File not found:  " << fileName << "\n\n\n";
+            OD_LOG_WRN("File not found=" + fileName);
             return false;
         }
 

--- a/source/utils/Helper.h
+++ b/source/utils/Helper.h
@@ -50,6 +50,19 @@ namespace Helper
         return t;
     }
 
+    /*! \brief Converts a primitive type T to a string
+     *
+     *  \param str The string to be converted
+     *  \return The converted primitive number
+     */
+    template<typename T>
+    std::string TTostring(T t)
+    {
+        std::stringstream ss;
+        ss << t;
+        return ss.str();
+    }
+
     //! \brief Turn a std::string to a wstring.
     inline std::wstring atow(const std::string& str)
     {
@@ -120,6 +133,10 @@ namespace Helper
     { return Ogre::StringConverter::toString(d); }
     inline std::string toString(uint32_t d)
     { return Ogre::StringConverter::toString(d); }
+    inline std::string toString(int64_t d)
+    { return TTostring(d); }
+    inline std::string toString(uint64_t d)
+    { return TTostring(d); }
     inline std::string toString(const Ogre::Vector3& v)
     { return Ogre::StringConverter::toString(v); }
     inline std::string toString(const Ogre::Radian& r)

--- a/source/utils/LogManager.h
+++ b/source/utils/LogManager.h
@@ -25,8 +25,8 @@
 #define OD_STRING_S(x) #x
 #define OD_STRING_S_(x) OD_STRING_S(x)
 #define S__LINE__ OD_STRING_S_(__LINE__)
-#define OD_LOG_ERR(a)      LogManager::getSingleton().logMessage("ERROR: " + std::string(__FILE__) + " line " + std::string(S__LINE__) + (a), LogMessageLevel::CRITICAL)
-#define OD_LOG_WRN(a)      LogManager::getSingleton().logMessage("WARNING: " + std::string(__FILE__) + " line " + std::string(S__LINE__) + (a), LogMessageLevel::WARNING)
+#define OD_LOG_ERR(a)      LogManager::getSingleton().logMessage("ERROR: " + std::string(__FILE__) + " line " + std::string(S__LINE__) + std::string(" ") + (a), LogMessageLevel::CRITICAL)
+#define OD_LOG_WRN(a)      LogManager::getSingleton().logMessage("WARNING: " + std::string(__FILE__) + " line " + std::string(S__LINE__) + std::string(" ") + (a), LogMessageLevel::WARNING)
 #define OD_LOG_INF(a)      LogManager::getSingleton().logMessage(a, LogMessageLevel::NORMAL)
 #define OD_LOG_DBG(a)      LogManager::getSingleton().logMessage(a, LogMessageLevel::TRIVIAL)
 #define OD_ASSERT_TRUE(a)        if(!(a)) LogManager::getSingleton().logMessage("ERROR: Assert failed file " + std::string(__FILE__) + " line " + std::string(S__LINE__), LogMessageLevel::CRITICAL)

--- a/source/utils/LogManager.h
+++ b/source/utils/LogManager.h
@@ -25,14 +25,19 @@
 #define OD_STRING_S(x) #x
 #define OD_STRING_S_(x) OD_STRING_S(x)
 #define S__LINE__ OD_STRING_S_(__LINE__)
-#define OD_ASSERT_TRUE(a)        if(!(a)) LogManager::getSingleton().logMessage("ERROR: Assert failed file " + std::string(__FILE__) + " line " + std::string(S__LINE__))
-#define OD_ASSERT_TRUE_MSG(a,b)  if(!(a)) LogManager::getSingleton().logMessage("ERROR: Assert failed file " + std::string(__FILE__) + " line " + std::string(S__LINE__) + std::string(" info : ") + b)
+#define OD_LOG_ERR(a)      LogManager::getSingleton().logMessage("ERROR: " + std::string(__FILE__) + " line " + std::string(S__LINE__) + (a), LogMessageLevel::CRITICAL)
+#define OD_LOG_WRN(a)      LogManager::getSingleton().logMessage("WARNING: " + std::string(__FILE__) + " line " + std::string(S__LINE__) + (a), LogMessageLevel::WARNING)
+#define OD_LOG_INF(a)      LogManager::getSingleton().logMessage(a, LogMessageLevel::NORMAL)
+#define OD_LOG_DBG(a)      LogManager::getSingleton().logMessage(a, LogMessageLevel::TRIVIAL)
+#define OD_ASSERT_TRUE(a)        if(!(a)) LogManager::getSingleton().logMessage("ERROR: Assert failed file " + std::string(__FILE__) + " line " + std::string(S__LINE__), LogMessageLevel::CRITICAL)
+#define OD_ASSERT_TRUE_MSG(a,b)  if(!(a)) LogManager::getSingleton().logMessage("ERROR: Assert failed file " + std::string(__FILE__) + " line " + std::string(S__LINE__) + std::string(" info : ") + b, LogMessageLevel::CRITICAL)
 
 
 enum class LogMessageLevel
 {
     TRIVIAL = 1,
     NORMAL,
+    WARNING,
     CRITICAL
 };
 
@@ -42,8 +47,7 @@ class LogManager : public Ogre::Singleton<LogManager>
 public:
     LogManager() {};
     //! \brief Log a message to the game log.
-    virtual void logMessage(const std::string& message, LogMessageLevel lml = LogMessageLevel::NORMAL,
-                    bool maskDebug = false, bool addTimeStamp = false) = 0;
+    virtual void logMessage(const std::string& message, LogMessageLevel lml) = 0;
 
     //! \brief Set the log detail level.
     //Messages lower than this level will be filtered.
@@ -54,10 +58,5 @@ private:
     LogManager(const LogManager&) = delete;
     LogManager& operator=(const LogManager&) = delete;
 };
-
-inline void OD_LOG_MESSAGE(const std::string& message)
-{
-    LogManager::getSingleton().logMessage(message);
-}
 
 #endif // LOGMANAGER_H

--- a/source/utils/LogManagerFile.cpp
+++ b/source/utils/LogManagerFile.cpp
@@ -31,7 +31,7 @@ LogManagerFile::LogManagerFile(const std::string& userDataPath) :
     mFileLog.open(userDataPath);
 }
 
-void LogManagerFile::logMessage(const std::string& message, LogMessageLevel lml, bool maskDebug, bool addTimeStamp)
+void LogManagerFile::logMessage(const std::string& message, LogMessageLevel lml)
 {
     if(mLevel > lml)
         return;

--- a/source/utils/LogManagerFile.h
+++ b/source/utils/LogManagerFile.h
@@ -25,8 +25,7 @@ class LogManagerFile final : public LogManager
 {
 public:
     LogManagerFile(const std::string& userDataPath);
-    void logMessage(const std::string& message, LogMessageLevel lml = LogMessageLevel::NORMAL,
-                    bool maskDebug = false, bool addTimeStamp = false) override;
+    void logMessage(const std::string& message, LogMessageLevel lml) override;
     void setLogDetail(LogMessageLevel ll) override;
 private:
     std::ofstream	mFileLog;

--- a/source/utils/LogManagerOgre.h
+++ b/source/utils/LogManagerOgre.h
@@ -33,7 +33,8 @@
 
 namespace Ogre
 {
-    class Log;
+class Log;
+class LogManager;
 }
 
 //! \brief Logger implementation using the logging system from ogre
@@ -41,10 +42,11 @@ class LogManagerOgre final : public LogManager
 {
 public:
     LogManagerOgre(const std::string& userDataPath);
-    void logMessage(const std::string& message, LogMessageLevel lml = LogMessageLevel::NORMAL,
-                    bool maskDebug = false, bool addTimeStamp = false) override;
+    ~LogManagerOgre();
+    void logMessage(const std::string& message, LogMessageLevel lml) override;
     void setLogDetail(LogMessageLevel ll) override;
 private:
+    Ogre::LogManager* mLogManager;
     Ogre::Log* mGameLog;
 #ifdef LOGMANAGER_USE_LOCKS
     std::mutex mLogLockMutex;

--- a/source/utils/ResourceManager.cpp
+++ b/source/utils/ResourceManager.cpp
@@ -185,57 +185,72 @@ void ResourceManager::setupUserDataFolders(boost::program_options::variables_map
     mUserDataPath.clear();
     mUserConfigPath.clear();
 
-#if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
-    passwd* pw = getpwuid(getuid());
-    if(pw)
+    if(options.count("appData") > 0)
     {
-        mUserDataPath = std::string(pw->pw_dir) + "/Library/Application Support/opendungeons/";
-        mUserConfigPath = mUserDataPath + "cfg/";
-    }
-#elif OGRE_PLATFORM == OGRE_PLATFORM_LINUX
-    // $XDG_DATA_HOME/opendungeons/
-    // equals to: ~/.local/share/opendungeons/ most of the time
-    if (std::getenv("XDG_DATA_HOME"))
-    {
-        mUserDataPath = std::string(std::getenv("XDG_DATA_HOME")) + "/opendungeons/";
-    }
-    else
-    {
-        // We create a sane default if possible: ~/.local/share/opendungeons
-        passwd *pw = getpwuid(getuid());
-        if(pw)
+        mUserDataPath = options["appData"].as<std::string>();
+        if(!mUserDataPath.empty())
         {
-            mUserDataPath = std::string(pw->pw_dir) + "/.local/share/opendungeons/";
-        }
-    }
+            uint32_t len = mUserDataPath.length();
+            if((mUserDataPath.at(len - 1) != '/') && (mUserDataPath.at(len - 1) != '\\'))
+                mUserDataPath += '/';
 
-    // $XDG_CONFIG_HOME/opendungeons
-    // equals to: ~/.config/opendungeons/ most of the time
-    if (std::getenv("XDG_CONFIG_HOME"))
-    {
-        mUserConfigPath = std::string(std::getenv("XDG_CONFIG_HOME")) + "/opendungeons/";
+            mUserConfigPath = mUserDataPath + "cfg/";
+        }
     }
     else
     {
-        // We create a sane default if possible: ~/.config/opendungeons
-        passwd *pw = getpwuid(getuid());
+#if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
+        passwd* pw = getpwuid(getuid());
         if(pw)
         {
-            mUserConfigPath = std::string(pw->pw_dir) + "/.config/opendungeons/";
+            mUserDataPath = std::string(pw->pw_dir) + "/Library/Application Support/opendungeons/";
+            mUserConfigPath = mUserDataPath + "cfg/";
         }
-    }
+#elif OGRE_PLATFORM == OGRE_PLATFORM_LINUX
+        // $XDG_DATA_HOME/opendungeons/
+        // equals to: ~/.local/share/opendungeons/ most of the time
+        if (std::getenv("XDG_DATA_HOME"))
+        {
+            mUserDataPath = std::string(std::getenv("XDG_DATA_HOME")) + "/opendungeons/";
+        }
+        else
+        {
+            // We create a sane default if possible: ~/.local/share/opendungeons
+            passwd *pw = getpwuid(getuid());
+            if(pw)
+            {
+                mUserDataPath = std::string(pw->pw_dir) + "/.local/share/opendungeons/";
+            }
+        }
+
+        // $XDG_CONFIG_HOME/opendungeons
+        // equals to: ~/.config/opendungeons/ most of the time
+        if (std::getenv("XDG_CONFIG_HOME"))
+        {
+            mUserConfigPath = std::string(std::getenv("XDG_CONFIG_HOME")) + "/opendungeons/";
+        }
+        else
+        {
+            // We create a sane default if possible: ~/.config/opendungeons
+            passwd *pw = getpwuid(getuid());
+            if(pw)
+            {
+                mUserConfigPath = std::string(pw->pw_dir) + "/.config/opendungeons/";
+            }
+        }
 
 #elif OGRE_PLATFORM == OGRE_PLATFORM_WIN32
-    char path[MAX_PATH];
-    // %APPDATA% (%USERPROFILE%\Application Data)
-    if(SUCCEEDED(SHGetFolderPathA(nullptr, CSIDL_APPDATA, nullptr, 0, path)))
-    {
-        mUserDataPath = std::string(path) + "/opendungeons/";
-        mUserConfigPath = mUserDataPath + "cfg/";
-    }
+        char path[MAX_PATH];
+        // %APPDATA% (%USERPROFILE%\Application Data)
+        if(SUCCEEDED(SHGetFolderPathA(nullptr, CSIDL_APPDATA, nullptr, 0, path)))
+        {
+            mUserDataPath = std::string(path) + "/opendungeons/";
+            mUserConfigPath = mUserDataPath + "cfg/";
+        }
 #else
 #error("Unknown platform!")
 #endif
+    }
 
     // Use local defaults if everything else failed.
     if (mUserDataPath.empty())
@@ -444,6 +459,7 @@ void ResourceManager::buildCommandOptions(boost::program_options::options_descri
     desc.add_options()
         ("log", boost::program_options::value<std::string>(), "log file to use")
         ("server", boost::program_options::value<std::string>(), "Launches the game on server mode and opens the given level")
+        ("appData", boost::program_options::value<std::string>(), "Sets appData to the given path (where logs, replays, ... are saved)")
     ;
 }
 

--- a/source/utils/ResourceManager.cpp
+++ b/source/utils/ResourceManager.cpp
@@ -380,7 +380,7 @@ void ResourceManager::setupOgreResources(uint16_t shaderLanguageVersion)
     Ogre::ResourceGroupManager& resourceGroupManager = Ogre::ResourceGroupManager::getSingleton();
     if(gpuProgramManager.isSyntaxSupported("glsl"))
     {
-        LogManager::getSingleton().logMessage("Supported shader version is: " + Helper::toString(shaderLanguageVersion));
+        OD_LOG_INF("Supported shader version is: " + Helper::toString(shaderLanguageVersion));
 
         // Add GLSL shader location for RTShader system
         resourceGroupManager.addResourceLocation(mGameDataPath + "materials/RTShaderLib/GLSL", "FileSystem", "Graphics");

--- a/source/utils/ResourceManager.h
+++ b/source/utils/ResourceManager.h
@@ -41,6 +41,8 @@ class variables_map;
 }
 }
 
+//!\brief class that handle OD ressources. Note that this class might be created before the
+//! LogManager because it handles the log filename. Thus, it should not use LogManager.
 class ResourceManager : public Ogre::Singleton<ResourceManager>
 {
 public:


### PR DESCRIPTION
I've splitted the commit between spell/room/trap to make it easier to read. The basic idea is to let each spell/room/trap handle the inputs (selected tiles/text) as it wants. For example, building a door will not allow to choose more than 1 tile and will display an explicit text if the door is not next to 2 full tiles.
Later, it will also allow to change easily icons if we want to (per spell/room/trap).

I've also changed a bit how text is displayed when building rooms/traps/spells
- If the player do not select tiles, the price will be for 1 target and red if not enough mana/gold for 1 target. White otherwise.
- if the player selects a tile (left button), the price will be displayed white and it will be what will be spent if he releases the button (0 if no target or not enough gold/mana or more if enough gold/mana).

Note that ATM, the tile selector is not displayed by default in gamemode (only when tiles are selected for digging). This is more to test this behaviour. If you prefer displaying it, I will make a commit.
