### PR TITLE
Improve BASH unit test script to remove hardcoded test names

### DIFF
--- a/scripts/unix/run_unit_tests.sh
+++ b/scripts/unix/run_unit_tests.sh
@@ -2,7 +2,7 @@
 # Shell script to run the unit tests for OpenDungeons
 
 OD_BINARY="opendungeons"
-UNIT_TESTS="00-ConsoleInterface 00-Random Goal 00-ODPacket 00-Pathfinding aa-LaunchGame"
+TEST_BASENAME="boosttest-source_tests-"
 
 if [ ! -x $(pwd)/${OD_BINARY} ]; then
     echo "Can't find the ${OD_BINARY} binary in the current directory, aborting."
@@ -12,18 +12,31 @@ fi
 TESTS_PASSED=""
 TESTS_FAILED=""
 
-for test in ${UNIT_TESTS}; do
+# The boost test filenames are supposed to be as follows: ${TEST_BASENAME}LL-*
+# LL=name of the level server the game should launch (00 if none).
+for testbin in boosttest-source_tests-*; do
+    test=$(echo ${testbin} |sed 's/'${TEST_BASENAME}'//')
     echo -e "\n### Unit test: ${test}\n"
 
-    if [ "${test}" == "aa-LaunchGame" ]; then
-        ./${OD_BINARY} --server UnitTest.level --port 32222 --log srvLog.txt &
+    pid=0
+    level=$(echo ${test} |cut -d'-' -f1)
+    if [ "${level}" != "00" ]; then
+        echo "--- Starting a server with map ${level}.level ---"
+        ./${OD_BINARY} --server "${level}.level" --port 32222 --log srvLog.txt &
+        pid=$!
     fi
-    ./boosttest-source_tests-${test}
+
+    ./${testbin}
 
     if [ $? == 0 ]; then
         TESTS_PASSED+=" ${test}"
     else
         TESTS_FAILED+=" ${test}"
+    fi
+
+    if [ ${pid} -ne 0 ]; then
+        kill $pid
+        wait $pid  # Wait for the process to terminate
     fi
 done
 
@@ -32,6 +45,6 @@ echo "The following tests were PASSED: ${TESTS_PASSED}"
 echo "The following tests were FAILED: ${TESTS_FAILED}"
 echo -e "#####################################\n"
 
-if [ ! -z ${TESTS_FAILED} ]; then
+if [ ! -z "${TESTS_FAILED}" ]; then
     exit 2
 fi


### PR DESCRIPTION
The tests are now named with a $basename-LL-$test convention where LL is the name of the level that should be run in the server, if any (00 if none).
Also fixed final check to know if some tests failed that would not work on strings with spaces (i.e. more than one failed test).
