### PR TITLE
Add support for changing input grab in the settings window

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,20 +59,6 @@ if(OD_BUILD_TESTING)
     include(CTest)
 endif()
 
-if (UNIX AND NOT APPLE)
-    # Linux option - Do not grab the keyboard when using OIS
-    # This is breaking the game's input on certain linux distributions and thus, must stay an option for now...
-    option(OD_LINUX_NO_KEYBOARD_GRAB "Do not grab keyboard input when using OIS under Linux. Permits input in other applications." ON)
-
-    # Defines the value for the preprocessor.
-    if(OD_LINUX_NO_KEYBOARD_GRAB)
-        message(STATUS "Linux (OIS): x11_keyboard_grab = false")
-        add_definitions(-DOD_LINUX_NO_KEYBOARD_GRAB)
-    else()
-        message(STATUS "Linux (OIS): x11_keyboard_grab = true")
-    endif()
-endif()
-
 ##################################
 #### Useful variables ############
 ##################################

--- a/gui/WindowSettings.layout
+++ b/gui/WindowSettings.layout
@@ -85,6 +85,26 @@
                     </Window>
                 </Window>
             </Window>
+            <Window type="DefaultWindow" name="Input" >
+                <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
+                <Property name="Text" value="Input" />
+                <Property name="MaxSize" value="{{1,0},{1,0}}" />
+                <Property name="Visible" value="False" />
+                <Property name="RiseOnClickEnabled" value="False" />
+                <Window type="OD/ScrollablePane" name="InputSP" >
+                    <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
+                    <Window type="OD/Checkbox" name="KeyboardGrabCheckbox" >
+                        <Property name="Area" value="{{0,32},{0,40},{0,150},{0,60}}" />
+                        <Property name="Text" value="Keyboard grab" />
+                        <Property name="TooltipText" value="When checked, the keyboard is grabbed and can't be used in other applications (requires restart)." />
+                    </Window>
+                    <Window type="OD/Checkbox" name="MouseGrabCheckbox" >
+                        <Property name="Area" value="{{0,32},{0,80},{0,150},{0,100}}" />
+                        <Property name="Text" value="Mouse grab" />
+                        <Property name="TooltipText" value="When checked, the mouse is grabbed and can't be used in other applications (requires restart)." />
+                    </Window>
+                </Window>
+            </Window>
             <Window type="DefaultWindow" name="Game" >
                 <Property name="Area" value="{{0,0},{0,0},{1,0},{1,0}}" />
                 <Property name="Text" value="Game" />

--- a/source/modes/InputManager.cpp
+++ b/source/modes/InputManager.cpp
@@ -17,7 +17,9 @@
 
 #include "InputManager.h"
 
+#include "utils/ConfigManager.h"
 #include "utils/LogManager.h"
+
 #include <OIS/OISMouse.h>
 #include <OIS/OISKeyboard.h>
 #include <OIS/OISInputManager.h>
@@ -55,22 +57,22 @@ InputManager::InputManager(Ogre::RenderWindow* renderWindow):
     std::ostringstream windowHndStr;
     windowHndStr << windowHnd;
 
+    ConfigManager& config = ConfigManager::getSingleton();
+    bool mouseGrab = config.getInputValue(Config::MOUSE_GRAB, "No", false) == "Yes";
+    bool keyboardGrab = config.getInputValue(Config::KEYBOARD_GRAB, "No", false) == "Yes";
+
     //setup parameter list for OIS
     OIS::ParamList paramList;
     paramList.insert(std::make_pair(std::string("WINDOW"), windowHndStr.str()));
 #if defined OIS_WIN32_PLATFORM
     paramList.insert(std::make_pair(std::string("w32_mouse"), std::string("DISCL_FOREGROUND" )));
-    paramList.insert(std::make_pair(std::string("w32_mouse"), std::string("DISCL_NONEXCLUSIVE")));
+    paramList.insert(std::make_pair(std::string("w32_mouse"), std::string(mouseGrab ? "DISCL_EXCLUSIVE" : "DISCL_NONEXCLUSIVE")));
     paramList.insert(std::make_pair(std::string("w32_keyboard"), std::string("DISCL_FOREGROUND")));
