### PR TITLE
First part of #3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,7 @@ set(OD_SOURCEFILES
     ${SRC}/modes/MenuModeReplay.cpp
     ${SRC}/modes/MenuModeSkirmish.cpp
     ${SRC}/modes/ModeManager.cpp
+    ${SRC}/modes/SettingsWindow.cpp
 
     ${SRC}/network/ChatEventMessage.cpp
     ${SRC}/network/ClientNotification.cpp

--- a/gui/MenuMain.layout
+++ b/gui/MenuMain.layout
@@ -57,5 +57,13 @@
             <Property name="Text" value="Quit" />
             <Property name="AlwaysOnTop" value="True" />
         </Window>
+        <Window type="OD/ImageButton" name="SettingsButton" >
+            <Property name="Area" value="{{1,-27},{0,5},{1,-2},{0,30}}" />
+            <Property name="ButtonImage" value="OpenDungeonsIcons/OptionsIcon" />
+            <Property name="AlwaysOnTop" value="True" />
+            <Property name="TooltipText" value="Options" />
+            <Property name="ClippedByParent" value="False" />
+            <Property name="Visible" value="True" />
+        </Window>
     </Window>
 </GUILayout>

--- a/gui/MenuMain.layout
+++ b/gui/MenuMain.layout
@@ -25,37 +25,30 @@
         <Window type="OD/MainMenuButton" name="StartSkirmishButton" >
             <Property name="Area" value="{{0.5,-310},{0.5,-10},{0.5,-170},{0.5,70}}" />
             <Property name="Text" value="Skirmish" />
-            <Property name="AlwaysOnTop" value="True" />
         </Window>
         <Window type="OD/MainMenuButton" name="LoadGameButton" >
             <Property name="Area" value="{{0.5,-310},{0.5,100},{0.5,-170},{0.5,180}}" />
             <Property name="Text" value="Load" />
-            <Property name="AlwaysOnTop" value="True" />
         </Window>
         <Window type="OD/MainMenuButton" name="StartMultiplayerClientButton" >
             <Property name="Area" value="{{0.5,-150},{0.5,-10},{0.5,-10},{0.5,70}}" />
             <Property name="Text" value="Join Game" />
-            <Property name="AlwaysOnTop" value="True" />
         </Window>
         <Window type="OD/MainMenuButton" name="StartMultiplayerServerButton" >
             <Property name="Area" value="{{0.5,-150},{0.5,100},{0.5,-10},{0.5,180}}" />
             <Property name="Text" value="Host Game" />
-            <Property name="AlwaysOnTop" value="True" />
         </Window>
         <Window type="OD/MainMenuButton" name="MapEditorButton" >
             <Property name="Area" value="{{0.5,10},{0.5,-10},{0.5,150},{0.5,70}}" />
             <Property name="Text" value="Map Editor" />
-            <Property name="AlwaysOnTop" value="True" />
         </Window>
         <Window type="OD/MainMenuButton" name="StartReplayButton" >
             <Property name="Area" value="{{0.5,10},{0.5,100},{0.5,150},{0.5,180}}" />
             <Property name="Text" value="Replay" />
-            <Property name="AlwaysOnTop" value="True" />
         </Window>
         <Window type="OD/MainMenuButton" name="QuitButton" >
             <Property name="Area" value="{{0.5,170},{0.5,40},{0.5,310},{0.5,120}}" />
             <Property name="Text" value="Quit" />
-            <Property name="AlwaysOnTop" value="True" />
         </Window>
         <Window type="OD/ImageButton" name="SettingsButton" >
             <Property name="Area" value="{{1,-27},{0,5},{1,-2},{0,30}}" />

--- a/gui/ModeGame.layout
+++ b/gui/ModeGame.layout
@@ -142,7 +142,6 @@
         <LayoutImport type="DefaultWindow" filename="WindowObjectives.layout" name="ObjectivesWindowImport" />
         <LayoutImport type="DefaultWindow" filename="WindowResearchTree.layout" name="ResearchTreeWindowImport" />
         <LayoutImport type="DefaultWindow" filename="WindowGameOptions.layout" name="GameOptionsMenuImport" />
-        <LayoutImport type="DefaultWindow" filename="WindowSettings.layout" name="SettingsMenuImport" />
         <LayoutImport type="DefaultWindow" filename="WindowEvent.layout" name="EventWindowImport" />
         <LayoutImport type="DefaultWindow" filename="WindowChat.layout" name="ChatWindowImport" />
         <LayoutImport type="DefaultWindow" filename="WindowHelp.layout" name="HelpWindowImport" />

--- a/gui/WindowEditorOptions.layout
+++ b/gui/WindowEditorOptions.layout
@@ -33,8 +33,8 @@
         </Window>
         <Window type="OD/IconButton" name="SettingsButton" >
             <Property name="Area" value="{{0.5,-80},{0,235},{0.5,80},{0,268}}" />
-            <Property name="Text" value="Settings (F10)" />
-            <Property name="Disabled" value="True" />
+            <Property name="Text" value="Settings" />
+            <Property name="Disabled" value="False" />
             <Property name="IconImage" value="OpenDungeonsIcons/OptionsIcon" />
             <Property name="TooltipText" value="Open the game settings window." />
         </Window>

--- a/gui/WindowGameOptions.layout
+++ b/gui/WindowGameOptions.layout
@@ -32,7 +32,7 @@
             <Property name="Area" value="{{0.5,-80},{0,235},{0.5,80},{0,268}}" />
             <Property name="IconImage" value="OpenDungeonsIcons/OptionsIcon" />
             <Property name="Text" value="Settings" />
-            <Property name="Disabled" value="True" />
+            <Property name="Disabled" value="False" />
             <Property name="TooltipText" value="Open the game settings window." />
         </Window>
         <Window type="OD/IconButton" name="QuitGameButton" >

