### PR TITLE
Editor: activate newly-placed traps by default

### DIFF
--- a/source/traps/Trap.cpp
+++ b/source/traps/Trap.cpp
@@ -291,6 +291,10 @@ void Trap::setupTrap(const std::string& name, Seat* seat, const std::vector<Tile
         // Allied seats with the creator do see the trap from the start
         trapTileData->seatsSawTriggering(alliedSeats);
         tile->setCoveringBuilding(this);
+
+        // In the editor, activate each trap tile by default
+        if(getGameMap()->isInEditorMode())
+            activate(tile);
     }
 }
 


### PR DESCRIPTION
Fixes #988.

I'm not 100% sure this is the best way to do it, so I'm open to critics :)
