### PR TITLE
Fixed segfault when exiting the settings menu

### DIFF
--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -237,12 +237,19 @@ void SettingsWindow::initConfig()
     }
 
     //! First of all, clear up the previously created windows.
+    CEGUI::WindowManager& winMgr = CEGUI::WindowManager::getSingleton();
     CEGUI::Window* parentWindow = mSettingsWindow->getChild("MainTabControl/Video/VideoSP/");
     for (CEGUI::Window* win : mCustomVideoComboBoxes)
-        parentWindow->destroyChild(win);
+    {
+        parentWindow->removeChild(win);
+        winMgr.destroyWindow(win);
+    }
     mCustomVideoComboBoxes.clear();
     for (CEGUI::Window* win : mCustomVideoTexts)
-        parentWindow->destroyChild(win);
+    {
+        parentWindow->removeChild(win);
+        winMgr.destroyWindow(win);
+    }
     mCustomVideoTexts.clear();
 
     // Find every other config options and add them to the config


### PR DESCRIPTION
Seems like scrollpanes do not like when calling destroyChild.

It seems like systematic because I experienced the same with an ingame menu with a scrollpane I've recently added