--- a/gui/WindowSettings.layout
+++ b/gui/WindowSettings.layout
@@ -2,18 +2,18 @@
 
 <GUILayout version="4" >
     <Window type="OD/FrameWindow" name="SettingsWindow" >
-        <Property name="Area" value="{{0,205},{0,128},{0,669},{0,581}}" />
+        <Property name="Area" value="{{0,205},{0,128},{0,669},{0,381}}" />
         <Property name="Text" value="Settings" />
         <Window type="OD/Button" name="CancelButton" >
-            <Property name="Area" value="{{0,219},{0,394},{0,302},{0,432}}" />
+            <Property name="Area" value="{{0,219},{1,-50},{0,302},{1,-20}}" />
             <Property name="Text" value="Cancel" />
         </Window>
         <Window type="OD/Button" name="ApplyButton" >
-            <Property name="Area" value="{{0,313},{0,394},{0,399},{0,432}}" />
+            <Property name="Area" value="{{0,313},{1,-50},{0,399},{1,-20}}" />
             <Property name="Text" value="Apply" />
         </Window>
         <Window type="OD/TabControl" name="MainTabControl" >
-            <Property name="Area" value="{{0,10},{1,-422},{1,-10},{1,-70}}" />
+            <Property name="Area" value="{{0,10},{1,-222},{1,-10},{1,-70}}" />
             <Property name="TabHeight" value="{0,30}" />
             <Property name="RiseOnClickEnabled" value="False" />
             <Window type="DefaultWindow" name="Video" >
@@ -33,7 +33,7 @@
                     <Property name="Text" value="Fullscreen" />
                 </Window>
                 <Window type="OD/Combobox" name="ResolutionCombobox" >
-                    <Property name="Area" value="{{0,22},{0,42},{0,166},{0,92}}" />
+                    <Property name="Area" value="{{0,22},{0,42},{0,166},{0,132}}" />
                     <Property name="ReadOnly" value="True" />
                 </Window>
             </Window>
@@ -55,32 +55,6 @@
                     <Property name="Text" value="" />
                     <Property name="VerticalSlider" value="False" />
                     <Property name="AutoRenderingSurface" value="True" />
-                </Window>
-                <Window type="OD/StaticText" name="SoundText" >
-                    <Property name="Area" value="{{0,32},{0,100},{0,220},{0,120}}" />
-                    <Property name="MaxSize" value="{{1,0},{1,0}}" />
-                    <Property name="Text" value="Sound:" />
-                    <Property name="BackgroundEnabled" value="False" />
-                    <Property name="FrameEnabled" value="False" />
-                </Window>
-                <Window type="OD/HorizontalSlider" name="SoundSlider" >
-                    <Property name="Area" value="{{0,31},{0,129},{0,326},{0,158}}" />
-                    <Property name="Text" value="" />
-                    <Property name="VerticalSlider" value="False" />
-                    <Property name="AutoRenderingSurface" value="True" />
-                </Window>
-            </Window>
-            <Window type="DefaultWindow" name="Misc" >
-                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
-                <Property name="Text" value="Misc" />
-                <Property name="MaxSize" value="{{1,0},{1,0}}" />
-                <Property name="Visible" value="False" />
-                <Property name="RiseOnClickEnabled" value="False" />
-                <Window type="OD/Checkbox" name="ConsoleCommandsCheckbox" >
-                    <Property name="Area" value="{{0,19},{0,22},{0,406},{0,48}}" />
-                    <Property name="Text" value="Activate console commands in multiplayer" />
-                    <Property name="AutoRenderingSurface" value="True" />
-                    <Property name="Selected" value="True" />
                 </Window>
             </Window>
         </Window>

--- a/gui/WindowSettings.layout
+++ b/gui/WindowSettings.layout
@@ -2,8 +2,9 @@
 
 <GUILayout version="4" >
     <Window type="OD/FrameWindow" name="SettingsWindow" >
-        <Property name="Area" value="{{0,205},{0,128},{0,669},{0,381}}" />
+        <Property name="Area" value="{{0,205},{0,128},{0,669},{0,481}}" />
         <Property name="Text" value="Settings" />
+        <Property name="SizingEnabled" value="False" />
         <Window type="OD/Button" name="CancelButton" >
             <Property name="Area" value="{{0,219},{1,-50},{0,302},{1,-20}}" />
             <Property name="Text" value="Cancel" />
@@ -13,7 +14,7 @@
             <Property name="Text" value="Apply" />
         </Window>
         <Window type="OD/TabControl" name="MainTabControl" >
-            <Property name="Area" value="{{0,10},{1,-222},{1,-10},{1,-70}}" />
+            <Property name="Area" value="{{0,10},{0,20},{1,-10},{1,-70}}" />
             <Property name="TabHeight" value="{0,30}" />
             <Property name="RiseOnClickEnabled" value="False" />
             <Window type="DefaultWindow" name="Video" >
@@ -22,19 +23,37 @@
                 <Property name="MaxSize" value="{{1,0},{1,0}}" />
                 <Property name="RiseOnClickEnabled" value="False" />
                 <Window type="OD/StaticText" name="ResolutionText" >
-                    <Property name="Area" value="{{0,22},{0,12},{0,184},{0,43}}" />
+                    <Property name="Area" value="{{0,22},{0,31},{0,184},{0,43}}" />
                     <Property name="MaxSize" value="{{1,0},{1,0}}" />
                     <Property name="Text" value="Resolution:" />
                     <Property name="BackgroundEnabled" value="False" />
                     <Property name="FrameEnabled" value="False" />
                 </Window>
+                <Window type="OD/Combobox" name="ResolutionCombobox" >
+                    <Property name="Area" value="{{0,22},{0,42},{0,166},{0,162}}" />
+                    <Property name="ReadOnly" value="True" />
+                </Window>
                 <Window type="OD/Checkbox" name="FullscreenCheckbox" >
                     <Property name="Area" value="{{0,222},{0,42},{0,342},{0,68}}" />
                     <Property name="Text" value="Fullscreen" />
                 </Window>
