### PR TITLE
Moved to full custom settings support.

### DIFF
--- a/gui/WindowSettings.layout
+++ b/gui/WindowSettings.layout
@@ -2,7 +2,7 @@
 
 <GUILayout version="4" >
     <Window type="OD/FrameWindow" name="SettingsWindow" >
-        <Property name="Area" value="{{0,205},{0,128},{0,669},{0,481}}" />
+        <Property name="Area" value="{{0,205},{0,128},{0,669},{0,600}}" />
         <Property name="Text" value="Settings" />
         <Property name="SizingEnabled" value="False" />
         <Property name="AlwaysOnTop" value="True" />
@@ -75,6 +75,8 @@
                     <Property name="Text" value="" />
                     <Property name="VerticalSlider" value="False" />
                     <Property name="AutoRenderingSurface" value="True" />
+                    <Property name="MaximumValue" value="100" />
+                    <Property name="ClickStepSize" value="5" />
                 </Window>
             </Window>
         </Window>

--- a/gui/WindowSettings.layout
+++ b/gui/WindowSettings.layout
@@ -79,6 +79,24 @@
                     <Property name="ClickStepSize" value="5" />
                 </Window>
             </Window>
+            <Window type="DefaultWindow" name="Game" >
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
+                <Property name="Text" value="Game" />
+                <Property name="MaxSize" value="{{1,0},{1,0}}" />
+                <Property name="Visible" value="False" />
+                <Property name="RiseOnClickEnabled" value="False" />
+                <Window type="OD/StaticText" name="NicknameText" >
+                    <Property name="Area" value="{{0,32},{0,40},{0,150},{0,60}}" />
+                    <Property name="MaxSize" value="{{1,0},{1,0}}" />
+                    <Property name="Text" value="Nickname:" />
+                    <Property name="BackgroundEnabled" value="False" />
+                    <Property name="FrameEnabled" value="False" />
+                </Window>
+                <Window type="OD/Editbox" name="NicknameEdit" >
+                    <Property name="Area" value="{{0,160},{0,40},{0,320},{0,60}}" />
+                    <Property name="Text" value="" />
+                </Window>
+            </Window>
         </Window>
     </Window>
 </GUILayout>

--- a/source/ODApplication.cpp
+++ b/source/ODApplication.cpp
@@ -100,15 +100,14 @@ void ODApplication::startClient()
     Random::initialize();
     //NOTE: The order of initialisation of the different "manager" classes is important,
     //as many of them depend on each other.
-    OD_LOG_INF("Creating OGRE::Root instance; Plugins path: " + resMgr.getPluginsPath()
-        + "; config file: " + resMgr.getOgreCfgFile());
+    OD_LOG_INF("Creating OGRE::Root instance; Plugins path: " + resMgr.getPluginsPath());
 
-    Ogre::Root ogreRoot(resMgr.getPluginsPath(),
-                        resMgr.getOgreCfgFile());
+    // N.B: We don't use any ogre.cfg file, hence setting the file path value to "".
+    Ogre::Root ogreRoot(resMgr.getPluginsPath(), "");
 
     ConfigManager configManager(resMgr.getConfigPath(), resMgr.getUserCfgFile());
 
-    if (!loadOgreConfig(ogreRoot))
+    if (!configManager.initVideoConfig(ogreRoot))
         return;
 
     // Needed for the TextRenderer and the Render Manager
@@ -170,41 +169,6 @@ void ODApplication::startClient()
     ogreRoot.removeFrameListener(&frameListener);
     Ogre::RTShader::ShaderGenerator::destroy();
     ogreRoot.destroyRenderTarget(renderWindow);
