### PR TITLE
Implemented new library logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,7 @@ set(OD_SOURCEFILES
     ${SRC}/entities/EntityLoading.cpp
     ${SRC}/entities/GameEntity.cpp
     ${SRC}/entities/GameEntityType.cpp
+    ${SRC}/entities/GiftBoxEntity.cpp
     ${SRC}/entities/MapLight.cpp
     ${SRC}/entities/MissileBoulder.cpp
     ${SRC}/entities/MissileObject.cpp
@@ -298,6 +299,8 @@ set(OD_SOURCEFILES
     ${SRC}/gamemap/MiniMapCamera.cpp
     ${SRC}/gamemap/TileContainer.cpp
     ${SRC}/gamemap/TileSet.cpp
+
+    ${SRC}/giftboxes/GiftBoxResearch.cpp
 
     ${SRC}/goals/Goal.cpp
     ${SRC}/goals/GoalClaimNTiles.cpp

--- a/config/rooms.cfg
+++ b/config/rooms.cfg
@@ -34,6 +34,7 @@
 # LibraryAwaknessPerWork            (double) How many awakness a creature looses for each work turn
 # LibraryCooldownWorkMin            (uint)   How many turns a creature will stay idle after working minimum
 # LibraryCooldownWorkMax            (uint)   How many turns a creature will stay idle after working maximum
+# LibraryResearchPointsBook         (uint)   How many points have to be researched to create a book
 
 [Rooms]
     HatcheryCostPerTile	100
@@ -66,4 +67,5 @@
     LibraryAwaknessPerWork	5.0
     LibraryCooldownWorkMin	3
     LibraryCooldownWorkMax	6
+    LibraryResearchPointsBook	50
 [/Rooms]

--- a/gui/WindowResearchTree.layout
+++ b/gui/WindowResearchTree.layout
@@ -2,97 +2,109 @@
 
 <GUILayout version="4" >
     <Window type="OD/FrameWindow" name="ResearchTreeWindow" >
-        <Property name="Area" value="{{0.5,-295},{0.5,-156},{0.5,295},{0.5,156}}" />
+        <Property name="Area" value="{{0.5,-305},{0.5,-196},{0.5,305},{0.5,196}}" />
         <Property name="Text" value="Research Tree" />
         <Property name="SizingEnabled" value="False" />
-        <Window type="OD/StaticImage" name="AttackSkills" >
-            <Property name="Area" value="{{0,20},{0,35},{0,200},{1,-20}}" />
+        <Window type="OD/StaticImage" name="Skills" >
+            <Property name="Area" value="{{0,20},{0,35},{1,-20},{1,-60}}" />
             <Property name="MaxSize" value="{{1,0},{1,0}}" />
-            <Property name="FrameColours" value="tl:FFFF0000 tr:FFFF0000 bl:FFFFFFFF br:FFFFFFFF" />
-            <Window type="OD/ImageButton" name="TrainingHallButton" >
-                <Property name="Area" value="{{0.5,-25},{0,15},{0.5,25},{0,65}}" />
-                <Property name="ButtonImage" value="OpenDungeonsIcons/TrainingHallButton" />
-                <Property name="TooltipText" value="Room: Training Hall" />
+            <Window type="OD/StaticImage" name="AttackSkills" >
+                <Property name="Area" value="{{0,10},{0,10},{0,190},{1,-10}}" />
+                <Property name="MaxSize" value="{{1,0},{1,0}}" />
+                <Property name="FrameColours" value="tl:FFFF0000 tr:FFFF0000 bl:FFFFFFFF br:FFFFFFFF" />
+                <Window type="OD/ImageButton" name="TrainingHallButton" >
+                    <Property name="Area" value="{{0.5,-25},{0,15},{0.5,25},{0,65}}" />
+                    <Property name="ButtonImage" value="OpenDungeonsIcons/TrainingHallButton" />
+                    <Property name="TooltipText" value="Room: Training Hall" />
+                </Window>
+                <Window type="OD/ImageButton" name="CallToWarButton" >
+                    <Property name="Area" value="{{0.3,-25},{0,75},{0.3,25},{0,125}}" />
+                    <Property name="ButtonImage" value="OpenDungeonsIcons/CallToWarButton" />
+                    <Property name="TooltipText" value="Spell: Call to War" />
+                </Window>
+                <Window type="OD/ImageButton" name="CreatureExplosionButton" >
+                    <Property name="Area" value="{{0.7,-25},{0,75},{0.7,25},{0,125}}" />
+                    <Property name="ButtonImage" value="OpenDungeonsIcons/CreatureExplosionButton" />
+                    <Property name="TooltipText" value="Spell: Creature Explosion" />
+                </Window>
             </Window>
-            <Window type="OD/ImageButton" name="CallToWarButton" >
-                <Property name="Area" value="{{0.3,-25},{0,75},{0.3,25},{0,125}}" />
-                <Property name="ButtonImage" value="OpenDungeonsIcons/CallToWarButton" />
-                <Property name="TooltipText" value="Spell: Call to War" />
+            <Window type="OD/StaticImage" name="TacticSkills" >
+                <Property name="Area" value="{{0,195},{0,10},{0,375},{1,-10}}" />
+                <Property name="MaxSize" value="{{1,0},{1,0}}" />
+                <Window type="OD/ImageButton" name="TreasuryButton" >
+                    <Property name="Area" value="{{0.2,-25},{0,15},{0.2,25},{0,65}}" />
+                    <Property name="ButtonImage" value="OpenDungeonsIcons/TreasuryButton" />
+                    <Property name="TooltipText" value="Room: Treasury" />
+                </Window>
+                <Window type="OD/ImageButton" name="HatcheryButton" >
+                    <Property name="Area" value="{{0.5,-25},{0,15},{0.5,25},{0,65}}" />
+                    <Property name="ButtonImage" value="OpenDungeonsIcons/HatcheryButton" />
+                    <Property name="TooltipText" value="Room: Hatchery" />
+                </Window>
+                <Window type="OD/ImageButton" name="DormitoryButton" >
+                    <Property name="Area" value="{{0.8,-25},{0,15},{0.8,25},{0,65}}" />
+                    <Property name="ButtonImage" value="OpenDungeonsIcons/DormitoryButton" />
+                    <Property name="TooltipText" value="Room: Dormitory" />
+                </Window>
+                <Window type="OD/ImageButton" name="WorkshopButton" >
+                    <Property name="Area" value="{{0.3,-25},{0,75},{0.3,25},{0,125}}" />
+                    <Property name="ButtonImage" value="OpenDungeonsIcons/WorkshopButton" />
+                    <Property name="TooltipText" value="Room: Workshop" />
+                </Window>
+                <Window type="OD/ImageButton" name="WoodenDoorTrapButton" >
+                    <Property name="Area" value="{{0.7,-25},{0,75},{0.7,25},{0,125}}" />
+                    <Property name="ButtonImage" value="OpenDungeonsIcons/WoodenDoorTrapButton" />
+                    <Property name="TooltipText" value="Trap: Wooden door" />
+                </Window>
+                <Window type="OD/ImageButton" name="CannonButton" >
+                    <Property name="Area" value="{{0.3,-25},{0,135},{0.3,25},{0,185}}" />
+                    <Property name="ButtonImage" value="OpenDungeonsIcons/CannonButton" />
+                    <Property name="TooltipText" value="Trap: Cannon" />
+                </Window>
+                <Window type="OD/ImageButton" name="SpikeTrapButton" >
+                    <Property name="Area" value="{{0.7,-25},{0,135},{0.7,25},{0,185}}" />
+                    <Property name="ButtonImage" value="OpenDungeonsIcons/SpikeTrapButton" />
+                    <Property name="TooltipText" value="Trap: Spike trap" />
+                </Window>
+                <Window type="OD/ImageButton" name="BoulderTrapButton" >
+                    <Property name="Area" value="{{0.5,-25},{0,195},{0.5,25},{0,245}}" />
+                    <Property name="ButtonImage" value="OpenDungeonsIcons/BoulderTrapButton" />
+                    <Property name="TooltipText" value="Trap: Boulder trap" />
+                </Window>
             </Window>
-            <Window type="OD/ImageButton" name="CreatureExplosionButton" >
-                <Property name="Area" value="{{0.7,-25},{0,75},{0.7,25},{0,125}}" />
-                <Property name="ButtonImage" value="OpenDungeonsIcons/CreatureExplosionButton" />
-                <Property name="TooltipText" value="Spell: Creature Explosion" />
+            <Window type="OD/StaticImage" name="MagicSkills" >
+                <Property name="Area" value="{{0,380},{0,10},{0,560},{1,-10}}" />
+                <Property name="MaxSize" value="{{1,0},{1,0}}" />
+                <Property name="FrameColours" value="tl:FF0000FF tr:FF0000FF bl:FFFFFFFF br:FFFFFFFF" />
+                <Window type="OD/ImageButton" name="LibraryButton" >
+                    <Property name="Area" value="{{0.7,-25},{0,15},{0.7,25},{0,65}}" />
+                    <Property name="ButtonImage" value="OpenDungeonsIcons/LibraryButton" />
+                    <Property name="TooltipText" value="Room: Library" />
+                </Window>
+                <Window type="OD/ImageButton" name="CryptButton" >
+                    <Property name="Area" value="{{0.3,-25},{0,75},{0.3,25},{0,125}}" />
+                    <Property name="ButtonImage" value="OpenDungeonsIcons/CryptButton" />
+                    <Property name="TooltipText" value="Room: Crypt" />
+                </Window>
+                <Window type="OD/ImageButton" name="SummonWorkerButton" >
+                    <Property name="Area" value="{{0.3,-25},{0,15},{0.3,25},{0,65}}" />
+                    <Property name="ButtonImage" value="OpenDungeonsIcons/SummonWorkerButton" />
+                    <Property name="TooltipText" value="Spell: Summon Worker" />
+                </Window>
+                <Window type="OD/ImageButton" name="CreatureHealButton" >
+                    <Property name="Area" value="{{0.7,-25},{0,75},{0.7,25},{0,125}}" />
+                    <Property name="ButtonImage" value="OpenDungeonsIcons/CreatureHealButton" />
+                    <Property name="TooltipText" value="Spell: Creature Heal" />
+                </Window>
             </Window>
         </Window>
-        <Window type="OD/StaticImage" name="TacticSkills" >
-            <Property name="Area" value="{{0,205},{0,35},{0,385},{1,-20}}" />
-            <Property name="MaxSize" value="{{1,0},{1,0}}" />
-            <Window type="OD/ImageButton" name="TreasuryButton" >
-                <Property name="Area" value="{{0.2,-25},{0,15},{0.2,25},{0,65}}" />
-                <Property name="ButtonImage" value="OpenDungeonsIcons/TreasuryButton" />
-                <Property name="TooltipText" value="Room: Treasury" />
-            </Window>
-            <Window type="OD/ImageButton" name="HatcheryButton" >
-                <Property name="Area" value="{{0.5,-25},{0,15},{0.5,25},{0,65}}" />
-                <Property name="ButtonImage" value="OpenDungeonsIcons/HatcheryButton" />
-                <Property name="TooltipText" value="Room: Hatchery" />
-            </Window>
-            <Window type="OD/ImageButton" name="DormitoryButton" >
-                <Property name="Area" value="{{0.8,-25},{0,15},{0.8,25},{0,65}}" />
-                <Property name="ButtonImage" value="OpenDungeonsIcons/DormitoryButton" />
-                <Property name="TooltipText" value="Room: Dormitory" />
-            </Window>
-            <Window type="OD/ImageButton" name="WorkshopButton" >
-                <Property name="Area" value="{{0.3,-25},{0,75},{0.3,25},{0,125}}" />
-                <Property name="ButtonImage" value="OpenDungeonsIcons/WorkshopButton" />
-                <Property name="TooltipText" value="Room: Workshop" />
-            </Window>
-            <Window type="OD/ImageButton" name="WoodenDoorTrapButton" >
-                <Property name="Area" value="{{0.7,-25},{0,75},{0.7,25},{0,125}}" />
-                <Property name="ButtonImage" value="OpenDungeonsIcons/WoodenDoorTrapButton" />
-                <Property name="TooltipText" value="Trap: Wooden door" />
-            </Window>
-            <Window type="OD/ImageButton" name="CannonButton" >
-                <Property name="Area" value="{{0.3,-25},{0,135},{0.3,25},{0,185}}" />
-                <Property name="ButtonImage" value="OpenDungeonsIcons/CannonButton" />
-                <Property name="TooltipText" value="Trap: Cannon" />
-            </Window>
-            <Window type="OD/ImageButton" name="SpikeTrapButton" >
-                <Property name="Area" value="{{0.7,-25},{0,135},{0.7,25},{0,185}}" />
-                <Property name="ButtonImage" value="OpenDungeonsIcons/SpikeTrapButton" />
-                <Property name="TooltipText" value="Trap: Spike trap" />
-            </Window>
-            <Window type="OD/ImageButton" name="BoulderTrapButton" >
-                <Property name="Area" value="{{0.5,-25},{0,195},{0.5,25},{0,245}}" />
-                <Property name="ButtonImage" value="OpenDungeonsIcons/BoulderTrapButton" />
-                <Property name="TooltipText" value="Trap: Boulder trap" />
-            </Window>
+        <Window type="OD/Button" name="CancelButton" >
+            <Property name="Area" value="{{1,-200},{1,-50},{1,-120},{1,-20}}" />
+            <Property name="Text" value="Cancel" />
         </Window>
-        <Window type="OD/StaticImage" name="MagicSkills" >
-            <Property name="Area" value="{{0,390},{0,35},{0,570},{1,-20}}" />
-            <Property name="MaxSize" value="{{1,0},{1,0}}" />
-            <Property name="FrameColours" value="tl:FF0000FF tr:FF0000FF bl:FFFFFFFF br:FFFFFFFF" />
-            <Window type="OD/ImageButton" name="LibraryButton" >
-                <Property name="Area" value="{{0.7,-25},{0,15},{0.7,25},{0,65}}" />
-                <Property name="ButtonImage" value="OpenDungeonsIcons/LibraryButton" />
-                <Property name="TooltipText" value="Room: Library" />
-            </Window>
-            <Window type="OD/ImageButton" name="CryptButton" >
-                <Property name="Area" value="{{0.3,-25},{0,75},{0.3,25},{0,125}}" />
-                <Property name="ButtonImage" value="OpenDungeonsIcons/CryptButton" />
-                <Property name="TooltipText" value="Room: Crypt" />
-            </Window>
-            <Window type="OD/ImageButton" name="SummonWorkerButton" >
-                <Property name="Area" value="{{0.3,-25},{0,15},{0.3,25},{0,65}}" />
-                <Property name="ButtonImage" value="OpenDungeonsIcons/SummonWorkerButton" />
-                <Property name="TooltipText" value="Spell: Summon Worker" />
-            </Window>
-            <Window type="OD/ImageButton" name="CreatureHealButton" >
-                <Property name="Area" value="{{0.7,-25},{0,75},{0.7,25},{0,125}}" />
-                <Property name="ButtonImage" value="OpenDungeonsIcons/CreatureHealButton" />
-                <Property name="TooltipText" value="Spell: Creature Heal" />
-            </Window>
+        <Window type="OD/Button" name="ApplyButton" >
+            <Property name="Area" value="{{1,-100},{1,-50},{1,-20},{1,-20}}" />
+            <Property name="Text" value="Apply" />
         </Window>
     </Window>
 </GUILayout>

--- a/levels/multiplayer/GreedOrMight.level
+++ b/levels/multiplayer/GreedOrMight.level
@@ -2382,8 +2382,12 @@ MineNGold	50
 [/CraftedTraps]
 
 [ResearchEntity]
-# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchPoints	PosX	PosY	PosZ
 [/ResearchEntity]
+
+[GiftBoxEntity]
+# GiftBoxType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData
+[/GiftBoxEntity]
 
 [Missiles]
 # missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData

--- a/levels/multiplayer/ScreamInTheDark.level
+++ b/levels/multiplayer/ScreamInTheDark.level
@@ -5202,6 +5202,7 @@ ProtectDungeonTemple	NULL
 38	61
 38	62
 38	63
+0
 [/Room]
 [Room]
 4	Portal5	5	9

--- a/levels/multiplayer/ScreamInTheDark.level
+++ b/levels/multiplayer/ScreamInTheDark.level
@@ -5287,8 +5287,12 @@ ProtectDungeonTemple	NULL
 [/CraftedTraps]
 
 [ResearchEntity]
-# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchPoints	PosX	PosY	PosZ
 [/ResearchEntity]
+
+[GiftBoxEntity]
+# GiftBoxType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData
+[/GiftBoxEntity]
 
 [Missiles]
 # missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData

--- a/levels/multiplayer/TestBigMap.level
+++ b/levels/multiplayer/TestBigMap.level
@@ -6080,8 +6080,12 @@ ProtectDungeonTemple	NULL
 [/CraftedTraps]
 
 [ResearchEntity]
-# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchPoints	PosX	PosY	PosZ
 [/ResearchEntity]
+
+[GiftBoxEntity]
+# GiftBoxType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData
+[/GiftBoxEntity]
 
 [Missiles]
 # missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData

--- a/levels/multiplayer/TestMultiplayerSmall1v1.level
+++ b/levels/multiplayer/TestMultiplayerSmall1v1.level
@@ -575,8 +575,12 @@ ProtectDungeonTemple	NULL
 [/CraftedTraps]
 
 [ResearchEntity]
-# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchPoints	PosX	PosY	PosZ
 [/ResearchEntity]
+
+[GiftBoxEntity]
+# GiftBoxType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData
+[/GiftBoxEntity]
 
 [Missiles]
 # missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData

--- a/levels/multiplayer/TestMultiplayerSmallAlliance.level
+++ b/levels/multiplayer/TestMultiplayerSmallAlliance.level
@@ -893,8 +893,12 @@ ProtectDungeonTemple	NULL
 [/CraftedTraps]
 
 [ResearchEntity]
-# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchPoints	PosX	PosY	PosZ
 [/ResearchEntity]
+
+[GiftBoxEntity]
+# GiftBoxType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData
+[/GiftBoxEntity]
 
 [Missiles]
 # missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData

--- a/levels/multiplayer/TestMultiplayerSmallFreeForAll.level
+++ b/levels/multiplayer/TestMultiplayerSmallFreeForAll.level
@@ -894,8 +894,12 @@ ProtectDungeonTemple	NULL
 [/CraftedTraps]
 
 [ResearchEntity]
-# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchPoints	PosX	PosY	PosZ
 [/ResearchEntity]
+
+[GiftBoxEntity]
+# GiftBoxType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData
+[/GiftBoxEntity]
 
 [Missiles]
 # missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData

--- a/levels/multiplayer/TheBridge.level
+++ b/levels/multiplayer/TheBridge.level
@@ -4589,8 +4589,12 @@ ProtectDungeonTemple	NULL
 [/CraftedTraps]
 
 [ResearchEntity]
-# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchPoints	PosX	PosY	PosZ
 [/ResearchEntity]
+
+[GiftBoxEntity]
+# GiftBoxType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData
+[/GiftBoxEntity]
 
 [Missiles]
 # missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData

--- a/levels/skirmish/FallingKeeper.level
+++ b/levels/skirmish/FallingKeeper.level
@@ -2112,6 +2112,7 @@ ProtectDungeonTemple	NULL
 40	42
 40	43
 40	44
+0
 [/Room]
 [Room]
 4	Portal5	2	9

--- a/levels/skirmish/FallingKeeper.level
+++ b/levels/skirmish/FallingKeeper.level
@@ -2234,8 +2234,12 @@ BigKnight	12
 [/CraftedTraps]
 
 [ResearchEntity]
-# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchPoints	PosX	PosY	PosZ
 [/ResearchEntity]
+
+[GiftBoxEntity]
+# GiftBoxType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData
+[/GiftBoxEntity]
 
 [Missiles]
 # missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData

--- a/levels/skirmish/StonekeepSiege.level
+++ b/levels/skirmish/StonekeepSiege.level
@@ -4201,8 +4201,12 @@ ProtectDungeonTemple	NULL
 [/CraftedTraps]
 
 [ResearchEntity]
-# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchPoints	PosX	PosY	PosZ
 [/ResearchEntity]
+
+[GiftBoxEntity]
+# GiftBoxType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData
+[/GiftBoxEntity]
 
 [Missiles]
 # missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData

--- a/levels/skirmish/StonekeepSiege.level
+++ b/levels/skirmish/StonekeepSiege.level
@@ -3986,6 +3986,7 @@ ProtectDungeonTemple	NULL
 47	83
 47	84
 47	85
+0
 [/Room]
 [Room]
 4	Portal17	4	9

--- a/levels/skirmish/TestLegacy.level
+++ b/levels/skirmish/TestLegacy.level
@@ -6859,8 +6859,12 @@ ProtectDungeonTemple	NULL
 [/CraftedTraps]
 
 [ResearchEntity]
-# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchPoints	PosX	PosY	PosZ
 [/ResearchEntity]
+
+[GiftBoxEntity]
+# GiftBoxType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData
+[/GiftBoxEntity]
 
 [Missiles]
 # missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData

--- a/levels/skirmish/TestModelsFair.level
+++ b/levels/skirmish/TestModelsFair.level
@@ -916,6 +916,7 @@ Spider12	16	13	0
 17	9
 17	10
 17	11
+0
 [/Room]
 [Room]
 4	Portal1	1	9

--- a/levels/skirmish/TestModelsFair.level
+++ b/levels/skirmish/TestModelsFair.level
@@ -1087,8 +1087,12 @@ Spider12	16	13	0
 [/CraftedTraps]
 
 [ResearchEntity]
-# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchPoints	PosX	PosY	PosZ
 [/ResearchEntity]
+
+[GiftBoxEntity]
+# GiftBoxType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData
+[/GiftBoxEntity]
 
 [Missiles]
 # missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData

--- a/levels/skirmish/TestSingleplayerSmall.level
+++ b/levels/skirmish/TestSingleplayerSmall.level
@@ -32,14 +32,13 @@ spellCreatureHeal
 spellCreatureExplosion
 [/ResearchDone]
 [ResearchNotAllowed]
+trapSpike
 [/ResearchNotAllowed]
 [ResearchPending]
 roomTrainingHall
 spellCallToWar
-trapSpike
 roomWorkshop
 roomCrypt
-trapBoulder
 [/ResearchPending]
 [/Seat]
 [Seat]

--- a/levels/skirmish/TestSingleplayerSmall.level
+++ b/levels/skirmish/TestSingleplayerSmall.level
@@ -1284,8 +1284,12 @@ DwarfWorker	1
 [/CraftedTraps]
 
 [ResearchEntity]
-# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchPoints	PosX	PosY	PosZ
 [/ResearchEntity]
+
+[GiftBoxEntity]
+# GiftBoxType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData
+[/GiftBoxEntity]
 
 [Missiles]
 # missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData

--- a/levels/skirmish/TestSingleplayerSmallEmpty.level
+++ b/levels/skirmish/TestSingleplayerSmallEmpty.level
@@ -2637,8 +2637,12 @@ ProtectDungeonTemple	NULL
 [/CraftedTraps]
 
 [ResearchEntity]
-# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchPoints	PosX	PosY	PosZ
 [/ResearchEntity]
+
+[GiftBoxEntity]
+# GiftBoxType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData
+[/GiftBoxEntity]
 
 [Missiles]
 # missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData

--- a/levels/skirmish/TestSingleplayerSmallPassability.level
+++ b/levels/skirmish/TestSingleplayerSmallPassability.level
@@ -220,8 +220,12 @@ ProtectDungeonTemple	NULL
 [/CraftedTraps]
 
 [ResearchEntity]
-# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchPoints	PosX	PosY	PosZ
 [/ResearchEntity]
+
+[GiftBoxEntity]
+# GiftBoxType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData
+[/GiftBoxEntity]
 
 [Missiles]
 # missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData

--- a/levels/template.level
+++ b/levels/template.level
@@ -115,8 +115,12 @@ ProtectDungeonTemple	NULL
 [/CraftedTraps]
 
 [ResearchEntity]
-# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchType	PosX	PosY	PosZ
+# SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	researchPoints	PosX	PosY	PosZ
 [/ResearchEntity]
+
+[GiftBoxEntity]
+# GiftBoxType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	optionalData
+[/GiftBoxEntity]
 
 [Missiles]
 # missileType	SeatId	Name	MeshName	PosX	PosY	PosZ	opacity	rotationAngle	directionX	directionY	directionZ	missileAlive	damageAllies	optionalData

--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -767,6 +767,7 @@ void Creature::doUpkeep()
                 obj->setPosition(spawnPosition);
             }
 
+/* TODO : Use a gift box
             if(mResearchTypeDropDeath != ResearchType::nullResearchType)
             {
                 ResearchEntity* researchEntity = new ResearchEntity(getGameMap(), getIsOnServerMap(),
@@ -777,6 +778,7 @@ void Creature::doUpkeep()
                 researchEntity->createMesh();
                 researchEntity->setPosition(spawnPosition);
             }
+            */
 
             // TODO: drop weapon when available
         }