-                <Window type="OD/Combobox" name="ResolutionCombobox" >
-                    <Property name="Area" value="{{0,22},{0,42},{0,166},{0,132}}" />
+                <Window type="OD/StaticText" name="RendererText" >
+                    <Property name="Area" value="{{0,22},{0,78},{0,184},{0,90}}" />
+                    <Property name="MaxSize" value="{{1,0},{1,0}}" />
+                    <Property name="Text" value="Renderer*:" />
+                    <Property name="BackgroundEnabled" value="False" />
+                    <Property name="FrameEnabled" value="False" />
+                    <Property name="TooltipText" value="* Needs a restart to be applied." />
+                </Window>
+                <Window type="OD/Combobox" name="RendererCombobox" >
+                    <Property name="Area" value="{{0,22},{0,90},{0,266},{0,210}}" />
                     <Property name="ReadOnly" value="True" />
+                    <Property name="TooltipText" value="* Needs a restart to be applied." />
+                </Window>
+                <Window type="OD/Checkbox" name="VSyncCheckbox" >
+                    <Property name="Area" value="{{0,22},{0,120},{0,166},{0,135}}" />
+                    <Property name="Text" value="VSync*" />
+                    <Property name="TooltipText" value="* Needs a restart to be potentially applied." />
                 </Window>
             </Window>
             <Window type="DefaultWindow" name="Audio" >
@@ -51,7 +70,7 @@
                     <Property name="FrameEnabled" value="False" />
                 </Window>
                 <Window type="OD/HorizontalSlider" name="MusicSlider" >
-                    <Property name="Area" value="{{0,32},{0,67},{0,327},{0,96}}" />
+                    <Property name="Area" value="{{0,32},{0,67},{0,327},{0,80}}" />
                     <Property name="Text" value="" />
                     <Property name="VerticalSlider" value="False" />
                     <Property name="AutoRenderingSurface" value="True" />

--- a/source/ODApplication.cpp
+++ b/source/ODApplication.cpp
@@ -163,9 +163,6 @@ void ODApplication::startClient()
     ogreRoot.addFrameListener(&frameListener);
     ogreRoot.startRendering();
 
-    // Rendering ended, let's quit
-    ogreRoot.saveConfig();
-
     OD_LOG_INF("Disconnecting client...");
     client.disconnect();
     OD_LOG_INF("Stopping server...");

--- a/source/ODApplication.h
+++ b/source/ODApplication.h
@@ -32,6 +32,10 @@ class variables_map;
 }
 }
 
+namespace Ogre {
+class Root;
+}
+
 class LogManager;
 
 //! \brief Base class which manages the startup of OpenDungeons.
@@ -60,6 +64,10 @@ private:
     void startClient();
     //! \brief Server mode. Creates only the needed to launch a level. Note that this is to be used without gui
     void startServer();
+
+    //! \brief Loads the ogre startup configuration, or create a default one if it isn't found or unrestorable.
+    //! \return Whether initialization succeeded.
+    bool loadOgreConfig(Ogre::Root& ogreRoot);
 };
 
 #endif // ODAPPLICATION_H

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -18,7 +18,6 @@
 #include "modes/EditorMode.h"
 
 #include "modes/GameEditorModeConsole.h"
-#include "modes/SettingsWindow.h"
 
 #include "gamemap/GameMap.h"
 #include "gamemap/MiniMap.h"
@@ -82,7 +81,7 @@ EditorMode::EditorMode(ModeManager* modeManager):
     mCurrentCreatureIndex(0),
     mMouseX(0),
     mMouseY(0),
-    mSettings(new SettingsWindow(mRootWindow))
+    mSettings(SettingsWindow(mRootWindow))
 {
     // Set per default the input on the map
     mModeManager->getInputManager().mMouseDownOnCEGUIWindow = false;
@@ -160,9 +159,6 @@ EditorMode::~EditorMode()
 
     // Now that the server is stopped, we can clear the client game map
     ODFrameListener::getSingleton().getClientGameMap()->clearAll();
-
-    // Clear up the settings window.
-    delete mSettings;
 }
 
 void EditorMode::activate()
@@ -804,7 +800,7 @@ bool EditorMode::toggleOptionsWindow(const CEGUI::EventArgs& /*arg*/)
 bool EditorMode::showSettingsFromOptions(const CEGUI::EventArgs& /*e*/)
 {
     mRootWindow->getChild("EditorOptionsWindow")->hide();
-    mSettings->show();
+    mSettings.show();
     return true;
 }
 

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -160,6 +160,9 @@ EditorMode::~EditorMode()
 
     // Now that the server is stopped, we can clear the client game map
     ODFrameListener::getSingleton().getClientGameMap()->clearAll();
+
+    // Clear up the settings window.
+    delete mSettings;
 }
 
 void EditorMode::activate()

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -18,6 +18,7 @@
 #include "modes/EditorMode.h"
 
 #include "modes/GameEditorModeConsole.h"
+#include "modes/SettingsWindow.h"
 
 #include "gamemap/GameMap.h"
 #include "gamemap/MiniMap.h"
@@ -80,7 +81,8 @@ EditorMode::EditorMode(ModeManager* modeManager):
     mCurrentFullness(100.0),
     mCurrentCreatureIndex(0),
     mMouseX(0),
-    mMouseY(0)
+    mMouseY(0),
+    mSettings(new SettingsWindow(mRootWindow))
 {
     // Set per default the input on the map
     mModeManager->getInputManager().mMouseDownOnCEGUIWindow = false;
@@ -120,6 +122,12 @@ EditorMode::EditorMode(ModeManager* modeManager):
             CEGUI::Window::EventMouseClick,
             CEGUI::Event::Subscriber(&EditorMode::onSaveButtonClickFromOptions, this)
     ));