-}
-
-bool ODApplication::loadOgreConfig(Ogre::Root& ogreRoot)
-{
-    if (ogreRoot.restoreConfig())
-        return true;
-
-    Ogre::RenderSystem* renderSystem = ogreRoot.getRenderSystemByName("OpenGL Rendering Subsystem");
-    if (renderSystem == nullptr)
-    {
-        const Ogre::RenderSystemList& renderers = ogreRoot.getAvailableRenderers();
-        if(renderers.empty())
-        {
-            OD_LOG_ERR("No valid renderer found. Exitting...");
-            return false;
-        }
-        renderSystem = *renderers.begin();
-        OD_LOG_INF("No OpenGL renderer found. Using the first available: " + renderSystem->getName());
-    }
-
-    ogreRoot.setRenderSystem(renderSystem);
-
-    // Manually set some configuration options
-    // By default, using low hardware config values.
-    renderSystem->setConfigOption("Video Mode", "800 x 600");
-    renderSystem->setConfigOption("Full Screen", "No");
-    renderSystem->setConfigOption("Display Frequency", "60 Hz");
-    renderSystem->setConfigOption("FSAA", "0");
-    renderSystem->setConfigOption("VSync", "No");
-    renderSystem->setConfigOption("RTT Preferred Mode", "FBO");
-    renderSystem->setConfigOption("Fixed Pipeline Enabled", "Yes");
-    renderSystem->setConfigOption("sRGB Gamma Conversion", "No");
-
-    ogreRoot.saveConfig();
-    return true;
 }
 
 //TODO: find some better places for some of these

--- a/source/ODApplication.h
+++ b/source/ODApplication.h
@@ -64,10 +64,6 @@ private:
     void startClient();
     //! \brief Server mode. Creates only the needed to launch a level. Note that this is to be used without gui
     void startServer();
-
-    //! \brief Loads the ogre startup configuration, or create a default one if it isn't found or unrestorable.
-    //! \return Whether initialization succeeded.
-    bool loadOgreConfig(Ogre::Root& ogreRoot);
 };
 
 #endif // ODAPPLICATION_H

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -64,7 +64,7 @@
 #include <sstream>
 #include <string>
 
-const std::string DEFAULT_NICK = "Player";
+const std::string DEFAULT_NICK = "You";
 
 using namespace std;
 

--- a/source/modes/MenuModeConfigureSeats.cpp
+++ b/source/modes/MenuModeConfigureSeats.cpp
@@ -134,7 +134,7 @@ void MenuModeConfigureSeats::activate()
         textSeatId->setArea(CEGUI::UDim(0,20), CEGUI::UDim(0,65 + offset), CEGUI::UDim(0.3,0), CEGUI::UDim(0,30));
         textSeatId->setText("[colour='" + Helper::getCEGUIColorFromOgreColourValue(seatColor) + "']Seat "  + Helper::toString(seat->getId()));
         textSeatId->setProperty("FrameEnabled", "False");
-        textSeatId->setProperty("BackgroundEnabled", "False");;
+        textSeatId->setProperty("BackgroundEnabled", "False");
 
         name = COMBOBOX_PLAYER_FACTION_PREFIX + Helper::toString(seat->getId());
         combo = static_cast<CEGUI::Combobox*>(winMgr.createWindow("OD/Combobox", name));

--- a/source/modes/MenuModeConfigureSeats.cpp
+++ b/source/modes/MenuModeConfigureSeats.cpp
@@ -257,7 +257,7 @@ void MenuModeConfigureSeats::activate()
     tmpWin = getModeManager().getGui().getGuiSheet(Gui::guiSheet::configureSeats)->getChild("ListPlayers/LaunchGameButton");
     tmpWin->setEnabled(enabled);
 
-    // We notify the server we are ready to recceive players and configure them
+    // We notify the server we are ready to receive players and configure them
     ODClient::getSingleton().queueClientNotification(ClientNotificationType::readyForSeatConfiguration);
 }
 

