### PR TITLE
Implemented listeners on GameEntity

### DIFF
--- a/source/entities/Creature.h
+++ b/source/entities/Creature.h
@@ -32,6 +32,7 @@
 #include <deque>
 
 class Creature;
+class CreatureActionWrapper;
 class CreatureEffect;
 class CreatureDefinition;
 class CreatureOverlayStatus;
@@ -595,7 +596,7 @@ private:
     //! it is possible. To avoid testing several times the same action, we check in mActionTry if the action as already been
     //! tried. If yes and forcePush is false, the action won't be pushed and pushAction will return false. If the action has
     //! not been tested or if forcePush is true, the action will be pushed and pushAction will return true
-    bool pushAction(CreatureAction action, bool popCurrentIfPush, bool forcePush);
+    bool pushAction(CreatureActionType actionType, bool popCurrentIfPush, bool forcePush, GameEntity* attackedEntity = nullptr, Tile* tile = nullptr);
     void popAction();
 
     //! \brief Picks a destination far away in the visible tiles and goes there
@@ -624,84 +625,84 @@ private:
     //! \brief A sub-function called by doTurn()
     //! This functions will handle the creature idle action logic.
     //! \return true when another action should handled after that one.
-    bool handleIdleAction(const CreatureAction& actionItem);
+    bool handleIdleAction(const CreatureActionWrapper& actionItem);
 
     //! \brief A sub-function called by doTurn()
     //! This functions will handle the creature walking action logic.
     //! \return true when another action should handled after that one.
-    bool handleWalkToTileAction(const CreatureAction& actionItem);
+    bool handleWalkToTileAction(const CreatureActionWrapper& actionItem);
 
     //! \brief A sub-function called by doTurn()
     //! This functions will handle the creature claim tile action logic.
     //! \return true when another action should handled after that one.
-    bool handleClaimTileAction(const CreatureAction& actionItem);
+    bool handleClaimTileAction(const CreatureActionWrapper& actionItem);
 
     //! \brief A sub-function called by doTurn()
     //! This functions will handle the creature claim wall tile action logic.
     //! \return true when another action should handled after that one.
-    bool handleClaimWallTileAction(const CreatureAction& actionItem);
+    bool handleClaimWallTileAction(const CreatureActionWrapper& actionItem);
 
     //! \brief A sub-function called by doTurn()
     //! This functions will handle the creature dig tile action logic.
     //! \return true when another action should handled after that one.
-    bool handleDigTileAction(const CreatureAction& actionItem);
+    bool handleDigTileAction(const CreatureActionWrapper& actionItem);
 
     //! \brief A sub-function called by doTurn()
     //! This functions will handle the creature finding home action logic.
     //! \return true when another action should handled after that one.
-    bool handleFindHomeAction(const CreatureAction& actionItem);
+    bool handleFindHomeAction(const CreatureActionWrapper& actionItem);
 
     //! \brief A sub-function called by doTurn()
     //! This functions will handle the creature job action logic.
     //! \return true when another action should handled after that one.
-    bool handleJobAction(const CreatureAction& actionItem);
+    bool handleJobAction(const CreatureActionWrapper& actionItem);
 
     //! \brief A sub-function called by doTurn()
     //! This functions will handle the creature eating action logic.
     //! \return true when another action should handled after that one.
-    bool handleEatingAction(const CreatureAction& actionItem);
+    bool handleEatingAction(const CreatureActionWrapper& actionItem);
 
     //! \brief A sub-function called by doTurn()
     //! This functions will handle the creature attack action logic.
     //! \return true when another action should handled after that one.
-    bool handleAttackAction(const CreatureAction& actionItem);
+    bool handleAttackAction(const CreatureActionWrapper& actionItem);
 
     //! \brief A sub-function called by doTurn()
     //! This functions will handle the creature fighting action logic.
     //! \return true when another action should handled after that one.
-    bool handleFightAction(const CreatureAction& actionItem);
+    bool handleFightAction(const CreatureActionWrapper& actionItem);
 
     //! \brief A sub-function called by doTurn()
     //! This functions will handle the creature sleeping action logic.
     //! \return true when another action should handled after that one.
-    bool handleSleepAction(const CreatureAction& actionItem);
+    bool handleSleepAction(const CreatureActionWrapper& actionItem);
 
     //! \brief A sub-function called by doTurn()
     //! This functions will handle the creature fleeing action logic.
     //! \return true when another action should handled after that one.
