### PR TITLE
Fixed the console auto-completion when using tab.

### DIFF
--- a/source/modes/GameEditorModeConsole.cpp
+++ b/source/modes/GameEditorModeConsole.cpp
@@ -51,11 +51,6 @@ GameEditorModeConsole::GameEditorModeConsole(ModeManager* modeManager):
                                    CEGUI::Event::Subscriber(&GameEditorModeConsole::executeCurrentPrompt, this))
     );
 
-    addEventConnection(
-        mEditboxWindow->subscribeEvent(CEGUI::Editbox::EventTextAccepted,
-                                       CEGUI::Event::Subscriber(&GameEditorModeConsole::executeCurrentPrompt, this))
-    );
-
     mConsoleHistoryWindow->getVertScrollbar()->setEndLockEnabled(true);
 
     // Permits closing the console.
@@ -119,6 +114,10 @@ bool GameEditorModeConsole::keyPressed(const OIS::KeyEvent &arg)
             mEditboxWindow->setCaretIndex(mEditboxWindow->getText().length());
             break;
         }
+        case OIS::KC_RETURN:
+        case OIS::KC_NUMPADENTER:
+            executeCurrentPrompt();
+            break;
         default:
             break;
     }

--- a/source/modes/GameEditorModeConsole.h
+++ b/source/modes/GameEditorModeConsole.h
@@ -49,7 +49,7 @@ public:
 
 private:
     void printToConsole(const std::string& text);
-    bool executeCurrentPrompt(const CEGUI::EventArgs &e);
+    bool executeCurrentPrompt(const CEGUI::EventArgs& e = {});
 
     ConsoleInterface mConsoleInterface;
 

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -776,7 +776,8 @@ bool GameMode::keyPressedNormal(const OIS::KeyEvent &arg)
         ResourceManager::getSingleton().takeScreenshot(frameListener.getRenderWindow());
         break;
 
-    case OIS::KC_RETURN: {
+    case OIS::KC_RETURN:
+    case OIS::KC_NUMPADENTER: {
         mCurrentInputMode = InputModeChat;
         CEGUI::Window* chatEditBox = mRootWindow->getChild("GameChatWindow/GameChatEditBox");
         chatEditBox->show();
@@ -816,7 +817,7 @@ bool GameMode::keyPressedChat(const OIS::KeyEvent &arg)
         return true;
     }
 
-    if(arg.key != OIS::KC_RETURN)
+    if(arg.key != OIS::KC_RETURN && arg.key != OIS::KC_NUMPADENTER)
         return true;
 
     mCurrentInputMode = InputModeNormal;


### PR DESCRIPTION
The console editbox was executing the prompt command
when this event was happening: CEGUI::Editbox::EventTextAccepted
But this CEGUI event is also triggered when tab is pushed, breaking the auto-completion.

This is now fixed.

I also added support to use the keypad enter key as well as the standard enter key
for chat/console.

Fixes #757