--- a/source/modes/MenuModeMultiplayerClient.cpp
+++ b/source/modes/MenuModeMultiplayerClient.cpp
@@ -62,7 +62,8 @@ MenuModeMultiplayerClient::MenuModeMultiplayerClient(ModeManager *modeManager):
 void MenuModeMultiplayerClient::activate()
 {
     // Loads the corresponding Gui sheet.
-    getModeManager().getGui().loadGuiSheet(Gui::guiSheet::multiplayerClientMenu);
+    Gui& gui = getModeManager().getGui();
+    gui.loadGuiSheet(Gui::guiSheet::multiplayerClientMenu);
 
     giveFocus();
 
@@ -74,17 +75,21 @@ void MenuModeMultiplayerClient::activate()
     gameMap->clearAll();
     gameMap->setGamePaused(true);
 
-    CEGUI::Window* mainWin = getModeManager().getGui().getGuiSheet(Gui::guiSheet::multiplayerClientMenu);
+    CEGUI::Window* mainWin = gui.getGuiSheet(Gui::guiSheet::multiplayerClientMenu);
     mainWin->getChild(Gui::MPM_TEXT_LOADING)->setText("");
+
+    CEGUI::Editbox* editNick = static_cast<CEGUI::Editbox*>(mainWin->getChild(Gui::MPM_EDIT_NICK));
+    ConfigManager& config = ConfigManager::getSingleton();
+    editNick->setText(reinterpret_cast<const CEGUI::utf8*>(config.getGameValue(Config::NICKNAME).c_str()));
 }
 
 bool MenuModeMultiplayerClient::clientButtonPressed(const CEGUI::EventArgs&)
 {
-    CEGUI::Editbox* editIp = static_cast<CEGUI::Editbox*>(
-                                 getModeManager().getGui().getGuiSheet(Gui::multiplayerClientMenu)->getChild(Gui::MPM_EDIT_IP));
+    CEGUI::Window* mainWin = getModeManager().getGui().getGuiSheet(Gui::guiSheet::multiplayerClientMenu);
+    CEGUI::Editbox* editIp = static_cast<CEGUI::Editbox*>(mainWin->getChild(Gui::MPM_EDIT_IP));
     const std::string ip = editIp->getText().c_str();
 
-    CEGUI::Window* infoText = getModeManager().getGui().getGuiSheet(Gui::multiplayerClientMenu)->getChild(Gui::MPM_TEXT_LOADING);
+    CEGUI::Window* infoText = mainWin->getChild(Gui::MPM_TEXT_LOADING);
 
     if (ip.empty())
     {
@@ -92,8 +97,7 @@ bool MenuModeMultiplayerClient::clientButtonPressed(const CEGUI::EventArgs&)
         return true;
     }
 
-    CEGUI::Editbox* editNick = static_cast<CEGUI::Editbox*>(
-                                   getModeManager().getGui().getGuiSheet(Gui::multiplayerClientMenu)->getChild(Gui::MPM_EDIT_NICK));
+    CEGUI::Editbox* editNick = static_cast<CEGUI::Editbox*>(mainWin->getChild(Gui::MPM_EDIT_NICK));
     std::string nick = editNick->getText().c_str();
     CEGUI::String nickCeguiStr = reinterpret_cast<const CEGUI::utf8*>(nick.c_str());
     if (nickCeguiStr.empty())

--- a/source/modes/MenuModeSkirmish.cpp
+++ b/source/modes/MenuModeSkirmish.cpp
@@ -113,6 +113,11 @@ void MenuModeSkirmish::activate()
                                        getGuiSheet(Gui::skirmishMenu)->getChild(Gui::SKM_LIST_LEVEL_TYPES));
     levelTypeCb->setItemSelectState(static_cast<size_t>(0), true);
     updateFilesList();
+
+    // Set the player name if valid. (Will use the defaut one if not.)
+    std::string nickname = ConfigManager::getSingleton().getGameValue(Config::NICKNAME);
+    if (!nickname.empty())
+        ODFrameListener::getSingleton().getClientGameMap()->setLocalPlayerNick(nickname);
 }
 
 bool MenuModeSkirmish::updateFilesList(const CEGUI::EventArgs&)