--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -27,7 +27,6 @@
 #include "entities/CreatureDefinition.h"
 #include "entities/CreatureSound.h"
 #include "entities/MissileOneHit.h"
-#include "entities/ResearchEntity.h"
 #include "entities/Tile.h"
 #include "entities/TreasuryObject.h"
 #include "entities/Weapon.h"
@@ -38,6 +37,8 @@
 
 #include "gamemap/GameMap.h"
 #include "gamemap/Pathfinding.h"
+
+#include "giftboxes/GiftBoxResearch.h"
 
 #include "network/ODClient.h"
 #include "network/ODServer.h"
@@ -767,10 +768,9 @@ void Creature::doUpkeep()
                 obj->setPosition(spawnPosition);
             }
 
-/* TODO : Use a gift box
             if(mResearchTypeDropDeath != ResearchType::nullResearchType)
             {
-                ResearchEntity* researchEntity = new ResearchEntity(getGameMap(), getIsOnServerMap(),
+                GiftBoxResearch* researchEntity = new GiftBoxResearch(getGameMap(), getIsOnServerMap(),
                     "DroppedBy" + getName(), mResearchTypeDropDeath);
                 researchEntity->addToGameMap();
                 Ogre::Vector3 spawnPosition(static_cast<Ogre::Real>(myTile->getX()),
@@ -778,7 +778,6 @@ void Creature::doUpkeep()
                 researchEntity->createMesh();
                 researchEntity->setPosition(spawnPosition);
             }
-            */
 
             // TODO: drop weapon when available
         }

