### PR TITLE
Improve travis-ci build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,26 +19,20 @@ compiler:
     #- binutils-dev
 
 before_install:
-  - export HOME_DIR=`pwd`; gcc --version
+  - gcc --version
   - sudo apt-get update -qq
 # OD dependencies
-  - sudo apt-get install -y cmake libogre-1.9-dev libsfml-dev libois-dev
+  - sudo apt-get install -y cmake pkg-config libogre-1.9-dev libopenal-dev libsfml-dev libois-dev
   - sudo apt-get install -y libboost-filesystem-dev libboost-locale-dev libboost-program-options-dev libboost-date-time-dev libboost-thread-dev libboost-system-dev libboost-test-dev
-# CEGUI dependencies
-  - sudo apt-get install -y libfreetype6-dev libopenal-dev libexpat1-dev libsilly-dev
-# CEGUI is not packaged. We need to compile it ourself. Note that we could also compile it and download binaries if need be
-  - wget http://sourceforge.net/projects/crayzedsgui/files/cegui-0.8.4.tar.bz2/download -O /tmp/cegui.tar.bz2
-  - cd /tmp
-  - sudo tar -xjf cegui.tar.bz2
-  - cd cegui-0.8.4
-  - sudo cmake . -DCEGUI_HAS_FREETYPE=ON -DCEGUI_BUILD_IMAGECODEC_SILLY=ON -DCEGUI_BUILD_XMLPARSER_EXPAT=ON -DCEGUI_BUILD_RENDERER_OGRE=ON -DCEGUI_BUILD_PYTHON_MODULES=OFF -DCEGUI_SAMPLES_ENABLED=OFF
-  - sudo make install
-  - cd $HOME_DIR
+# Install CEGUI from GetDeb
+  - wget -q -O - http://archive.getdeb.net/getdeb-archive.key | sudo apt-key add -
+  - sudo sh -c 'echo "deb http://archive.getdeb.net/ubuntu trusty-getdeb games" >> /etc/apt/sources.list.d/getdeb.list'
+  - sudo apt-get update -qq; sudo apt-get install -y libcegui-0.8-dev
 
 script:
-  - cmake . -DOD_BUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=./install-root
-  - make -j2 && make install
-  - find ./install-root
+  - cmake . -DOD_BUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
+  - make -j2
+  - make install DESTDIR=./install-root
   - ./scripts/unix/run_unit_tests.sh
 
 #cache: apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
+language: cpp
 
+sudo: required
 dist: trusty
 
 os:
@@ -9,43 +11,34 @@ os:
 compiler:
   - gcc
 
-addons:
-  apt:
-    packages:
-    - make
-    - cmake
-    - binutils-dev
+#addons:
+  #apt:
+    #packages:
+    #- make
+    #- cmake
+    #- binutils-dev
 
 before_install:
-# we need a repository that has ogre
-  - export HOME_DIR=`pwd`
+  - export HOME_DIR=`pwd`; gcc --version
   - sudo apt-get update -qq
-  - sudo apt-get install -qq libois-dev libfreetype6-dev libopenal-dev libexpat1-dev libsilly-dev
-# Boost
-  - sudo apt-get install -qq libboost-filesystem-dev libboost-locale-dev libboost-program-options-dev libboost-date-time-dev libboost-thread-dev libboost-system-dev libboost-test-dev
-  - sudo apt-get install -qq libogre-1.9-dev
-  - sudo apt-get install -qq libsfml-dev
-  - sudo apt-get install -qq g++-4.8 gcc-4.8
-  - sudo apt-get install --only-upgrade cmake
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
-  - sudo apt-get install libstdc++-4.8-dev
-  - gcc --version
+# OD dependencies
+  - sudo apt-get install -y cmake libogre-1.9-dev libsfml-dev libois-dev
+  - sudo apt-get install -y libboost-filesystem-dev libboost-locale-dev libboost-program-options-dev libboost-date-time-dev libboost-thread-dev libboost-system-dev libboost-test-dev
+# CEGUI dependencies
+  - sudo apt-get install -y libfreetype6-dev libopenal-dev libexpat1-dev libsilly-dev
 # CEGUI is not packaged. We need to compile it ourself. Note that we could also compile it and download binaries if need be
   - wget http://sourceforge.net/projects/crayzedsgui/files/cegui-0.8.4.tar.bz2/download -O /tmp/cegui.tar.bz2
-# We download SFML binaries
-  - wget http://mirror2.sfml-dev.org/files/SFML-2.3.1-linux-gcc-64-bit.tar.gz -O /tmp/sfml.tar.gz
   - cd /tmp
   - sudo tar -xjf cegui.tar.bz2
   - cd cegui-0.8.4
   - sudo cmake . -DCEGUI_HAS_FREETYPE=ON -DCEGUI_BUILD_IMAGECODEC_SILLY=ON -DCEGUI_BUILD_XMLPARSER_EXPAT=ON -DCEGUI_BUILD_RENDERER_OGRE=ON -DCEGUI_BUILD_PYTHON_MODULES=OFF -DCEGUI_SAMPLES_ENABLED=OFF
   - sudo make install
-  - cd /tmp
-  - sudo tar -xzf sfml.tar.gz
-  - sudo cp -r SFML-2.3.1/* /usr/
   - cd $HOME_DIR
-script:
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then cmake . -DOD_BUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release && make && sudo make install; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then ./scripts/unix/run_unit_tests.sh; fi
 
-cache: apt
+script:
+  - cmake . -DOD_BUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=./install-root
+  - make -j2 && make install
+  - find ./install-root
+  - ./scripts/unix/run_unit_tests.sh
+
+#cache: apt


### PR DESCRIPTION
- No need to build SFML, we install it from trusty
- GCC is already 4.8 (at least when requiring cpp language)
- Disable caching and addons as they don't work on non
  container-based platforms (i.e. we can't use caching and sudo)
- Cleanup a bit and install files to our path
- Install cegui-0.8 from PlayDeb repo