+    addEventConnection(
+        mRootWindow->getChild("EditorOptionsWindow/SettingsButton")->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&EditorMode::showSettingsFromOptions, this)
+        )
+    );
     addEventConnection(
         mRootWindow->getChild("EditorOptionsWindow/QuitEditorButton")->subscribeEvent(
             CEGUI::Window::EventMouseClick,
@@ -790,11 +798,17 @@ bool EditorMode::toggleOptionsWindow(const CEGUI::EventArgs& /*arg*/)
     return true;
 }
 
+bool EditorMode::showSettingsFromOptions(const CEGUI::EventArgs& /*e*/)
+{
+    mRootWindow->getChild("EditorOptionsWindow")->hide();
+    mSettings->show();
+    return true;
+}
+
 bool EditorMode::showQuitMenuFromOptions(const CEGUI::EventArgs& /*arg*/)
 {
-    CEGUI::Window* guiSheet = mRootWindow;
-    guiSheet->getChild("ConfirmExit")->show();
-    guiSheet->getChild("EditorOptionsWindow")->hide();
+    mRootWindow->getChild("ConfirmExit")->show();
+    mRootWindow->getChild("EditorOptionsWindow")->hide();
     return true;
 }
 

--- a/source/modes/EditorMode.h
+++ b/source/modes/EditorMode.h
@@ -23,6 +23,7 @@
 
 class GameMap;
 class Gui; // Used to change the Current tile type
+class SettingsWindow;
 
 enum class TileVisual;
 
@@ -55,6 +56,7 @@ public:
 
     //! \brief Options window functions
     bool toggleOptionsWindow(const CEGUI::EventArgs& arg = {});
+    bool showSettingsFromOptions(const CEGUI::EventArgs& e = {});
     bool showQuitMenuFromOptions(const CEGUI::EventArgs& arg = {});
     bool onSaveButtonClickFromOptions(const CEGUI::EventArgs& arg = {});
 
@@ -93,6 +95,9 @@ private:
     //! \brief Stores the lastest mouse cursor and light positions.
     int mMouseX;
     int mMouseY;
+
+    //! \brief The settings window.
+    SettingsWindow* mSettings;
 
     //! \brief A sub-function called by mouseMoved()
     //! It will handle the potential mouse wheel logic

--- a/source/modes/EditorMode.h
+++ b/source/modes/EditorMode.h
@@ -19,11 +19,12 @@
 #define EDITORMODE_H
 
 #include "GameEditorModeBase.h"
+
 #include "modes/InputCommand.h"
+#include "modes/SettingsWindow.h"
 
 class GameMap;
 class Gui; // Used to change the Current tile type
-class SettingsWindow;
 
 enum class TileVisual;
 
@@ -97,7 +98,7 @@ private:
     int mMouseY;
 
     //! \brief The settings window.
-    SettingsWindow* mSettings;
+    SettingsWindow mSettings;
 
     //! \brief A sub-function called by mouseMoved()
     //! It will handle the potential mouse wheel logic

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -18,7 +18,6 @@
 #include "modes/GameMode.h"
 
 #include "modes/GameEditorModeConsole.h"
-#include "modes/SettingsWindow.h"
 
 #include "ODApplication.h"
 #include "camera/CameraManager.h"
@@ -79,7 +78,7 @@ GameMode::GameMode(ModeManager *modeManager):
     GameEditorModeBase(modeManager, ModeManager::GAME, modeManager->getGui().getGuiSheet(Gui::guiSheet::inGameMenu)),
     mDigSetBool(false),
     mIndexEvent(0),
-    mSettings(new SettingsWindow(mRootWindow))
+    mSettings(SettingsWindow(mRootWindow))
 {
     // Set per default the input on the map
     mModeManager->getInputManager().mMouseDownOnCEGUIWindow = false;
@@ -229,9 +228,6 @@ GameMode::~GameMode()
 
     // Now that the server is stopped, we can clear the client game map
     ODFrameListener::getSingleton().getClientGameMap()->clearAll();
-
-    // Clear up the settings window.
-    delete mSettings;
 }
 
 void GameMode::activate()
@@ -1119,7 +1115,7 @@ bool GameMode::saveGame(const CEGUI::EventArgs& /*e*/)
 bool GameMode::showSettingsFromOptions(const CEGUI::EventArgs& /*e*/)
 {
     mRootWindow->getChild("GameOptionsWindow")->hide();
-    mSettings->show();
+    mSettings.show();
     return true;
 }
 

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -18,6 +18,7 @@
 #include "modes/GameMode.h"
 
 #include "modes/GameEditorModeConsole.h"
+#include "modes/SettingsWindow.h"
 
 #include "ODApplication.h"
 #include "camera/CameraManager.h"
@@ -77,7 +78,8 @@ namespace
 GameMode::GameMode(ModeManager *modeManager):
     GameEditorModeBase(modeManager, ModeManager::GAME, modeManager->getGui().getGuiSheet(Gui::guiSheet::inGameMenu)),
     mDigSetBool(false),
-    mIndexEvent(0)
+    mIndexEvent(0),
+    mSettings(new SettingsWindow(mRootWindow))
 {
     // Set per default the input on the map
     mModeManager->getInputManager().mMouseDownOnCEGUIWindow = false;
@@ -165,19 +167,6 @@ GameMode::GameMode(ModeManager *modeManager):
             CEGUI::Event::Subscriber(&GameMode::showQuitMenuFromOptions, this)
         )
     );
-    //Settings window
-    addEventConnection(
-        guiSheet->getChild("SettingsWindow/CancelButton")->subscribeEvent(
-            CEGUI::PushButton::EventClicked,
-            CEGUI::Event::Subscriber(&GameMode::hideSettingsWindow, this)
-        )
-    );
-    addEventConnection(
-        guiSheet->getChild("SettingsWindow/__auto_closebutton__")->subscribeEvent(
-            CEGUI::PushButton::EventClicked,
-            CEGUI::Event::Subscriber(&GameMode::hideSettingsWindow, this)
-        )
-    );
 
     //Exit confirmation box
     addEventConnection(
@@ -240,6 +229,9 @@ GameMode::~GameMode()
 
     // Now that the server is stopped, we can clear the client game map
     ODFrameListener::getSingleton().getClientGameMap()->clearAll();
+
+    // Clear up the settings window.
+    delete mSettings;
 }
 
 void GameMode::activate()