-    bool handleFleeAction(const CreatureAction& actionItem);
+    bool handleFleeAction(const CreatureActionWrapper& actionItem);
 
     //! \brief A sub-function called by doTurn()
     //! This functions will handle the creature action logic about finding a carryable entity.
     //! And trying to carry it to a suitable building
     //! \return true when another action should handled after that one.
-    bool handleCarryableEntities(const CreatureAction& actionItem);
+    bool handleCarryableEntities(const CreatureActionWrapper& actionItem);
 
     //! \brief A sub-function called by doTurn()
     //! This functions will handle the creature action logic about getting the creature fee.
     //! \return true when another action should handled after that one.
-    bool handleGetFee(const CreatureAction& actionItem);
+    bool handleGetFee(const CreatureActionWrapper& actionItem);
 
     //! \brief A sub-function called by doTurn()
     //! This functions will handle the creature action logic about trying to leave the dungeon.
     //! \return true when another action should handled after that one.
-    bool handleLeaveDungeon(const CreatureAction& actionItem);
+    bool handleLeaveDungeon(const CreatureActionWrapper& actionItem);
 
     //! \brief A sub-function called by doTurn()
     //! This functions will handle the creature fighting action logic when
     //! fighting an allied natural enemy (when in bad mood)
     //! \return true when another action should handled after that one.
-    bool handleFightAlliedNaturalEnemyAction(const CreatureAction& actionItem);
+    bool handleFightAlliedNaturalEnemyAction(const CreatureActionWrapper& actionItem);
 
     //! \brief Restores the creature's stats according to its current level
     void buildStats();

--- a/source/entities/CreatureAction.h
+++ b/source/entities/CreatureAction.h
@@ -50,10 +50,11 @@ enum class CreatureActionType
 };
 
 //! \brief A data structure to be used in the creature AI calculations.
