### PR TITLE
Notify player when the research queue is empty

### DIFF
--- a/source/game/Player.cpp
+++ b/source/game/Player.cpp
@@ -33,6 +33,7 @@ Player::Player(GameMap* gameMap, int32_t id) :
     mGameMap(gameMap),
     mSeat(nullptr),
     mIsHuman(false),
+    mNoResearchInQueueTime(0.0f),
     mNoTreasuryAvailableTime(0.0f),
     mHasLost(false),
     mSpellsCooldown(std::vector<uint32_t>(static_cast<uint32_t>(SpellType::nbSpells), 0))

--- a/source/game/Player.h
+++ b/source/game/Player.h
@@ -164,7 +164,11 @@ public:
     //! the place where the fight is happening and player is the Player actually fighting
     void notifyTeamFighting(Player* player, Tile* tile);
 
-    //! \brief Notify the player is fighting
+    //! \brief Notify the player that they are not research anything
+    //! Should be called on the server game map for human players only
+    void notifyNoResearchInQueue();
+
+    //! \brief Notify the player that no treasury tiles are available for gold storage
     //! Should be called on the server game map for human players only
     void notifyNoTreasuryAvailable();
 
@@ -174,7 +178,7 @@ public:
     //! the time remaining of PlayerEvent class is not relevant on client side
     void updateEvents(const std::vector<PlayerEvent*>& events);
 
-    //! \brief get the next event. After index. If index > events size, the first one is
+    //! \brief Get the next event. After index. If index > events size, the first one is
     //! sent. When the function returns, index is set to the index of the returned event
     //! and it returns the PlayerEvent if any (nullptr is none).
     //! Note that on client side, PlayerEvent::mTimeRemain is not relevant
@@ -211,6 +215,10 @@ private:
 
     //! True: player is human. False: player is a computer/inactive.
     bool mIsHuman;
+
+    //! \brief This counter tells for how much time is left before considering
+    //! the player should be notified again that he has not queued a research.
+    float mNoResearchInQueueTime;
 
     //! \brief This counter tells for how much time is left before considering
     //! the player should be notified again that he has no free space to store gold.

--- a/source/game/PlayerFunctions.cpp
+++ b/source/game/PlayerFunctions.cpp
@@ -19,6 +19,7 @@
 
 #include "entities/GameEntity.h"
 #include "entities/Tile.h"
+#include "game/ResearchManager.h"
 #include "game/Seat.h"
 #include "gamemap/GameMap.h"
 #include "gamemap/Pathfinding.h"
@@ -437,7 +438,7 @@ void Player::upkeepPlayer(double timeSinceLastUpkeep)
         else
             mNoResearchInQueueTime = 0.0f;
             // Reprint the warning if there is still no research being done
-            if(getSeat() != nullptr and !getSeat()->isResearching())
+            if(getSeat() != nullptr and !getSeat()->isResearching() and !ResearchManager::isAllResearchesDoneForSeat(getSeat()))
                 notifyNoResearchInQueue();
     }
 

--- a/source/game/PlayerFunctions.cpp
+++ b/source/game/PlayerFunctions.cpp
@@ -40,9 +40,11 @@ const float BATTLE_TIME_COUNT = 10.0f;
 //! Note that the distance is squared (100 would mean 10 tiles)
 const int MIN_DIST_EVENT_SQUARED = 100;
 