@@ -1091,12 +1083,6 @@ bool GameMode::toggleOptionsWindow(const CEGUI::EventArgs& e)
     return true;
 }
 
-bool GameMode::hideSettingsWindow(const CEGUI::EventArgs&)
-{
-    mRootWindow->getChild("SettingsWindow")->hide();
-    return true;
-}
-
 bool GameMode::showQuitMenuFromOptions(const CEGUI::EventArgs& /*e*/)
 {
     mRootWindow->getChild("GameOptionsWindow")->hide();
@@ -1133,7 +1119,7 @@ bool GameMode::saveGame(const CEGUI::EventArgs& /*e*/)
 bool GameMode::showSettingsFromOptions(const CEGUI::EventArgs& /*e*/)
 {
     mRootWindow->getChild("GameOptionsWindow")->hide();
-    mRootWindow->getChild("SettingsWindow")->show();
+    mSettings->show();
     return true;
 }
 

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -19,7 +19,9 @@
 #define GAMEMODE_H
 
 #include "GameEditorModeBase.h"
+
 #include "modes/InputCommand.h"
+#include "modes/SettingsWindow.h"
 
 #include <CEGUI/EventArgs.h>
 
@@ -27,7 +29,6 @@ namespace CEGUI
 {
 class Window;
 }
-class SettingsWindow;
 
 enum class SpellType;
 enum class ResearchType;
@@ -149,7 +150,7 @@ private:
     uint32_t mIndexEvent;
 
     //! \brief The settings window.
-    SettingsWindow* mSettings;
+    SettingsWindow mSettings;
 
     //! \brief Set the help window (quite long) text.
     void setHelpWindowText();

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -27,6 +27,7 @@ namespace CEGUI
 {
 class Window;
 }
+class SettingsWindow;
 
 enum class SpellType;
 enum class ResearchType;
@@ -108,9 +109,6 @@ class GameMode final : public GameEditorModeBase, public InputCommand
     bool hideOptionsWindow(const CEGUI::EventArgs& = {});
     bool toggleOptionsWindow(const CEGUI::EventArgs& = {});
 
-    //! \brief Hides the settings window.
-    bool hideSettingsWindow(const CEGUI::EventArgs& = {});
-
     //! \brief Refreshes the player current goals.
     void refreshPlayerGoals(const std::string& goalsDisplayString);
 
@@ -149,6 +147,9 @@ private:
 
     //! \brief Index of the event in the game event queue (for zooming automatically)
     uint32_t mIndexEvent;
+
+    //! \brief The settings window.
+    SettingsWindow* mSettings;
 
     //! \brief Set the help window (quite long) text.
     void setHelpWindowText();

--- a/source/modes/MenuModeMain.cpp
+++ b/source/modes/MenuModeMain.cpp
@@ -18,7 +18,6 @@
 #include "MenuModeMain.h"
 
 #include "modes/ModeManager.h"
-#include "modes/SettingsWindow.h"
 
 #include "ODApplication.h"
 #include "gamemap/GameMap.h"
@@ -48,7 +47,7 @@ public:
 
 MenuModeMain::MenuModeMain(ModeManager *modeManager):
     AbstractApplicationMode(modeManager, ModeManager::MENU_MAIN),
-    mSettings(new SettingsWindow(getModeManager().getGui().getGuiSheet(Gui::mainMenu)))
+    mSettings(SettingsWindow(getModeManager().getGui().getGuiSheet(Gui::mainMenu)))
 {
     connectModeChangeEvent(Gui::MM_BUTTON_MAPEDITOR, AbstractModeManager::ModeType::MENU_EDITOR);
     connectModeChangeEvent(Gui::MM_BUTTON_START_SKIRMISH, AbstractModeManager::ModeType::MENU_SKIRMISH);
@@ -67,14 +66,9 @@ MenuModeMain::MenuModeMain(ModeManager *modeManager):
     addEventConnection(
         rootWin->getChild("SettingsButton")->subscribeEvent(
             CEGUI::PushButton::EventClicked,
-            CEGUI::Event::Subscriber(&MenuModeMain::showSettings, this)
+            CEGUI::Event::Subscriber(&MenuModeMain::toggleSettings, this)
         )
     );
-}
-
-MenuModeMain::~MenuModeMain()
-{
-    delete mSettings;
 }
 
 void MenuModeMain::activate()
@@ -113,8 +107,11 @@ bool MenuModeMain::quitButtonPressed(const CEGUI::EventArgs&)
     return true;
 }
 
-bool MenuModeMain::showSettings(const CEGUI::EventArgs&)
+bool MenuModeMain::toggleSettings(const CEGUI::EventArgs&)
 {
-    mSettings->show();
+    if (mSettings.isVisible())
+        mSettings.cancelSettings();
+    else
+        mSettings.show();
     return true;
 }

--- a/source/modes/MenuModeMain.cpp
+++ b/source/modes/MenuModeMain.cpp
@@ -17,9 +17,11 @@
 
 #include "MenuModeMain.h"
 
+#include "modes/ModeManager.h"
+#include "modes/SettingsWindow.h"
+
 #include "ODApplication.h"
 #include "gamemap/GameMap.h"
-#include "modes/ModeManager.h"
 #include "render/Gui.h"
 #include "render/ODFrameListener.h"
 #include "render/TextRenderer.h"
@@ -45,7 +47,8 @@ public:
 } // namespace
 
 MenuModeMain::MenuModeMain(ModeManager *modeManager):