@@ -176,20 +181,16 @@ bool MenuModeSkirmish::updateFilesList(const CEGUI::EventArgs&)
 
 bool MenuModeSkirmish::launchSelectedButtonPressed(const CEGUI::EventArgs&)
 {
-    CEGUI::Window* tmpWin = getModeManager().getGui().getGuiSheet(Gui::skirmishMenu)->getChild(Gui::SKM_LIST_LEVELS);
-    CEGUI::Listbox* levelSelectList = static_cast<CEGUI::Listbox*>(tmpWin);
+    CEGUI::Window* mainWin = getModeManager().getGui().getGuiSheet(Gui::skirmishMenu);
+    CEGUI::Listbox* levelSelectList = static_cast<CEGUI::Listbox*>(mainWin->getChild(Gui::SKM_LIST_LEVELS));
 
     if(levelSelectList->getSelectedCount() == 0)
     {
-        tmpWin = getModeManager().getGui().getGuiSheet(Gui::skirmishMenu)->getChild(Gui::SKM_TEXT_LOADING);
-        tmpWin->setText("Please select a level first.");
-        tmpWin->show();
+        mainWin->getChild(Gui::SKM_TEXT_LOADING)->setText("Please select a level first.");
         return true;
     }
 
-    tmpWin = getModeManager().getGui().getGuiSheet(Gui::skirmishMenu)->getChild(Gui::SKM_TEXT_LOADING);
-    tmpWin->setText("Loading...");
-    tmpWin->show();
+    mainWin->getChild(Gui::SKM_TEXT_LOADING)->setText("Loading...");
 
     CEGUI::ListboxItem* selItem = levelSelectList->getFirstSelectedItem();
     int id = selItem->getID();
@@ -199,18 +200,14 @@ bool MenuModeSkirmish::launchSelectedButtonPressed(const CEGUI::EventArgs&)
     if(!ODServer::getSingleton().startServer(level, ServerMode::ModeGameSinglePlayer))
     {
         OD_LOG_ERR("Could not start server for single player game !!!");
-        tmpWin = getModeManager().getGui().getGuiSheet(Gui::skirmishMenu)->getChild(Gui::SKM_TEXT_LOADING);
-        tmpWin->setText("ERROR: Could not start server for single player game !!!");
-        tmpWin->show();
+        mainWin->getChild(Gui::SKM_TEXT_LOADING)->setText("ERROR: Could not start server for single player game !!!");
         return true;
     }
 
     if(!ODClient::getSingleton().connect("localhost", ConfigManager::getSingleton().getNetworkPort()))
     {
         OD_LOG_ERR("Could not connect to server for single player game !!!");
-        tmpWin = getModeManager().getGui().getGuiSheet(Gui::skirmishMenu)->getChild(Gui::SKM_TEXT_LOADING);
-        tmpWin->setText("Error: Couldn't connect to local server!");
-        tmpWin->show();
+        mainWin->getChild(Gui::SKM_TEXT_LOADING)->setText("Error: Couldn't connect to local server!");
         return true;
     }
     return true;
@@ -219,10 +216,10 @@ bool MenuModeSkirmish::launchSelectedButtonPressed(const CEGUI::EventArgs&)
 bool MenuModeSkirmish::updateDescription(const CEGUI::EventArgs&)
 {
     // Get the level corresponding id
-    CEGUI::Window* tmpWin = getModeManager().getGui().getGuiSheet(Gui::skirmishMenu)->getChild(Gui::SKM_LIST_LEVELS);
-    CEGUI::Listbox* levelSelectList = static_cast<CEGUI::Listbox*>(tmpWin);
+    CEGUI::Window* mainWin = getModeManager().getGui().getGuiSheet(Gui::skirmishMenu);
+    CEGUI::Listbox* levelSelectList = static_cast<CEGUI::Listbox*>(mainWin->getChild(Gui::SKM_LIST_LEVELS));
 
-    CEGUI::Window* descTxt = getModeManager().getGui().getGuiSheet(Gui::skirmishMenu)->getChild("LevelWindowFrame/MapDescriptionText");
+    CEGUI::Window* descTxt = mainWin->getChild("LevelWindowFrame/MapDescriptionText");
 
     if(levelSelectList->getSelectedCount() == 0)
     {

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -239,9 +239,12 @@ void SettingsWindow::initConfig()
     }
 
     //! First of all, clear up the previously created windows.
-    for (CEGUI::Window* win : mCustomVideoWidgets)
+    for (CEGUI::Window* win : mCustomVideoComboBoxes)
         mSettingsWindow->destroyChild(win);
-    mCustomVideoWidgets.clear();
+    mCustomVideoComboBoxes.clear();
+    for (CEGUI::Window* win : mCustomVideoTexts)
+        mSettingsWindow->destroyChild(win);
+    mCustomVideoTexts.clear();
 
     // Find every other config options and add them to the config
     CEGUI::Window* videoTab = mSettingsWindow->getChild("MainTabControl/Video");
@@ -272,8 +275,8 @@ void SettingsWindow::initConfig()
         videoCb->setSortingEnabled(true);
 
         // Register the widgets for potential later deletion.
-        mCustomVideoWidgets.push_back(videoCbText);
-        mCustomVideoWidgets.push_back(videoCb);
+        mCustomVideoTexts.push_back(videoCbText);
+        mCustomVideoComboBoxes.push_back(videoCb);
 
         // Fill the combobox with possible values.
         uint32_t cbIndex = 0;
@@ -358,8 +361,15 @@ void SettingsWindow::saveConfig()
     renderer->setConfigOption(VSYNC, (vsCheckBox->isSelected() ? "Yes" : "No"));
     config.setVideoValue(VSYNC, fsCheckBox->isSelected() ? "Yes" : "No");
 
-    ogreRoot->saveConfig();
-    // TODO: Only save and handle custom config. Drop ogre config if possible.
+    // Save renderer dependent settings and apply them.
+    for (CEGUI::Window* combo : mCustomVideoComboBoxes)
+    {
+        std::string optionName = combo->getName().c_str();
+        std::string optionValue = combo->getText().c_str();
+        renderer->setConfigOption(optionName, optionValue);
+        config.setVideoValue(optionName, optionValue);
+    }
+
     config.saveUserConfig();
 
     // Apply config

--- a/source/modes/SettingsWindow.h
+++ b/source/modes/SettingsWindow.h
@@ -63,6 +63,9 @@ private:
     //! \brief The root window.
     CEGUI::Window* mRootWindow;
 
+    //! \brief The temporary video comboboxes created depending on the video settings.
+    std::vector<CEGUI::Window*> mCustomVideoWidgets;
+
     //! \brief Set the different widget values according to current config.
     void initConfig();
 

--- a/source/modes/SettingsWindow.h
+++ b/source/modes/SettingsWindow.h
@@ -63,8 +63,9 @@ private:
     //! \brief The root window.
     CEGUI::Window* mRootWindow;
 
-    //! \brief The temporary video comboboxes created depending on the video settings.
-    std::vector<CEGUI::Window*> mCustomVideoWidgets;
+    //! \brief The temporary video comboboxes and texts created depending on the video settings.
+    std::vector<CEGUI::Window*> mCustomVideoComboBoxes;
+    std::vector<CEGUI::Window*> mCustomVideoTexts;
 
     //! \brief Set the different widget values according to current config.
     void initConfig();

--- a/source/utils/ConfigManager.h
+++ b/source/utils/ConfigManager.h
@@ -152,6 +152,10 @@ public:
     //! \brief Save the user configuration file.
     bool saveUserConfig();
 
+    //! \brief Tries to restore the previous video config
+    //! To be called at startup once the user config has been loaded.
+    bool initVideoConfig(Ogre::Root& ogreRoot);
+
 private:
     //! \brief Function used to load the global configuration. They should return true if the configuration
     //! is ok and false if a mandatory parameter is missing
@@ -171,7 +175,7 @@ private:
     bool loadTilesets(const std::string& fileName);
     bool loadTilesetValues(std::istream& defFile, TileVisual tileVisual, std::vector<TileSetValue>& tileValues);
 
-    // \brief Loads the user configuration values, and use default ones if it cannot do it.
+    //! \brief Loads the user configuration values, and use default ones if it cannot do it.
     void loadUserConfig(const std::string& fileName);
 
     std::map<std::string, Ogre::ColourValue> mSeatColors;

--- a/source/utils/ConfigManager.h
+++ b/source/utils/ConfigManager.h
@@ -34,6 +34,20 @@ class TileSetValue;
 enum class CreatureMoodLevel;
 enum class TileVisual;
 
+namespace Config
+{
+//! \brief Config options names
+//! Video
+const std::string RENDERER = "Renderer";
+const std::string VIDEO_MODE = "Video Mode";
+const std::string VSYNC = "VSync";
+const std::string FULL_SCREEN = "Full Screen";
+//! Audio
+const std::string MUSIC_VOLUME = "Music Volume";
+//! Game
+const std::string NICKNAME = "Nickname";
+}
+
 //! \brief This class is used to manage global configuration such as network configuration, global creature stats, ...
 //! It should NOT be used to load level specific stuff. For that, there is GameMap.
 class ConfigManager : public Ogre::Singleton<ConfigManager>
@@ -143,11 +157,14 @@ public:
     { mVideoUserConfig[param] = value; }
     void setInputValue(const std::string& param, const std::string& value)
     { mInputUserConfig[param] = value; }
+    void setGameValue(const std::string& param, const std::string& value)
+    { mGameUserConfig[param] = value; }
 
     //! \brief Get a config value.
     const std::string& getAudioValue(const std::string& param) const;
     const std::string& getVideoValue(const std::string& param) const;
     const std::string& getInputValue(const std::string& param) const;
+    const std::string& getGameValue(const std::string& param) const;
 
     //! \brief Save the user configuration file.
     bool saveUserConfig();
@@ -235,6 +252,7 @@ private:
     std::map<std::string, std::string> mAudioUserConfig;
     std::map<std::string, std::string> mVideoUserConfig;
     std::map<std::string, std::string> mInputUserConfig;
+    std::map<std::string, std::string> mGameUserConfig;
 };
 
 #endif //CONFIGMANAGER_H

--- a/source/utils/ResourceManager.cpp
+++ b/source/utils/ResourceManager.cpp
@@ -68,7 +68,6 @@ const std::string ResourceManager::CONFIGSUBPATH = "config/";
 const std::string ResourceManager::SCRIPTSUBPATH = "scripts/";
 const std::string ResourceManager::LANGUAGESUBPATH = "lang/";
 const std::string ResourceManager::SHADERCACHESUBPATH = "shaderCache/";
-const std::string ResourceManager::CONFIGFILENAME = "ogre.cfg";
 const std::string ResourceManager::LOGFILENAME = "opendungeons.log";
 const std::string ResourceManager::CEGUILOGFILENAME = "CEGUI.log";
 const std::string ResourceManager::USERCFGFILENAME = "config.cfg";
@@ -310,7 +309,6 @@ void ResourceManager::setupUserDataFolders(boost::program_options::variables_map
         exit(1);
     }
 
-    mOgreCfgFile = mUserConfigPath + CONFIGFILENAME;
     if(options.count("log") > 0)
     {
         // We change log file

--- a/source/utils/ResourceManager.h
+++ b/source/utils/ResourceManager.h
@@ -116,9 +116,6 @@ public:
     inline const std::string& getShaderCachePath() const
     { return mShaderCachePath; }
 
-    inline const std::string& getOgreCfgFile() const
-    { return mOgreCfgFile; }
-
     inline const std::string& getUserCfgFile() const
     { return mUserConfigFile; }
 
@@ -160,9 +157,6 @@ private:
     //! Same as home path + "cfg/" on Windows.
     std::string mUserConfigPath;
 
-    //! \brief The Ogre config file
-    std::string mOgreCfgFile;
-
     //! \brief Main files in the user data path
     std::string mUserConfigFile;
     std::string mOgreLogFile;
@@ -187,7 +181,6 @@ private:
     static const std::string CONFIGSUBPATH;
     static const std::string LANGUAGESUBPATH;
     static const std::string SHADERCACHESUBPATH;
-    static const std::string CONFIGFILENAME;
     static const std::string LOGFILENAME;
     static const std::string CEGUILOGFILENAME;
     static const std::string USERCFGFILENAME;


### PR DESCRIPTION
- Save and display custom renderer settings. Fixes #822 
- Dropped ogre.cfg need. Fixes #823 

The renderer should start with default settings at first run, and save them once you modify settings.
When changing the renderer settings, all the video settings should be reset.

Please test, especially on Windows. ;)