--- a/source/entities/EntityLoading.cpp
+++ b/source/entities/EntityLoading.cpp
@@ -21,6 +21,7 @@
 #include "entities/ChickenEntity.h"
 #include "entities/CraftedTrap.h"
 #include "entities/Creature.h"
+#include "entities/GiftBoxEntity.h"
 #include "entities/MapLight.h"
 #include "entities/MissileObject.h"
 #include "entities/PersistentObject.h"
@@ -111,6 +112,11 @@ GameEntity* getGameEntityFromStream(GameMap* gameMap, GameEntityType type, std::
             entity = ResearchEntity::getResearchEntityFromStream(gameMap, is);
             break;
         }
+        case GameEntityType::giftBoxEntity:
+        {
+            entity = GiftBoxEntity::getGiftBoxEntityFromStream(gameMap, is);
+            break;
+        }
         default:
         {
             OD_LOG_ERR("Unknown enum value : " + Helper::toString(
@@ -194,6 +200,11 @@ GameEntity* getGameEntityFromPacket(GameMap* gameMap, ODPacket& is)
         case GameEntityType::researchEntity:
         {
             entity = ResearchEntity::getResearchEntityFromPacket(gameMap, is);
+            break;
+        }
+        case GameEntityType::giftBoxEntity:
+        {
+            entity = GiftBoxEntity::getGiftBoxEntityFromPacket(gameMap, is);
             break;
         }
         default:

--- a/source/entities/GameEntity.h
+++ b/source/entities/GameEntity.h
@@ -53,6 +53,7 @@ enum class EntityCarryType
     corpse,
     researchEntity,
     craftedTrap,
+    giftBox,
     gold
 };
 

--- a/source/entities/GiftBoxEntity.cpp
+++ b/source/entities/GiftBoxEntity.cpp
@@ -99,27 +99,15 @@ void GiftBoxEntity::exportHeadersToStream(std::ostream& os) const
     os << mGiftBoxType << "\t";
 }
 
-void GiftBoxEntity::exportToStream(std::ostream& os) const
-{
-    RenderedMovableEntity::exportToStream(os);
-    os << mPosition.x << "\t" << mPosition.y << "\t" << mPosition.z << "\t";
-}
-
-void GiftBoxEntity::importFromStream(std::istream& is)
-{
-    RenderedMovableEntity::importFromStream(is);
-    OD_ASSERT_TRUE(is >> mPosition.x >> mPosition.y >> mPosition.z);
-}
-
 std::string GiftBoxEntity::getGiftBoxEntityStreamFormat()
 {
     std::string format = RenderedMovableEntity::getRenderedMovableEntityStreamFormat();
     if(!format.empty())
         format += "\t";
 
-    format += "GiftBoxType\tPosX\tPosY\tPosZ";
+    format += "optionalData";
 
-    return format;
+    return "GiftBoxType\t" + format;
 }
 
 std::ostream& operator<<(std::ostream& os, const GiftBoxType& type)

--- a/source/entities/GiftBoxEntity.h
+++ b/source/entities/GiftBoxEntity.h
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (C) 2011-2015  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef GIFTBOXENTITY_H
+#define GIFTBOXENTITY_H
+
+#include "entities/RenderedMovableEntity.h"
+
+#include <string>
+#include <iosfwd>
+
+class Creature;
+class Room;
+class GameMap;
+class Tile;
+class ODPacket;
+
+enum class GiftBoxType
+{
+    research,
+    nbTypes
+};
+std::ostream& operator<<(std::ostream& os, const GiftBoxType& type);
+std::istream& operator>>(std::istream& is, GiftBoxType& type);
+
+class GiftBoxEntity: public RenderedMovableEntity
+{
+public:
+    GiftBoxEntity(GameMap* gameMap, bool isOnServerMap, const std::string& baseName, const std::string& meshName, GiftBoxType type);
+    GiftBoxEntity(GameMap* gameMap, bool isOnServerMap);
+
+    virtual GameEntityType getObjectType() const override
+    { return GameEntityType::giftBoxEntity; }
+
+    virtual const Ogre::Vector3& getScale() const override;
+
+    virtual EntityCarryType getEntityCarryType() override
+    { return EntityCarryType::giftBox; }
+
+    virtual void notifyEntityCarryOn(Creature* carrier) override;
+    virtual void notifyEntityCarryOff(const Ogre::Vector3& position) override;
+
+    virtual void exportHeadersToStream(std::ostream& os) const override;
+    virtual void exportToStream(std::ostream& os) const override;
+    virtual void importFromStream(std::istream& is) override;
+
+    //! \brief Server side function that will be called when the gift box is carried to the dungeon temple. It should be
+    //! called by the overriding classes to do what they need. However, this function is not pure virtual because on client side,
+    //! we don't want to make a difference
+    virtual void applyEffect()
+    {}
+
+    static GiftBoxEntity* getGiftBoxEntityFromStream(GameMap* gameMap, std::istream& is);
+    static GiftBoxEntity* getGiftBoxEntityFromPacket(GameMap* gameMap, ODPacket& is);
+    static std::string getGiftBoxEntityStreamFormat();
+private:
+    GiftBoxType mGiftBoxType;
+};
+
+#endif // GIFTBOXENTITY_H

--- a/source/entities/GiftBoxEntity.h
+++ b/source/entities/GiftBoxEntity.h
@@ -55,8 +55,6 @@ public:
     virtual void notifyEntityCarryOff(const Ogre::Vector3& position) override;
 
     virtual void exportHeadersToStream(std::ostream& os) const override;
-    virtual void exportToStream(std::ostream& os) const override;
-    virtual void importFromStream(std::istream& is) override;
 
     //! \brief Server side function that will be called when the gift box is carried to the dungeon temple. It should be
     //! called by the overriding classes to do what they need. However, this function is not pure virtual because on client side,

--- a/source/entities/ResearchEntity.cpp
+++ b/source/entities/ResearchEntity.cpp
@@ -40,9 +40,9 @@ const std::string EMPTY_STRING;
 
 const Ogre::Vector3 SCALE(0.5,0.5,0.5);
 
-ResearchEntity::ResearchEntity(GameMap* gameMap, bool isOnServerMap, const std::string& libraryName, ResearchType researchType) :
+ResearchEntity::ResearchEntity(GameMap* gameMap, bool isOnServerMap, const std::string& libraryName, int32_t researchPoints) :
     RenderedMovableEntity(gameMap, isOnServerMap, libraryName, "Grimoire", 0.0f, false, 1.0f),
-    mResearchType(researchType)
+    mResearchPoints(researchPoints)
 {
     mPrevAnimationState = "Loop";
     mPrevAnimationStateLoop = true;
@@ -85,14 +85,14 @@ ResearchEntity* ResearchEntity::getResearchEntityFromPacket(GameMap* gameMap, OD
 void ResearchEntity::exportToStream(std::ostream& os) const
 {
     RenderedMovableEntity::exportToStream(os);
-    os << mResearchType << "\t";
+    os << mResearchPoints << "\t";
     os << mPosition.x << "\t" << mPosition.y << "\t" << mPosition.z << "\t";
 }
 
 void ResearchEntity::importFromStream(std::istream& is)
 {
     RenderedMovableEntity::importFromStream(is);
-    OD_ASSERT_TRUE(is >> mResearchType);
+    OD_ASSERT_TRUE(is >> mResearchPoints);
     OD_ASSERT_TRUE(is >> mPosition.x >> mPosition.y >> mPosition.z);
 }
 
@@ -102,7 +102,7 @@ std::string ResearchEntity::getResearchEntityStreamFormat()
     if(!format.empty())
         format += "\t";
 
-    format += "researchType\tPosX\tPosY\tPosZ";
+    format += "researchPoints\tPosX\tPosY\tPosZ";
 
     return format;
 }

--- a/source/entities/ResearchEntity.h
+++ b/source/entities/ResearchEntity.h
@@ -29,12 +29,10 @@ class GameMap;
 class Tile;
 class ODPacket;
 
-enum class ResearchType;
-
 class ResearchEntity: public RenderedMovableEntity
 {
 public:
-    ResearchEntity(GameMap* gameMap, bool isOnServerMap, const std::string& libraryName, ResearchType researchType);
+    ResearchEntity(GameMap* gameMap, bool isOnServerMap, const std::string& libraryName, int32_t researchPoints);
     ResearchEntity(GameMap* gameMap, bool isOnServerMap);
 
     virtual GameEntityType getObjectType() const override
@@ -42,8 +40,8 @@ public:
 
     virtual const Ogre::Vector3& getScale() const override;
 
-    ResearchType getResearchType() const
-    { return mResearchType; }
+    inline int32_t getResearchPoints() const
+    { return mResearchPoints; }
 
     virtual EntityCarryType getEntityCarryType() override
     { return EntityCarryType::researchEntity; }
@@ -58,7 +56,7 @@ public:
     static ResearchEntity* getResearchEntityFromPacket(GameMap* gameMap, ODPacket& is);
     static std::string getResearchEntityStreamFormat();
 private:
-    ResearchType mResearchType;
+    int32_t mResearchPoints;
 };
 
 #endif // RESEARCHENTITY_H

--- a/source/game/Player.h
+++ b/source/game/Player.h
@@ -170,27 +170,27 @@ public:
 
     void fireEvents();
 
-    //! Called on client side to update the current list of events. Note that
+    //! \brief Called on client side to update the current list of events. Note that
     //! the time remaining of PlayerEvent class is not relevant on client side
     void updateEvents(const std::vector<PlayerEvent*>& events);
 
-    //! get the next event. After index. If index > events size, the first one is
+    //! \brief get the next event. After index. If index > events size, the first one is
     //! sent. When the function returns, index is set to the index of the returned event
     //! and it returns the PlayerEvent if any (nullptr is none).
     //! Note that on client side, PlayerEvent::mTimeRemain is not relevant
     const PlayerEvent* getNextEvent(uint32_t& index) const;
 
-    //! Marks the tiles for digging and send the refresh event to concerned player if human
+    //! \brief Marks the tiles for digging and send the refresh event to concerned player if human
     void markTilesForDigging(bool marked, const std::vector<Tile*>& tiles, bool asyncMsg);
 
     uint32_t getSpellCooldownTurns(SpellType spellType);
 
     void setSpellCooldownTurns(SpellType spellType, uint32_t cooldown);
 
-    //! Called each turn, it should handle Player upkeep on server side
+    //! \brief Called each turn, it should handle Player upkeep on server side
     void upkeepPlayer(double timeSinceLastUpkeep);
 
-    //! Decreases cooldown for all spells. Used on both server and client sides
+    //! \brief Decreases cooldown for all spells. Used on both server and client sides
     void decreaseSpellCooldowns();
 
 private:

--- a/source/game/Research.cpp
+++ b/source/game/Research.cpp
@@ -44,6 +44,33 @@ bool Research::canBeResearched(const std::vector<ResearchType>& researchesDone) 
     return false;
 }
 
+void Research::buildDependencies(const std::vector<ResearchType>& researchesDone, std::vector<ResearchType>& dependencies) const
+{
+    for(const Research* research : mResearchDepends)
+    {
+        if(std::find(researchesDone.begin(), researchesDone.end(), research->getType()) != researchesDone.end())
+            continue;
+
+        research->buildDependencies(researchesDone, dependencies);
+    }
+
+    dependencies.push_back(getType());
+}
+
+bool Research::dependsOn(ResearchType type) const
+{
+    for(const Research* research : mResearchDepends)
+    {
+        if(research->getType() == type)
+            return true;
+
+        if(research->dependsOn(type))
+            return true;
+    }
+
+    return false;
+}
+
 std::string Research::researchTypeToString(ResearchType type)
 {
     switch(type)

--- a/source/game/Research.h
+++ b/source/game/Research.h
@@ -74,6 +74,15 @@ public:
 
     bool canBeResearched(const std::vector<ResearchType>& researchesDone) const;
 
+    //! \brief Builds the dependency tree in dependencies with the researches required for this research
+    //! excluding researches already done in researchesDone including the research itself. Note that the returned vector
+    //! will contain needed researches ordered by feasible researches (the first one will have no needed dependencies,
+    //! the second none other than the first, ...)
+    void buildDependencies(const std::vector<ResearchType>& researchesDone, std::vector<ResearchType>& dependencies) const;
+
+    //! \brief Returns true if the research depends on the given type and false otherwise
+    bool dependsOn(ResearchType type) const;
+
     //! \brief The research name as used in level files.
     static std::string researchTypeToString(ResearchType type);
 

--- a/source/game/Seat.h
+++ b/source/game/Seat.h
@@ -212,6 +212,15 @@ public:
     inline void setPlayerType(const std::string& playerType)
     { mPlayerType = playerType; }
 
+    inline const std::vector<ResearchType>& getResearchDone() const
+    { return mResearchDone; }
+
+    inline const std::vector<ResearchType>& getResearchPending() const
+    { return mResearchPending; }
+
+    inline const std::vector<ResearchType>& getResearchNotAllowed() const
+    { return mResearchNotAllowed; }
+
     void setPlayer(Player* player);
 
     void addAlliedSeat(Seat* seat);
@@ -266,15 +275,9 @@ public:
     bool isResearching() const
     { return mCurrentResearch != nullptr; }
 
-    //! \brief Gets the current research being done
-    ResearchType getCurrentResearchType() const;
-
     //! \brief Tells whether the given research type is in the pending queue.
     //! \return The number of the pending research in the research queue or 0 if not there.
     uint32_t isResearchPending(ResearchType resType) const;
-
-    //! \brief Tells whether a research entity is existing for the given ResearchType.
-    bool hasResearchWaitingForType(ResearchType resType);
 
     //! \brief Checks if the given spell is available for the Player. This check
     //! should be done on server side to avoid cheating
@@ -292,10 +295,6 @@ public:
     //! otherwise
     bool isResearchDone(ResearchType type) const;
 
-    //! \brief Tells the server and client a new research entity is waiting to be brought
-    //! to the temple.
-    void addResearchWaiting(ResearchType type);
-
     //! Called when the research entity reaches its destination. From there, the researched
     //! thing is available
     //! Returns true if the type was inserted and false otherwise
@@ -304,7 +303,7 @@ public:
     //! Called from the library as creatures are researching. When enough points are gathered,
     //! the corresponding research will become available.
     //! Returns the research done if enough points have been gathered and nullptr otherwise
-    const Research* addResearchPoints(int32_t points);
+    void addResearchPoints(int32_t points);
 
     //! Used on both client and server side. On server side, the research tree's validity will be
     //! checked. If ok, it will be sent to the client. If not, the research tree will not be
@@ -470,9 +469,6 @@ private:
     //! \brief Researches already done. This is used on both client and server side and should be updated
     std::vector<ResearchType> mResearchDone;
 
-    //! \brief Research done but awaiting to be brought to the temple.
-    std::vector<ResearchType> mResearchWaiting;
-
     //! \brief Researches pending. Used on both client and server side and should be updated.
     std::vector<ResearchType> mResearchPending;
 
@@ -484,10 +480,9 @@ private:
     int32_t mConfigTeamId;
     int32_t mConfigFactionIndex;
 
-    //! \brief On server side: Sets mCurrentResearch to the first entry in mResearchPending. If the pending
+    //! \brief Server side function. Sets mCurrentResearch to the first entry in mResearchPending. If the pending
     //! list in empty, mCurrentResearch will be set to null
     //! researchedType is the currently researched type if any (nullResearchType if none)
-    //! On the player side: Set the next research pending to update the Gui.
     void setNextResearch(ResearchType researchedType);
 
     //! Fills mTilesStateLoaded with the tiles of the given tileVisual is the given istream.

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -2667,6 +2667,7 @@ GameEntity* GameMap::getEntityFromTypeAndName(GameEntityType entityType,
         case GameEntityType::trapEntity:
         case GameEntityType::treasuryObject:
         case GameEntityType::researchEntity:
+        case GameEntityType::giftBoxEntity:
             return getRenderedMovableEntity(entityName);
 
         case GameEntityType::spell:

--- a/source/gamemap/MapLoader.cpp
+++ b/source/gamemap/MapLoader.cpp
@@ -30,6 +30,7 @@
 #include "entities/CreatureDefinition.h"
 #include "entities/EntityLoading.h"
 #include "entities/GameEntity.h"
+#include "entities/GiftBoxEntity.h"
 #include "entities/MapLight.h"
 #include "entities/MissileObject.h"
 #include "entities/ResearchEntity.h"
@@ -534,6 +535,12 @@ bool readGameMapFromFile(const std::string& fileName, GameMap& gameMap)
         return false;
     }
 
+    if(!readGameEntity(gameMap, "GiftBoxEntity", GameEntityType::giftBoxEntity, levelFile))
+    {
+        OD_LOG_WRN("Invalid GiftBoxEntity section");
+        return false;
+    }
+
     if(!readGameEntity(gameMap, "Missiles", GameEntityType::missileObject, levelFile))
     {
         OD_LOG_WRN("Invalid Missiles section");
@@ -767,6 +774,19 @@ void writeGameMapToFile(const std::string& fileName, GameMap& gameMap)
         levelFile << std::endl;
     }
     levelFile << "[/ResearchEntity]" << std::endl;
+
+    levelFile << "\n[GiftBoxEntity]\n";
+    levelFile << "# " << GiftBoxEntity::getGiftBoxEntityStreamFormat() << "\n";
+    for (RenderedMovableEntity* rendered : rendereds)
+    {
+        if(rendered->getObjectType() != GameEntityType::giftBoxEntity)
+            continue;
+
+        rendered->exportHeadersToStream(levelFile);
+        rendered->exportToStream(levelFile);
+        levelFile << std::endl;
+    }
+    levelFile << "[/GiftBoxEntity]" << std::endl;
 
     levelFile << "\n[Missiles]\n";
     levelFile << "# " << MissileObject::getMissileObjectStreamFormat() << "\n";

--- a/source/giftboxes/GiftBoxResearch.cpp
+++ b/source/giftboxes/GiftBoxResearch.cpp
@@ -39,6 +39,18 @@ GiftBoxResearch::GiftBoxResearch(GameMap* gameMap, bool isOnServerMap) :
 {
 }
 
+void GiftBoxResearch::exportToStream(std::ostream& os) const
+{
+    GiftBoxEntity::exportToStream(os);
+    os << mResearchType << "\t";
+}
+
+void GiftBoxResearch::importFromStream(std::istream& is)
+{
+    GiftBoxEntity::importFromStream(is);
+    OD_ASSERT_TRUE(is >> mResearchType);
+}
+
 void GiftBoxResearch::applyEffect()
 {
     if(getSeat() == nullptr)

--- a/source/giftboxes/GiftBoxResearch.cpp
+++ b/source/giftboxes/GiftBoxResearch.cpp
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (C) 2011-2015  OpenDungeons Team
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "giftboxes/GiftBoxResearch.h"
+
+#include "game/Research.h"
+#include "game/Seat.h"
+#include "gamemap/GameMap.h"
+#include "utils/Helper.h"
+#include "utils/LogManager.h"
+
+#include <iostream>
+
+GiftBoxResearch::GiftBoxResearch(GameMap* gameMap, bool isOnServerMap, const std::string& baseName, ResearchType researchType) :
+    GiftBoxEntity(gameMap, isOnServerMap, baseName, "MysteryBox", GiftBoxType::research),
+    mResearchType(researchType)
+{
+    mPrevAnimationState = "Loop";
+    mPrevAnimationStateLoop = true;
+}
+
+GiftBoxResearch::GiftBoxResearch(GameMap* gameMap, bool isOnServerMap) :
+    GiftBoxEntity(gameMap, isOnServerMap),
+    mResearchType(ResearchType::nullResearchType)
+{
+}
+
+void GiftBoxResearch::applyEffect()
+{
+    if(getSeat() == nullptr)
+    {
+        OD_LOG_ERR("null Seat for giftbox=" + getName() + " pos=" + Helper::toString(getPosition()));
+        return;
+    }
+
+    getSeat()->addResearch(mResearchType);
+}

--- a/source/giftboxes/GiftBoxResearch.h
+++ b/source/giftboxes/GiftBoxResearch.h
@@ -31,6 +31,9 @@ public:
     GiftBoxResearch(GameMap* gameMap, bool isOnServerMap, const std::string& baseName, ResearchType researchType);
     GiftBoxResearch(GameMap* gameMap, bool isOnServerMap);
 
+    virtual void exportToStream(std::ostream& os) const override;
+    virtual void importFromStream(std::istream& is) override;
+
     virtual void applyEffect();
 
 private:

--- a/source/giftboxes/GiftBoxResearch.h
+++ b/source/giftboxes/GiftBoxResearch.h
@@ -1,4 +1,4 @@
-/*!
+/*
  *  Copyright (C) 2011-2015  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -15,37 +15,26 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef GAMEENTITYTYPE_H
-#define GAMEENTITYTYPE_H
+#ifndef GIFTBOXRESEARCH_H
+#define GIFTBOXRESEARCH_H
 
+#include "entities/GiftBoxEntity.h"
+
+#include <string>
 #include <iosfwd>
 
-class ODPacket;
+enum class ResearchType;
 
-enum class GameEntityType
+class GiftBoxResearch: public GiftBoxEntity
 {
-    unknown,
-    creature,
-    room,
-    trap,
-    tile,
-    mapLight,
-    spell,
-    buildingObject,
-    treasuryObject,
-    chickenEntity,
-    smallSpiderEntity,
-    craftedTrap,
-    missileObject,
-    persistentObject,
-    trapEntity,
-    researchEntity,
-    giftBoxEntity
+public:
+    GiftBoxResearch(GameMap* gameMap, bool isOnServerMap, const std::string& baseName, ResearchType researchType);
+    GiftBoxResearch(GameMap* gameMap, bool isOnServerMap);
+
+    virtual void applyEffect();
+
+private:
+    ResearchType mResearchType;
 };
 
-ODPacket& operator<<(ODPacket& os, const GameEntityType& type);
-ODPacket& operator>>(ODPacket& is, GameEntityType& type);
-std::ostream& operator<<(std::ostream& os, const GameEntityType& type);
-std::istream& operator>>(std::istream& is, GameEntityType& type);
-
-#endif
+#endif // GIFTBOXRESEARCH_H

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -104,6 +104,8 @@ class GameMode final : public GameEditorModeBase, public InputCommand
     bool showResearchWindow(const CEGUI::EventArgs& = {});
     bool hideResearchWindow(const CEGUI::EventArgs& = {});
     bool toggleResearchWindow(const CEGUI::EventArgs& = {});
+    bool applyResearchWindow(const CEGUI::EventArgs& = {});
+    void closeResearchWindow(bool saveResearch);
 
     //! \brief Shows/hides/toggles the options window
     bool showOptionsWindow(const CEGUI::EventArgs& = {});
@@ -121,6 +123,23 @@ class GameMode final : public GameEditorModeBase, public InputCommand
     void unselectAllTiles() override;
 
     void displayText(const Ogre::ColourValue& txtColour, const std::string& txt) override;
+
+    //! \brief Called when the research window is displayed. This function will call the Seat to get
+    //! the current research tree and update it as the player clicks on the research buttons by calling
+    //! researchButtonTreeClicked
+    void resetResearchTree();
+    //! \brief Called when the player clicks a research in the research tree. Note that resetResearchTree
+    //! should be called before calling researchButtonTreeClicked
+    //! Returns true if the pending list have been changed and false otherwise
+    bool researchButtonTreeClicked(ResearchType type);
+    //! \brief Called when the player closes the research tree. If apply is true, the changes
+    //! should be sent to the server. If false, the changes should be canceled.
+    void endResearchTree(bool apply);
+
+    //! \brief Called at each frame. It checks if the Gui should be refreshed (for example,
+    //! if a research is done) and, if yes, refreshes accordingly.
+    //! \param forceRefresh Refresh the gui even if no changes was declared by the local player Seat.
+    void refreshGuiResearch(bool forceRefresh = false);
 
 protected:
     bool onClickYesQuitMenu(const CEGUI::EventArgs& /*arg*/);
@@ -152,6 +171,12 @@ private:
     //! \brief The settings window.
     SettingsWindow mSettings;
 
+    //! \brief Researches pending (Client side). This is copied from the seat for temporary changes while the
+    //! player clicks on the research tree window
+    std::vector<ResearchType> mResearchPending;
+
+    bool mIsResearchWindowOpen;
+
     //! \brief Set the help window (quite long) text.
     void setHelpWindowText();
 
@@ -159,17 +184,16 @@ private:
     //! It will handle the potential mouse wheel logic
     void handleMouseWheel(const OIS::MouseEvent& arg);
 
-    //! \brief Called at each frame. It checks if the Gui should be refreshed (for example,
-    //! if a research is done) and, if yes, refreshes accordingly.
-    //! \param forceRefresh Refresh the gui even if no changes was declared by the local player Seat.
-    void refreshGuiResearch(bool forceRefresh = false);
-
-    //! \brief Set the state of the given research button accordingly
-    //! to the research type given.
+    //! \brief Set the state of the given research button accordingly to the research type given.
     //! \note: Called by refreshGuiResearch() for each researchType.
     void refreshResearchButtonState(ResearchType resType);
 
+    //! \brief sets cegui button name according to the given resType
+    //! returns true is the button name is found for the given resType and false otherwise
+    bool researchButtonFromType(ResearchType resType, std::string& researchWidgetButton, std::string& useWidgetButton);
+
     void connectSpellSelect(const std::string& buttonName, SpellType spellType);
+    void connectResearchSelect(const std::string& buttonName, ResearchType type);
 
     //! \brief Tells whether the latest mouse click was made on a relevant CEGUI widget,
     //! and thus, the game should ignore it.

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -915,24 +915,6 @@ bool ODClient::processOneClientSocketMessage()
             break;
         }
 
-        case ServerNotificationType::researchStarted:
-        {
-            ResearchType resType = ResearchType::nullResearchType;
-            OD_ASSERT_TRUE(packetReceived >> resType);
-
-            getPlayer()->getSeat()->setNextResearch(resType);
-            break;
-        }
-
-        case ServerNotificationType::researchWaiting:
-        {
-            ResearchType resType = ResearchType::nullResearchType;
-            OD_ASSERT_TRUE(packetReceived >> resType);
-
-            getPlayer()->getSeat()->addResearchWaiting(resType);
-            break;
-        }
-
         case ServerNotificationType::researchesDone:
         {
             uint32_t nbItems;

--- a/source/network/ServerNotification.h
+++ b/source/network/ServerNotification.h
@@ -80,8 +80,6 @@ enum class ServerNotificationType
     releaseCarriedEntity,
 
     researchTree,
-    researchStarted, // Warns a client a new research has started.
-    researchWaiting, // Tells the client a research entity is waiting for research info data
     researchesDone,
 
     setSpellCooldown,

--- a/source/rooms/RoomDungeonTemple.cpp
+++ b/source/rooms/RoomDungeonTemple.cpp
@@ -20,6 +20,7 @@
 #include "game/Seat.h"
 #include "gamemap/GameMap.h"
 #include "entities/Creature.h"
+#include "entities/GiftBoxEntity.h"
 #include "entities/PersistentObject.h"
 #include "entities/ResearchEntity.h"
 #include "entities/Tile.h"
@@ -93,48 +94,66 @@ void RoomDungeonTemple::destroyMeshLocal()
 
 bool RoomDungeonTemple::hasCarryEntitySpot(GameEntity* carriedEntity)
 {
-    if(carriedEntity->getObjectType() != GameEntityType::researchEntity)
-        return false;
-
-    // We accept any researchEntity
-    return true;
+    switch(carriedEntity->getObjectType())
+    {
+        case GameEntityType::giftBoxEntity:
+        case GameEntityType::researchEntity:
+            return true;
+        default:
+            return false;
+    }
 }
 
 Tile* RoomDungeonTemple::askSpotForCarriedEntity(GameEntity* carriedEntity)
 {
-    if(carriedEntity->getObjectType() != GameEntityType::researchEntity)
+    switch(carriedEntity->getObjectType())
     {
-        OD_LOG_ERR("room=" + getName() + ", entity=" + carriedEntity->getName());
-        return nullptr;
+        case GameEntityType::giftBoxEntity:
+        case GameEntityType::researchEntity:
+            return getCentralTile();
+        default:
+            OD_LOG_ERR("room=" + getName() + ", entity=" + carriedEntity->getName());
+            return nullptr;
     }
-
-    // We accept any researchEntity
-    return getCentralTile();
 }
 
 void RoomDungeonTemple::notifyCarryingStateChanged(Creature* carrier, GameEntity* carriedEntity)
 {
-    if(carriedEntity->getObjectType() != GameEntityType::researchEntity)
-    {
-        OD_LOG_ERR("room=" + getName() + ", entity=" + carriedEntity->getName());
-        return;
-    }
-
     // We check if the carrier is at the expected destination. If not on the wanted tile,
-    // we don't accept the researchEntity
-    // Note that if the wanted tile were to move during the transport, the researchEntity
+    // we don't accept the entity
+    // Note that if the wanted tile were to move during the transport, the carried entity
     // will be dropped at its original destination and will become available again so there
     // should be no problem
     Tile* carrierTile = carrier->getPositionTile();
     if(carrierTile != getCentralTile())
         return;
 
-    // We notify the player that the research is now available and we delete the researchEntity
-    ResearchEntity* researchEntity = static_cast<ResearchEntity*>(carriedEntity);
-    getSeat()->addResearchPoints(researchEntity->getResearchPoints());
-    researchEntity->removeEntityFromPositionTile();
-    researchEntity->removeFromGameMap();
-    researchEntity->deleteYourself();
+    switch(carriedEntity->getObjectType())
+    {
+        case GameEntityType::giftBoxEntity:
+        {
+            // We apply the gift box effect
+            GiftBoxEntity* giftBox = static_cast<GiftBoxEntity*>(carriedEntity);
+            giftBox->applyEffect();
+            giftBox->removeEntityFromPositionTile();
+            giftBox->removeFromGameMap();
+            giftBox->deleteYourself();
+            return;
+        }
+        case GameEntityType::researchEntity:
+        {
+            // We notify the player that the research is now available and we delete the researchEntity
+            ResearchEntity* researchEntity = static_cast<ResearchEntity*>(carriedEntity);
+            getSeat()->addResearchPoints(researchEntity->getResearchPoints());
+            researchEntity->removeEntityFromPositionTile();
+            researchEntity->removeFromGameMap();
+            researchEntity->deleteYourself();
+            return;
+        }
+        default:
+            OD_LOG_ERR("room=" + getName() + ", entity=" + carriedEntity->getName());
+            return;
+    }
 }
 
 void RoomDungeonTemple::restoreInitialEntityState()

--- a/source/rooms/RoomDungeonTemple.cpp
+++ b/source/rooms/RoomDungeonTemple.cpp
@@ -131,7 +131,7 @@ void RoomDungeonTemple::notifyCarryingStateChanged(Creature* carrier, GameEntity
 
     // We notify the player that the research is now available and we delete the researchEntity
     ResearchEntity* researchEntity = static_cast<ResearchEntity*>(carriedEntity);
-    getSeat()->addResearch(researchEntity->getResearchType());
+    getSeat()->addResearchPoints(researchEntity->getResearchPoints());
     researchEntity->removeEntityFromPositionTile();
     researchEntity->removeFromGameMap();
     researchEntity->deleteYourself();

--- a/source/rooms/RoomLibrary.h
+++ b/source/rooms/RoomLibrary.h
@@ -61,6 +61,9 @@ public:
     virtual void removeCreatureUsingRoom(Creature* c) override;
     virtual void absorbRoom(Room *r) override;
 
+    virtual void exportToStream(std::ostream& os) const override;
+    virtual void importFromStream(std::istream& is) override;
+
     static void checkBuildRoom(GameMap* gameMap, const InputManager& inputManager, InputCommand& inputCommand);
     static bool buildRoom(GameMap* gameMap, Player* player, ODPacket& packet);
     static bool buildRoomOnTiles(GameMap* gameMap, Player* player, const std::vector<Tile*>& tiles);
@@ -80,6 +83,7 @@ private:
         Ogre::Real& wantedX, Ogre::Real& wantedY);
     std::vector<Tile*> mUnusedSpots;
     std::map<Creature*,Tile*> mCreaturesSpots;
+    int32_t mResearchPoints;
 };
 
 #endif // ROOMLIBRARY_H


### PR DESCRIPTION
With this PR:
- Library now only releases books that represents a fixed amount of points
- When enough points are gathered, the currently pending research is unlocked
- Researches pending order can be changed. If you click a pending research, it will be canceled. If you click a non pending research, it will be queued
- Note that if you click a research that has required researches not pending, they will be automatically selected
- If a research is completed while the research tree is displayed, the research tree should be correctly adapted ( @akien-mga I'm looking at you right now ;-) )
- A research can still be dropped by a creature (can be tested in the skirmish small test map 2v2). But now, it is a gift box ( @Danimal696 note that I've let the mesh be easily changeable so we can later use the grimoire if preferred but right now, it was an occasion to introduce the gift box mesh and ATM, particle effects can only be used on creatures)
- Note that if you click a research with a dependency not allowed, it won't be selected (can be tested in the skirmish small test map 2v2 by selecting boulder trap). However, the corresponding research is not unavailable because we could later unallow a research to have the player kill some creature that will release the research and unlock the tree)