-    AbstractApplicationMode(modeManager, ModeManager::MENU_MAIN)
+    AbstractApplicationMode(modeManager, ModeManager::MENU_MAIN),
+    mSettings(new SettingsWindow(getModeManager().getGui().getGuiSheet(Gui::mainMenu)))
 {
     connectModeChangeEvent(Gui::MM_BUTTON_MAPEDITOR, AbstractModeManager::ModeType::MENU_EDITOR);
     connectModeChangeEvent(Gui::MM_BUTTON_START_SKIRMISH, AbstractModeManager::ModeType::MENU_SKIRMISH);
@@ -59,6 +62,19 @@ MenuModeMain::MenuModeMain(ModeManager *modeManager):
             CEGUI::Event::Subscriber(&MenuModeMain::quitButtonPressed, this)
         )
     );
+
+    CEGUI::Window* rootWin = getModeManager().getGui().getGuiSheet(Gui::mainMenu);
+    addEventConnection(
+        rootWin->getChild("SettingsButton")->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&MenuModeMain::showSettings, this)
+        )
+    );
+}
+
+MenuModeMain::~MenuModeMain()
+{
+    delete mSettings;
 }
 
 void MenuModeMain::activate()
@@ -94,5 +110,11 @@ void MenuModeMain::connectModeChangeEvent(const std::string& buttonName, Abstrac
 bool MenuModeMain::quitButtonPressed(const CEGUI::EventArgs&)
 {
     ODFrameListener::getSingletonPtr()->requestExit();
+    return true;
+}
+
+bool MenuModeMain::showSettings(const CEGUI::EventArgs&)
+{
+    mSettings->show();
     return true;
 }

--- a/source/modes/MenuModeMain.h
+++ b/source/modes/MenuModeMain.h
@@ -20,18 +20,26 @@
 
 #include "AbstractApplicationMode.h"
 
+class SettingsWindow;
+
 class MenuModeMain: public AbstractApplicationMode
 {
 public:
     MenuModeMain(ModeManager*);
 
+    virtual ~MenuModeMain();
+
     //! \brief Called when the game mode is activated
     //! Used to call the corresponding Gui Sheet.
     void activate() final override;
 private:
+    //! \brief The Settings window
+    SettingsWindow* mSettings;
+
     //! \brief Helper function to connect a button to a mode change
     void connectModeChangeEvent(const std::string& buttonName, AbstractModeManager::ModeType mode);
     bool quitButtonPressed(const CEGUI::EventArgs&);
+    bool showSettings(const CEGUI::EventArgs&);
 };
 
 #endif // MENUMODEMAIN_H

--- a/source/modes/MenuModeMain.h
+++ b/source/modes/MenuModeMain.h
@@ -20,26 +20,28 @@
 
 #include "AbstractApplicationMode.h"
 
-class SettingsWindow;
+#include "modes/SettingsWindow.h"
 
 class MenuModeMain: public AbstractApplicationMode
 {
 public:
     MenuModeMain(ModeManager*);
 
-    virtual ~MenuModeMain();
+    virtual ~MenuModeMain()
+    {}
 
     //! \brief Called when the game mode is activated
     //! Used to call the corresponding Gui Sheet.
     void activate() final override;
+
 private:
     //! \brief The Settings window
-    SettingsWindow* mSettings;
+    SettingsWindow mSettings;
 
     //! \brief Helper function to connect a button to a mode change
     void connectModeChangeEvent(const std::string& buttonName, AbstractModeManager::ModeType mode);
     bool quitButtonPressed(const CEGUI::EventArgs&);
-    bool showSettings(const CEGUI::EventArgs&);
+    bool toggleSettings(const CEGUI::EventArgs&);
 };
 
 #endif // MENUMODEMAIN_H

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -70,7 +70,7 @@ SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow):
         )
     );
 
-    initWidgetConfig();
+    initConfig();
 }
 
 SettingsWindow::~SettingsWindow()
@@ -91,7 +91,7 @@ SettingsWindow::~SettingsWindow()
     }
 }
 
