### PR TITLE
Fix scoping issue in LogSinkOgre

### DIFF
--- a/source/utils/LogSinkOgre.cpp
+++ b/source/utils/LogSinkOgre.cpp
@@ -71,7 +71,7 @@ LogSinkOgre::LogSinkOgre(const std::string& userDataPath)
     /* Using a separate log if ogre doesn't have thread support as
     * as log writes from ogre itself won't be thread-safe in this case.
     */
-    mGameLog = mLogManager->createLog(userDataPath + GAMELOG_NAME);
+    mGameLog = mLogManager->createLog(userDataPath + LogManager::GAMELOG_NAME);
 #else
     mGameLog = mLogManager->createLog(userDataPath, true, true, false);
 #endif


### PR DESCRIPTION
A user reported this build issue on IRC while using Gentoo's ebuild for OD:

/var/tmp/portage/games-strategy/opendungeons-9999/work/opendungeons-9999/source/utils/LogSinkOgre.cpp:74:54: error: ‘GAMELOG_NAME’ was not declared in this scope
     mGameLog = mLogManager->createLog(userDataPath + GAMELOG_NAME);
                                                      ^