-class CreatureAction
+class CreatureAction : public GameEntityListener
 {
 public:
-    CreatureAction(const CreatureActionType actionType, GameEntityType entityType = GameEntityType::unknown, const std::string& entityName = "", Tile* tile = nullptr);
+    CreatureAction(Creature* creature, const CreatureActionType actionType, GameEntity* attackedEntity, Tile* tile);
+    virtual ~CreatureAction();
 
     inline const CreatureActionType getType() const
     { return mActionType; }
@@ -70,27 +71,28 @@ public:
     inline int32_t getNbTurnsActive() const
     { return mNbTurnsActive; }
 
+    inline GameEntity* getAttackedEntity() const
+    { return mAttackedEntity; }
+
     inline void clearNbTurnsActive()
     { mNbTurnsActive = 0; }
-
-    inline const std::string& getEntityName() const
-    { return mEntityName; }
-
-    inline GameEntityType getEntityType() const
-    { return mEntityType; }
 
     inline Tile* getTile() const
     { return mTile; }
 
     std::string toString() const;
 
+    std::string getListenerName() const override;
+    bool notifyDead(GameEntity* entity) override;
+    bool notifyRemovedFromGameMap(GameEntity* entity) override;
+    bool notifyPickedUp(GameEntity* entity) override;
+    bool notifyDropped(GameEntity* entity) override;
+
 private:
+    CreatureAction(const CreatureAction&) = delete;
+    Creature* mCreature;
     CreatureActionType mActionType;
-    //! We save the creature name, not the pointer because in creature action, most of the time, we want to keep a reference
-    //! for some time (for example when walking towards an enemy to attack). But the creature might be dead when we reach it.
-    //! The rule of thumb would be to not keep a creature pointer here
-    GameEntityType mEntityType;
-    std::string mEntityName;
+    GameEntity* mAttackedEntity;
     Tile* mTile;
     //! Number of turns the action is in the creature pending actions
     int32_t mNbTurns;

--- a/source/entities/EntityBase.h
+++ b/source/entities/EntityBase.h
@@ -25,6 +25,7 @@
 #include <string>
 
 class Seat;
+class Tile;
 namespace Ogre
 {
     class SceneNode;
@@ -121,6 +122,12 @@ public:
     { return false; }
     virtual void pickup()
     {}
+
+    virtual bool tryDrop(Seat* seat, Tile* tile)
+    { return false; }
+    virtual void drop(const Ogre::Vector3& v)
+    {}
+
 protected:
     //! \brief Function that implements the mesh creation
     virtual void createMeshLocal() {};

--- a/source/entities/MapLight.cpp
+++ b/source/entities/MapLight.cpp
@@ -85,6 +85,7 @@ void MapLight::addToGameMap()
 
 void MapLight::removeFromGameMap()
 {
+    fireEntityRemoveFromGameMap();
     removeEntityFromPositionTile();
     getGameMap()->removeMapLight(this);
     getGameMap()->removeAnimatedObject(this);

--- a/source/entities/RenderedMovableEntity.cpp
+++ b/source/entities/RenderedMovableEntity.cpp
@@ -109,6 +109,7 @@ void RenderedMovableEntity::addToGameMap()
 
 void RenderedMovableEntity::removeFromGameMap()
 {
+    fireEntityRemoveFromGameMap();
     removeEntityFromPositionTile();
     getGameMap()->removeRenderedMovableEntity(this);
     getGameMap()->removeAnimatedObject(this);

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -635,10 +635,8 @@ Creature* GameMap::getWorkerToPickupBySeat(Seat* seat)
         bool isClaiming = false;
         bool isDigging = false;
 
-        const std::deque<CreatureAction>& actions = creature->getActionQueue();
-        for(std::deque<CreatureAction>::const_iterator itAction = actions.begin(); itAction != actions.end(); ++itAction)
+        for(const CreatureAction& action : creature->getActionQueue())
         {
-            const CreatureAction& action = *itAction;
             switch(action.getType())
             {
                 case CreatureActionType::fight:
@@ -754,10 +752,8 @@ Creature* GameMap::getFighterToPickupBySeat(Seat* seat)
         bool isFleeing = false;
         bool isBusy = false;
 
-        const std::deque<CreatureAction>& actions = creature->getActionQueue();
-        for(std::deque<CreatureAction>::const_iterator itAction = actions.begin(); itAction != actions.end(); ++itAction)
+        for(const CreatureAction& action : creature->getActionQueue())
         {
-            const CreatureAction& action = *itAction;
             switch(action.getType())
             {
                 case CreatureActionType::flee:
@@ -2691,20 +2687,6 @@ GameEntity* GameMap::getEntityFromTypeAndName(GameEntityType entityType,
 
     return nullptr;
 }
-
-EntityBase* GameMap::getBaseEntityFromTypeAndName(GameEntityType entityType, const string& entityName)
-{
-    if(entityType == GameEntityType::tile)
-    {
-        int x, y;
-        if(!Tile::checkTileName(entityName, x, y))
-            return nullptr;
-
-        return getTile(x, y);
-    }
-    return getEntityFromTypeAndName(entityType, entityName);
-}
-
 
 void GameMap::logFloodFileTiles()
 {

--- a/source/gamemap/GameMap.h
+++ b/source/gamemap/GameMap.h
@@ -482,8 +482,6 @@ public:
     void clearRenderedMovableEntities();
     GameEntity* getEntityFromTypeAndName(GameEntityType entityType,
         const std::string& entityName);
-    EntityBase* getBaseEntityFromTypeAndName(GameEntityType entityType,
-                                             const std::string& entityName);
 
     //! brief Functions to add/remove/get Spells
     inline const std::vector<Spell*>& getSpells() const

--- a/source/rooms/Room.cpp
+++ b/source/rooms/Room.cpp
@@ -62,6 +62,7 @@ void Room::addToGameMap()
 
 void Room::removeFromGameMap()
 {
+    fireEntityRemoveFromGameMap();
     getGameMap()->removeRoom(this);
     setIsOnMap(false);
     for(Seat* seat : getGameMap()->getSeats())

--- a/source/spells/Spell.cpp
+++ b/source/spells/Spell.cpp
@@ -71,6 +71,7 @@ void Spell::addToGameMap()
 
 void Spell::removeFromGameMap()
 {
+    fireEntityRemoveFromGameMap();
     removeEntityFromPositionTile();
     getGameMap()->removeSpell(this);
     getGameMap()->removeAnimatedObject(this);

--- a/source/traps/Trap.cpp
+++ b/source/traps/Trap.cpp
@@ -85,6 +85,7 @@ void Trap::addToGameMap()
 
 void Trap::removeFromGameMap()
 {
+    fireEntityRemoveFromGameMap();
     setIsOnMap(false);
     getGameMap()->removeTrap(this);
     for(Seat* seat : getGameMap()->getSeats())


### PR DESCRIPTION
That allows to listen to what happens to an entity and be notified when something happens. It can, for example, be used on missiles to notify the sender that the missile hit (for counting killed enemies for example).