-void SettingsWindow::initWidgetConfig()
+void SettingsWindow::initConfig()
 {
     Ogre::Root* ogreRoot = Ogre::Root::getSingletonPtr();
     Ogre::RenderSystem* renderer = ogreRoot->getRenderSystem();
@@ -146,7 +146,7 @@ void SettingsWindow::initWidgetConfig()
 
 bool SettingsWindow::cancelSettings(const CEGUI::EventArgs&)
 {
-    initWidgetConfig();
+    initConfig();
     hide();
     return true;
 }

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -1,0 +1,81 @@
+/*!
+ *  Copyright (C) 2011-2015  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "modes/SettingsWindow.h"
+
+#include "utils/LogManager.h"
+
+#include <CEGUI/widgets/PushButton.h>
+#include <CEGUI/WindowManager.h>
+
+SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow):
+    mSettingsWindow(nullptr),
+    mRootWindow(rootWindow)
+{
+    if (rootWindow == nullptr)
+    {
+        OD_LOG_ERR("Settings Window loaded without any main CEGUI window!!");
+        return;
+    }
+    // Create the window child.
+    CEGUI::WindowManager* wmgr = CEGUI::WindowManager::getSingletonPtr();
+
+     mSettingsWindow = wmgr->loadLayoutFromFile("WindowSettings.layout");
+    if (mSettingsWindow == nullptr)
+    {
+        OD_LOG_ERR("Couldn't load the Settings Window layout!!");
+        return;
+    }
+    rootWindow->addChild(mSettingsWindow);
+    mSettingsWindow->hide();
+
+    // Events connections
+    addEventConnection(
+        mSettingsWindow->getChild("CancelButton")->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&SettingsWindow::hideSettingsWindow, this)
+        )
+    );
+    addEventConnection(
+        mSettingsWindow->getChild("__auto_closebutton__")->subscribeEvent(
+            CEGUI::PushButton::EventClicked,
+            CEGUI::Event::Subscriber(&SettingsWindow::hideSettingsWindow, this)
+        )
+    );
+}
+
+SettingsWindow::~SettingsWindow()
+{
+    // Disconnects all event connections.
+    for(CEGUI::Event::Connection& c : mEventConnections)
+    {
+        c->disconnect();
+    }
+
+    if (mSettingsWindow)
+    {
+        mRootWindow->removeChild(mSettingsWindow->getID());
+        CEGUI::WindowManager* wmgr = CEGUI::WindowManager::getSingletonPtr();
+        wmgr->destroyWindow(mSettingsWindow);
+    }
+}
+
+bool SettingsWindow::hideSettingsWindow(const CEGUI::EventArgs&)
+{
+    hide();
+    return true;
+}

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -41,7 +41,7 @@ SettingsWindow::SettingsWindow(CEGUI::Window* rootWindow):
     // Create the window child.
     CEGUI::WindowManager* wmgr = CEGUI::WindowManager::getSingletonPtr();
 
-     mSettingsWindow = wmgr->loadLayoutFromFile("WindowSettings.layout");
+    mSettingsWindow = wmgr->loadLayoutFromFile("WindowSettings.layout");
     if (mSettingsWindow == nullptr)
     {
         OD_LOG_ERR("Couldn't load the Settings Window layout!!");

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -78,7 +78,8 @@ SettingsWindow::~SettingsWindow()
     if (mSettingsWindow)
     {
         mSettingsWindow->hide();
-        mRootWindow->removeChild(mSettingsWindow->getID());
+        // Will be handled by the window manager. Don't do it.
+        //mRootWindow->removeChild(mSettingsWindow->getID());
         CEGUI::WindowManager* wmgr = CEGUI::WindowManager::getSingletonPtr();
         wmgr->destroyWindow(mSettingsWindow);
     }

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -18,6 +18,7 @@
 #include "modes/SettingsWindow.h"
 
 #include "utils/LogManager.h"
+#include "utils/Helper.h"
 
 #include <CEGUI/CEGUI.h>
 #include <CEGUI/widgets/Combobox.h>
@@ -26,6 +27,7 @@
 #include <CEGUI/WindowManager.h>
 
 #include <OgreRoot.h>
+#include <OgreRenderWindow.h>
 
 #include <SFML/Audio/Listener.hpp>
 
@@ -157,7 +159,7 @@ bool SettingsWindow::applySettings(const CEGUI::EventArgs&)
     // But later, we may want to centralize everything in a common config file,
     // And save volume values and other options.
 
-    // Video - TODO: Apply without a restart.
+    // Video
     Ogre::Root* ogreRoot = Ogre::Root::getSingletonPtr();
     Ogre::RenderSystem* renderer = ogreRoot->getRenderSystem();
 
@@ -170,6 +172,21 @@ bool SettingsWindow::applySettings(const CEGUI::EventArgs&)
     renderer->setConfigOption("Full Screen", (fsCheckBox->isSelected() ? "Yes" : "No"));
 
     ogreRoot->saveConfig();
+
+    // Apply config
+    Ogre::RenderWindow* win = ogreRoot->getAutoCreatedWindow();
+    std::vector<std::string> resVtr = Helper::split(resCb->getSelectedItem()->getText().c_str(), 'x');
+    if (resVtr.size() == 2)
+    {
+        uint32_t width = static_cast<uint32_t>(Helper::toInt(resVtr[0]));
+        uint32_t height = static_cast<uint32_t>(Helper::toInt(resVtr[1]));
+        win->setFullscreen(fsCheckBox->isSelected(), width, height);
+
+        // In windowed mode, the window needs resizing through other means
+        // NOTE: Doesn't work when the window is maximized on certain Composers.
+        if (!fsCheckBox->isSelected())
+            win->resize(width, height);
+    }
 
     // Audio - TODO: Save in config and reload at start.
     CEGUI::Slider* volumeSlider = static_cast<CEGUI::Slider*>(

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -127,6 +127,29 @@ void SettingsWindow::initConfig()
         }
     }
 
+    // Available renderers
+    const Ogre::RenderSystemList& rdrList = ogreRoot->getAvailableRenderers();
+    Ogre::RenderSystem* renderSystem = ogreRoot->getRenderSystem();
+
+    CEGUI::Combobox* rdrCb = static_cast<CEGUI::Combobox*>(
+            mRootWindow->getChild("SettingsWindow/MainTabControl/Video/RendererCombobox"));
+    rdrCb->setReadOnly(true);
+    rdrCb->setSortingEnabled(true);
+    uint32_t i = 0;
+    for (Ogre::RenderSystem* rdr : rdrList)
+    {
+        CEGUI::ListboxTextItem* item = new CEGUI::ListboxTextItem(rdr->getName(), i);
+        item->setSelectionBrushImage(selImg);
+        rdrCb->addItem(item);
+
+        if (rdr == renderSystem)
+        {
+            rdrCb->setItemSelectState(item, true);
+            rdrCb->setText(item->getText());
+        }
+        ++i;
+    }
+
     // Fullscreen
     it = options.find("Full Screen");
     if (it != options.end())
@@ -135,6 +158,16 @@ void SettingsWindow::initConfig()
         CEGUI::ToggleButton* fsCheckBox = static_cast<CEGUI::ToggleButton*>(
             mRootWindow->getChild("SettingsWindow/MainTabControl/Video/FullscreenCheckbox"));
         fsCheckBox->setSelected((fullscreen.currentValue == "Yes"));
+    }
+
+    // VSync
+    it = options.find("VSync");
+    if (it != options.end())
+    {
+        const Ogre::ConfigOption& vsync = it->second;
+        CEGUI::ToggleButton* vsCheckBox = static_cast<CEGUI::ToggleButton*>(
+            mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VSyncCheckbox"));
+        vsCheckBox->setSelected((vsync.currentValue == "Yes"));
     }
 
     // The current volume level
@@ -167,9 +200,18 @@ bool SettingsWindow::applySettings(const CEGUI::EventArgs&)
             mRootWindow->getChild("SettingsWindow/MainTabControl/Video/ResolutionCombobox"));
     renderer->setConfigOption("Video Mode", resCb->getSelectedItem()->getText().c_str());
 
+    // Needs to handled through custom config
+    /*CEGUI::Combobox* rdrCb = static_cast<CEGUI::Combobox*>(
+            mRootWindow->getChild("SettingsWindow/MainTabControl/Video/RendererCombobox"));*/
+    //renderer->setConfigOption("Render System", rdrCb->getSelectedItem()->getText().c_str());
+
     CEGUI::ToggleButton* fsCheckBox = static_cast<CEGUI::ToggleButton*>(
         mRootWindow->getChild("SettingsWindow/MainTabControl/Video/FullscreenCheckbox"));
     renderer->setConfigOption("Full Screen", (fsCheckBox->isSelected() ? "Yes" : "No"));
+
+    CEGUI::ToggleButton* vsCheckBox = static_cast<CEGUI::ToggleButton*>(
+        mRootWindow->getChild("SettingsWindow/MainTabControl/Video/VSyncCheckbox"));
+    renderer->setConfigOption("VSync", (vsCheckBox->isSelected() ? "Yes" : "No"));
 
     ogreRoot->saveConfig();
 

--- a/source/modes/SettingsWindow.h
+++ b/source/modes/SettingsWindow.h
@@ -1,0 +1,73 @@
+/*!
+ *  Copyright (C) 2011-2015  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SETTINGSWINDOW_H
+#define SETTINGSWINDOW_H
+
+#include <CEGUI/Event.h>
+#include <CEGUI/Window.h>
+
+#include <vector>
+
+//! \brief This class is creating a setting window gui child to the current gui context
+//! and populates its widgets with the current game, video, audio values.
+//! It also permits to change them.
+class SettingsWindow
+{
+public:
+    //! \brief Settings window constructor
+    //! \param rootWindow The main CEGUI window used as background to the current mode.
+    //! Used to load and later show the settings window.
+    SettingsWindow(CEGUI::Window* rootWindow);
+
+    ~SettingsWindow();
+
+    void show()
+    {
+        if (mSettingsWindow)
+            mSettingsWindow->show();
+    }
+
+    void hide()
+    {
+        if (mSettingsWindow)
+            mSettingsWindow->hide();
+    }
+
+protected:
+
+    //! \brief Adds an event binding to be cleared on exiting the mode.
+    inline void addEventConnection(CEGUI::Event::Connection conn)
+    {
+        mEventConnections.emplace_back(conn);
+    }
+
+private:
+    //! \brief Vector of cegui event bindings to be cleared on exiting the mode
+    std::vector<CEGUI::Event::Connection> mEventConnections;
+
+    //! \brief The Settings window.
+    CEGUI::Window* mSettingsWindow;
+
+    //! \brief The root window.
+    CEGUI::Window* mRootWindow;
+
+    //! \brief Hides the settings window.
+    bool hideSettingsWindow(const CEGUI::EventArgs& = {});
+};
+
+#endif // SETTINGSWINDOW_H

--- a/source/modes/SettingsWindow.h
+++ b/source/modes/SettingsWindow.h
@@ -48,7 +48,10 @@ public:
             mSettingsWindow->hide();
     }
 
-protected:
+private:
+
+    //! \brief Set the different widget values according to current config.
+    void initWidgetConfig();
 
     //! \brief Adds an event binding to be cleared on exiting the mode.
     inline void addEventConnection(CEGUI::Event::Connection conn)
@@ -56,7 +59,6 @@ protected:
         mEventConnections.emplace_back(conn);
     }
 
-private:
     //! \brief Vector of cegui event bindings to be cleared on exiting the mode
     std::vector<CEGUI::Event::Connection> mEventConnections;
 

--- a/source/modes/SettingsWindow.h
+++ b/source/modes/SettingsWindow.h
@@ -68,8 +68,9 @@ private:
     //! \brief The root window.
     CEGUI::Window* mRootWindow;
 
-    //! \brief Hides the settings window.
-    bool hideSettingsWindow(const CEGUI::EventArgs& = {});
+    //! \brief Cancel/Apply settings.
+    bool cancelSettings(const CEGUI::EventArgs&);
+    bool applySettings(const CEGUI::EventArgs&);
 };
 
 #endif // SETTINGSWINDOW_H

--- a/source/modes/SettingsWindow.h
+++ b/source/modes/SettingsWindow.h
@@ -48,10 +48,19 @@ public:
             mSettingsWindow->hide();
     }
 
+    bool isVisible() const
+    {
+        if (mSettingsWindow)
+            return mSettingsWindow->isVisible();
+        return false;
+    }
+
+    bool cancelSettings(const CEGUI::EventArgs& e = {});
+
 private:
 
     //! \brief Set the different widget values according to current config.
-    void initWidgetConfig();
+    void initConfig();
 
     //! \brief Adds an event binding to be cleared on exiting the mode.
     inline void addEventConnection(CEGUI::Event::Connection conn)
@@ -68,8 +77,6 @@ private:
     //! \brief The root window.
     CEGUI::Window* mRootWindow;
 
-    //! \brief Cancel/Apply settings.
-    bool cancelSettings(const CEGUI::EventArgs&);
     bool applySettings(const CEGUI::EventArgs&);
 };
 


### PR DESCRIPTION
- Created the SettingsWindow class that will take of creating/deleting the corresponding widget in any mother modes.
- Made it so the settings window is somewhat functional by loading/storing Ogre config.
- Removed the Ogre config window at startup and made OD capable to auto-create a viable config from scratch if necessary.

This PR is made to reach a first good step in implementing this feature and deal with a few questions at the same time.

What's left IMHO, is to move the default config making and the different stored values in the config manager and synd the config manager with Ogre.
Also, video settings changes should be applied wihout the need to restart the app.
WDYT?

I you agree, I'll work on that for the next PR.