-    paramList.insert(std::make_pair(std::string("w32_keyboard"), std::string("DISCL_NONEXCLUSIVE")));
+    paramList.insert(std::make_pair(std::string("w32_keyboard"), std::string(keyboardGrab ? "DISCL_EXCLUSIVE" : "DISCL_NONEXCLUSIVE")));
 #elif defined OIS_LINUX_PLATFORM
-    paramList.insert(std::make_pair(std::string("x11_mouse_grab"), std::string("false")));
+    paramList.insert(std::make_pair(std::string("x11_mouse_grab"), std::string(mouseGrab ? "true" : "false")));
     paramList.insert(std::make_pair(std::string("x11_mouse_hide"), std::string("false")));
-#if defined OD_LINUX_NO_KEYBOARD_GRAB
-    paramList.insert(std::make_pair(std::string("x11_keyboard_grab"), std::string("false")));
-#else
-    paramList.insert(std::make_pair(std::string("x11_keyboard_grab"), std::string("true")));
-#endif
+    paramList.insert(std::make_pair(std::string("x11_keyboard_grab"), std::string(keyboardGrab ? "true" : "false")));
     paramList.insert(std::make_pair(std::string("XAutoRepeatOn"), std::string("true")));
 #endif
 

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -154,6 +154,15 @@ void SettingsWindow::initConfig()
     if (!nickname.empty())
         nicknameEb->setText(reinterpret_cast<const CEGUI::utf8*>(nickname.c_str()));
 
+    // Input
+    CEGUI::ToggleButton* keyboardGrabCheckbox = static_cast<CEGUI::ToggleButton*>(
+        mRootWindow->getChild("SettingsWindow/MainTabControl/Input/InputSP/KeyboardGrabCheckbox"));
+    keyboardGrabCheckbox->setSelected(config.getInputValue(Config::KEYBOARD_GRAB, "No", false) == "Yes");
+
+    CEGUI::ToggleButton* mouseGrabCheckbox = static_cast<CEGUI::ToggleButton*>(
+        mRootWindow->getChild("SettingsWindow/MainTabControl/Input/InputSP/MouseGrabCheckbox"));
+    mouseGrabCheckbox->setSelected(config.getInputValue(Config::MOUSE_GRAB, "No", false) == "Yes");
+
     // Audio
     std::string volumeStr = config.getAudioValue(Config::MUSIC_VOLUME, std::string(), false);
     float volume = volumeStr.empty() ? sf::Listener::getGlobalVolume() : Helper::toFloat(volumeStr);
@@ -311,6 +320,15 @@ void SettingsWindow::saveConfig()
     CEGUI::Editbox* usernameEb = static_cast<CEGUI::Editbox*>(
             mRootWindow->getChild("SettingsWindow/MainTabControl/Game/GameSP/NicknameEdit"));
     config.setGameValue(Config::NICKNAME, usernameEb->getText().c_str());
+
+    // Input
+    CEGUI::ToggleButton* keyboardGrabCheckbox = static_cast<CEGUI::ToggleButton*>(
+        mRootWindow->getChild("SettingsWindow/MainTabControl/Input/InputSP/KeyboardGrabCheckbox"));
+    config.setInputValue(Config::KEYBOARD_GRAB, keyboardGrabCheckbox->isSelected() ? "Yes" : "No");
+
+    CEGUI::ToggleButton* mouseGrabCheckbox = static_cast<CEGUI::ToggleButton*>(
+        mRootWindow->getChild("SettingsWindow/MainTabControl/Input/InputSP/MouseGrabCheckbox"));
+    config.setInputValue(Config::MOUSE_GRAB, mouseGrabCheckbox->isSelected() ? "Yes" : "No");
 
     // Audio
     CEGUI::Slider* volumeSlider = static_cast<CEGUI::Slider*>(

--- a/source/utils/ConfigManager.h
+++ b/source/utils/ConfigManager.h
@@ -55,6 +55,9 @@ const std::string VSYNC = "VSync";
 const std::string FULL_SCREEN = "Full Screen";
 // Audio
 const std::string MUSIC_VOLUME = "Music Volume";
+// Input
+const std::string KEYBOARD_GRAB = "Keyboard Grab";
+const std::string MOUSE_GRAB = "Mouse Grab";
 // Game
 const std::string NICKNAME = "Nickname";
 }


### PR DESCRIPTION
Currently settings are only applied after a restart. To prevent the need for
a restart, the InputManager should be destroyed and recreated with the new
parameters.

The feature is implemented for both X11 and Win32, though untested on Win32.