-//! \brief The number of seconds the local player will not be notified again for looping notifications
-//! (no treasury tile available, no research in queue, etc.)
-const float NOTIFICATION_TIME_COUNT = 30.0f;
+//! \brief The number of seconds the local player will not be notified again if the research queue is empty
+const float NO_RESEARCH_TIME_COUNT = 60.0f;
+
+//! \brief The number of seconds the local player will not be notified again if no treasury is available
+const float NO_TREASURY_TIME_COUNT = 30.0f;
 
 void PlayerEvent::exportToPacket(GameMap* gameMap, ODPacket& os)
 {
@@ -255,7 +257,7 @@ void Player::notifyNoResearchInQueue()
 {
     if(mNoResearchInQueueTime == 0.0f)
     {
-        mNoResearchInQueueTime = NOTIFICATION_TIME_COUNT;
+        mNoResearchInQueueTime = NO_RESEARCH_TIME_COUNT;
 
         std::string chatMsg = "Your research queue is empty, while there are still skills that could be unlocked.";
         ServerNotification *serverNotification = new ServerNotification(
@@ -269,7 +271,7 @@ void Player::notifyNoTreasuryAvailable()
 {
     if(mNoTreasuryAvailableTime == 0.0f)
     {
-        mNoTreasuryAvailableTime = NOTIFICATION_TIME_COUNT;
+        mNoTreasuryAvailableTime = NO_TREASURY_TIME_COUNT;
 
         std::string chatMsg = "No treasury available. You should build a bigger one.";
         ServerNotification *serverNotification = new ServerNotification(

--- a/source/game/PlayerFunctions.cpp
+++ b/source/game/PlayerFunctions.cpp
@@ -438,7 +438,7 @@ void Player::upkeepPlayer(double timeSinceLastUpkeep)
         else
             mNoResearchInQueueTime = 0.0f;
             // Reprint the warning if there is still no research being done
-            if(getSeat() != nullptr and !getSeat()->isResearching() and !ResearchManager::isAllResearchesDoneForSeat(getSeat()))
+            if(getSeat() != nullptr && !getSeat()->isResearching() && !ResearchManager::isAllResearchesDoneForSeat(getSeat()))
                 notifyNoResearchInQueue();
     }
 

--- a/source/game/PlayerFunctions.cpp
+++ b/source/game/PlayerFunctions.cpp
@@ -434,6 +434,9 @@ void Player::upkeepPlayer(double timeSinceLastUpkeep)
             mNoResearchInQueueTime -= timeSinceLastUpkeep;
         else
             mNoResearchInQueueTime = 0.0f;
+            // Reprint the warning if there is still no research being done
+            if(getSeat() != nullptr and !getSeat()->isResearching())
+                notifyNoResearchInQueue();
     }
 
     if(mNoTreasuryAvailableTime > 0.0f)

--- a/source/game/ResearchManager.cpp
+++ b/source/game/ResearchManager.cpp
@@ -466,9 +466,11 @@ bool ResearchManager::isAllResearchesDoneForSeat(const Seat* seat)
     {
         if(research == nullptr)
             continue;
-
-        if(research->mResearch->canBeResearched(seat->getResearchDone()) && !seat->isResearchDone(research->mResearch->getType()))
-            return false;
+        if(seat->isResearchDone(research->mResearch->getType()))
+            continue;
+        if(!research->mResearch->canBeResearched(seat->getResearchDone()))
+            continue;
+        return false;
     }
     return true;
 }

--- a/source/game/ResearchManager.cpp
+++ b/source/game/ResearchManager.cpp
@@ -457,6 +457,22 @@ bool ResearchManager::isTrapAvailable(TrapType type, const Seat* seat)
     return seat->isResearchDone(resType);
 }
 
+bool ResearchManager::isAllResearchesDoneForSeat(const Seat* seat)
+{
+    if(seat->isResearching())
+        return false;
+
+    for(const ResearchDef* research : getResearchManager().mResearches)
+    {
+        if(research == nullptr)
+            continue;
+
+        if(research->mResearch->canBeResearched(seat->getResearchDone()) && !seat->isResearchDone(research->mResearch->getType()))
+            return false;
+    }
+    return true;
+}
+
 const Research* ResearchManager::getResearch(ResearchType resType)
 {
     uint32_t index = static_cast<uint32_t>(resType);
@@ -473,22 +489,6 @@ const Research* ResearchManager::getResearch(ResearchType resType)
         return nullptr;
     }
     return research->mResearch;
-}
-
-std::vector<ResearchType> ResearchManager::getRemainingResearchesForSeat(const Seat* seat)
-{
-    std::vector<ResearchType> allowedResTypes;
-    for(const ResearchDef* research : getResearchManager().mResearches)
-    {
-        if(research == nullptr)
-            continue;
-
-        if(research->mResearch->canBeResearched(seat->getResearchDone()))
-        {
-            allowedResTypes.push_back(research->mResearch->getType());
-        }
-    }
-    return allowedResTypes;
 }
 
 void ResearchManager::listAllResearches(const std::function<void(const std::string&, const std::string&,

--- a/source/game/ResearchManager.cpp
+++ b/source/game/ResearchManager.cpp
@@ -475,6 +475,22 @@ const Research* ResearchManager::getResearch(ResearchType resType)
     return research->mResearch;
 }
 
+std::vector<ResearchType> ResearchManager::getRemainingResearchesForSeat(const Seat* seat)
+{
+    std::vector<ResearchType> allowedResTypes;
+    for(const ResearchDef* research : getResearchManager().mResearches)
+    {
+        if(research == nullptr)
+            continue;
+
+        if(research->mResearch->canBeResearched(seat->getResearchDone()))
+        {
+            allowedResTypes.push_back(research->mResearch->getType());
+        }
+    }
+    return allowedResTypes;
+}
+
 void ResearchManager::listAllResearches(const std::function<void(const std::string&, const std::string&,
         const std::string&, ResearchType)>& func)
 {

--- a/source/game/ResearchManager.h
+++ b/source/game/ResearchManager.h
@@ -72,6 +72,8 @@ public:
 
     static const Research* getResearch(ResearchType resType);
 
+    static std::vector<ResearchType> getRemainingResearchesForSeat(const Seat* seat);
+
     static void listAllResearches(const std::function<void(const std::string&, const std::string&,
         const std::string&, ResearchType)>& func);
 

--- a/source/game/ResearchManager.h
+++ b/source/game/ResearchManager.h
@@ -70,9 +70,10 @@ public:
     //! should be done on server side to avoid cheating
     static bool isTrapAvailable(TrapType type, const Seat* seat);
 
-    static const Research* getResearch(ResearchType resType);
+    //! \brief Checks if the given seat has already researched all the allowed researches
+    static bool isAllResearchesDoneForSeat(const Seat* seat);
 
-    static std::vector<ResearchType> getRemainingResearchesForSeat(const Seat* seat);
+    static const Research* getResearch(ResearchType resType);
 
     static void listAllResearches(const std::function<void(const std::string&, const std::string&,
         const std::string&, ResearchType)>& func);

--- a/source/game/SeatFunctions.cpp
+++ b/source/game/SeatFunctions.cpp
@@ -1074,7 +1074,7 @@ void Seat::setNextResearch(ResearchType researchedType)
         mCurrentResearchType = ResearchType::nullResearchType;
 
         // Notify the player that no research is in the queue if there are still available researches
-        if(ResearchManager::getRemainingResearchesForSeat(this).size() == 0)
+        if(ResearchManager::isAllResearchesDoneForSeat(this))
             return;
 
         if(getPlayer() != nullptr && getPlayer()->getIsHuman())

--- a/source/game/SeatFunctions.cpp
+++ b/source/game/SeatFunctions.cpp
@@ -1072,6 +1072,10 @@ void Seat::setNextResearch(ResearchType researchedType)
     if(mResearchPending.empty())
     {
         mCurrentResearchType = ResearchType::nullResearchType;
+        // Notify the player that no research is in the queue
+        // TODO: Do not notify if there is nothing left to research in the tree
+        if(getPlayer() != nullptr && getPlayer()->getIsHuman())
+            getPlayer()->notifyNoResearchInQueue();
         return;
     }
 

--- a/source/game/SeatFunctions.cpp
+++ b/source/game/SeatFunctions.cpp
@@ -1072,8 +1072,11 @@ void Seat::setNextResearch(ResearchType researchedType)
     if(mResearchPending.empty())
     {
         mCurrentResearchType = ResearchType::nullResearchType;
-        // Notify the player that no research is in the queue
-        // TODO: Do not notify if there is nothing left to research in the tree
+
+        // Notify the player that no research is in the queue if there are still available researches
+        if(ResearchManager::getRemainingResearchesForSeat(this).size() == 0)
+            return;
+
         if(getPlayer() != nullptr && getPlayer()->getIsHuman())
             getPlayer()->notifyNoResearchInQueue();
         return;


### PR DESCRIPTION
Part of #869. What is missing is to add a check whether there are
actual skills left to be researched or not, and also make sure the
warning is displayed if there are no researches in queue from the start
(i.e. not only after a valid research is added).
