### PR TITLE
Update copyright years

### DIFF
--- a/dist/opendungeons.appdata.xml
+++ b/dist/opendungeons.appdata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2015 OpenDungeons Development Team <https://github.com/OpenDungeons> -->
+<!-- Copyright 2011-2016 OpenDungeons Development Team <https://github.com/OpenDungeons> -->
 <component type="desktop">
   <id>opendungeons.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>

--- a/source/ODApplication.cpp
+++ b/source/ODApplication.cpp
@@ -3,7 +3,7 @@
  *  \date   07 April 2011
  *  \brief  Class ODApplication containing everything to start the game
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/ODApplication.h
+++ b/source/ODApplication.h
@@ -3,7 +3,7 @@
  *  \date   07 April 2011
  *  \brief  Class ODApplication containing everything to start the game
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/ai/AIFactory.cpp
+++ b/source/ai/AIFactory.cpp
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/ai/AIFactory.h
+++ b/source/ai/AIFactory.h
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/ai/AIManager.cpp
+++ b/source/ai/AIManager.cpp
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/ai/AIManager.h
+++ b/source/ai/AIManager.h
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/ai/BaseAI.cpp
+++ b/source/ai/BaseAI.cpp
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/ai/BaseAI.h
+++ b/source/ai/BaseAI.h
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/ai/KeeperAI.cpp
+++ b/source/ai/KeeperAI.cpp
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/ai/KeeperAI.h
+++ b/source/ai/KeeperAI.h
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/ai/KeeperAIType.cpp
+++ b/source/ai/KeeperAIType.cpp
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/ai/KeeperAIType.h
+++ b/source/ai/KeeperAIType.h
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/camera/CameraManager.cpp
+++ b/source/camera/CameraManager.cpp
@@ -3,7 +3,7 @@
  * \date:  02 July 2011
  * \author StefanP.MUC
  * \brief  Handles the camera movements
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/camera/CameraManager.h
+++ b/source/camera/CameraManager.h
@@ -4,7 +4,7 @@
  * \author StefanP.MUC
  * \brief  Handles the camera movements
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/camera/HermiteCatmullSpline.cpp
+++ b/source/camera/HermiteCatmullSpline.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/camera/HermiteCatmullSpline.h
+++ b/source/camera/HermiteCatmullSpline.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureAction.cpp
+++ b/source/creatureaction/CreatureAction.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureAction.h
+++ b/source/creatureaction/CreatureAction.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionCarryEntity.cpp
+++ b/source/creatureaction/CreatureActionCarryEntity.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionCarryEntity.h
+++ b/source/creatureaction/CreatureActionCarryEntity.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionClaimGroundTile.cpp
+++ b/source/creatureaction/CreatureActionClaimGroundTile.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionClaimGroundTile.h
+++ b/source/creatureaction/CreatureActionClaimGroundTile.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionClaimWallTile.cpp
+++ b/source/creatureaction/CreatureActionClaimWallTile.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionClaimWallTile.h
+++ b/source/creatureaction/CreatureActionClaimWallTile.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionDigTile.cpp
+++ b/source/creatureaction/CreatureActionDigTile.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionDigTile.h
+++ b/source/creatureaction/CreatureActionDigTile.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionEatChicken.cpp
+++ b/source/creatureaction/CreatureActionEatChicken.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionEatChicken.h
+++ b/source/creatureaction/CreatureActionEatChicken.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionFight.cpp
+++ b/source/creatureaction/CreatureActionFight.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionFight.h
+++ b/source/creatureaction/CreatureActionFight.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionFightFriendly.cpp
+++ b/source/creatureaction/CreatureActionFightFriendly.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionFightFriendly.h
+++ b/source/creatureaction/CreatureActionFightFriendly.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionFindHome.cpp
+++ b/source/creatureaction/CreatureActionFindHome.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionFindHome.h
+++ b/source/creatureaction/CreatureActionFindHome.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionFlee.cpp
+++ b/source/creatureaction/CreatureActionFlee.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionFlee.h
+++ b/source/creatureaction/CreatureActionFlee.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionGetFee.cpp
+++ b/source/creatureaction/CreatureActionGetFee.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionGetFee.h
+++ b/source/creatureaction/CreatureActionGetFee.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionGrabEntity.cpp
+++ b/source/creatureaction/CreatureActionGrabEntity.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionGrabEntity.h
+++ b/source/creatureaction/CreatureActionGrabEntity.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionLeaveDungeon.cpp
+++ b/source/creatureaction/CreatureActionLeaveDungeon.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionLeaveDungeon.h
+++ b/source/creatureaction/CreatureActionLeaveDungeon.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionSearchEntityToCarry.cpp
+++ b/source/creatureaction/CreatureActionSearchEntityToCarry.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionSearchEntityToCarry.h
+++ b/source/creatureaction/CreatureActionSearchEntityToCarry.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionSearchFood.cpp
+++ b/source/creatureaction/CreatureActionSearchFood.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionSearchFood.h
+++ b/source/creatureaction/CreatureActionSearchFood.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionSearchGroundTileToClaim.cpp
+++ b/source/creatureaction/CreatureActionSearchGroundTileToClaim.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionSearchGroundTileToClaim.h
+++ b/source/creatureaction/CreatureActionSearchGroundTileToClaim.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionSearchJob.cpp
+++ b/source/creatureaction/CreatureActionSearchJob.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionSearchJob.h
+++ b/source/creatureaction/CreatureActionSearchJob.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionSearchTileToDig.cpp
+++ b/source/creatureaction/CreatureActionSearchTileToDig.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionSearchTileToDig.h
+++ b/source/creatureaction/CreatureActionSearchTileToDig.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionSearchWallTileToClaim.cpp
+++ b/source/creatureaction/CreatureActionSearchWallTileToClaim.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionSearchWallTileToClaim.h
+++ b/source/creatureaction/CreatureActionSearchWallTileToClaim.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionSleep.cpp
+++ b/source/creatureaction/CreatureActionSleep.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionSleep.h
+++ b/source/creatureaction/CreatureActionSleep.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionStealFreeGold.cpp
+++ b/source/creatureaction/CreatureActionStealFreeGold.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionStealFreeGold.h
+++ b/source/creatureaction/CreatureActionStealFreeGold.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionUseRoom.cpp
+++ b/source/creatureaction/CreatureActionUseRoom.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionUseRoom.h
+++ b/source/creatureaction/CreatureActionUseRoom.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionWalkToTile.cpp
+++ b/source/creatureaction/CreatureActionWalkToTile.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureaction/CreatureActionWalkToTile.h
+++ b/source/creatureaction/CreatureActionWalkToTile.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturebehaviour/CreatureBehaviour.cpp
+++ b/source/creaturebehaviour/CreatureBehaviour.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturebehaviour/CreatureBehaviour.h
+++ b/source/creaturebehaviour/CreatureBehaviour.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturebehaviour/CreatureBehaviourAttackEnemy.cpp
+++ b/source/creaturebehaviour/CreatureBehaviourAttackEnemy.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturebehaviour/CreatureBehaviourAttackEnemy.h
+++ b/source/creaturebehaviour/CreatureBehaviourAttackEnemy.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturebehaviour/CreatureBehaviourEngageNaturalEnemy.cpp
+++ b/source/creaturebehaviour/CreatureBehaviourEngageNaturalEnemy.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturebehaviour/CreatureBehaviourEngageNaturalEnemy.h
+++ b/source/creaturebehaviour/CreatureBehaviourEngageNaturalEnemy.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturebehaviour/CreatureBehaviourFleeWhenWeak.cpp
+++ b/source/creaturebehaviour/CreatureBehaviourFleeWhenWeak.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturebehaviour/CreatureBehaviourFleeWhenWeak.h
+++ b/source/creaturebehaviour/CreatureBehaviourFleeWhenWeak.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturebehaviour/CreatureBehaviourLeaveDungeonWhenFurious.cpp
+++ b/source/creaturebehaviour/CreatureBehaviourLeaveDungeonWhenFurious.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturebehaviour/CreatureBehaviourLeaveDungeonWhenFurious.h
+++ b/source/creaturebehaviour/CreatureBehaviourLeaveDungeonWhenFurious.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturebehaviour/CreatureBehaviourManager.cpp
+++ b/source/creaturebehaviour/CreatureBehaviourManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturebehaviour/CreatureBehaviourManager.h
+++ b/source/creaturebehaviour/CreatureBehaviourManager.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureeffect/CreatureEffect.cpp
+++ b/source/creatureeffect/CreatureEffect.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureeffect/CreatureEffect.h
+++ b/source/creatureeffect/CreatureEffect.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureeffect/CreatureEffectDefense.cpp
+++ b/source/creatureeffect/CreatureEffectDefense.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureeffect/CreatureEffectDefense.h
+++ b/source/creatureeffect/CreatureEffectDefense.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureeffect/CreatureEffectExplosion.cpp
+++ b/source/creatureeffect/CreatureEffectExplosion.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureeffect/CreatureEffectExplosion.h
+++ b/source/creatureeffect/CreatureEffectExplosion.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureeffect/CreatureEffectHeal.cpp
+++ b/source/creatureeffect/CreatureEffectHeal.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureeffect/CreatureEffectHeal.h
+++ b/source/creatureeffect/CreatureEffectHeal.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureeffect/CreatureEffectManager.cpp
+++ b/source/creatureeffect/CreatureEffectManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureeffect/CreatureEffectManager.h
+++ b/source/creatureeffect/CreatureEffectManager.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureeffect/CreatureEffectSlap.cpp
+++ b/source/creatureeffect/CreatureEffectSlap.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureeffect/CreatureEffectSlap.h
+++ b/source/creatureeffect/CreatureEffectSlap.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureeffect/CreatureEffectSpeedChange.cpp
+++ b/source/creatureeffect/CreatureEffectSpeedChange.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureeffect/CreatureEffectSpeedChange.h
+++ b/source/creatureeffect/CreatureEffectSpeedChange.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureeffect/CreatureEffectStrengthChange.cpp
+++ b/source/creatureeffect/CreatureEffectStrengthChange.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureeffect/CreatureEffectStrengthChange.h
+++ b/source/creatureeffect/CreatureEffectStrengthChange.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturemood/CreatureMood.cpp
+++ b/source/creaturemood/CreatureMood.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturemood/CreatureMood.h
+++ b/source/creaturemood/CreatureMood.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturemood/CreatureMoodCreature.cpp
+++ b/source/creaturemood/CreatureMoodCreature.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturemood/CreatureMoodCreature.h
+++ b/source/creaturemood/CreatureMoodCreature.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturemood/CreatureMoodFee.cpp
+++ b/source/creaturemood/CreatureMoodFee.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturemood/CreatureMoodFee.h
+++ b/source/creaturemood/CreatureMoodFee.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturemood/CreatureMoodHpLoss.cpp
+++ b/source/creaturemood/CreatureMoodHpLoss.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturemood/CreatureMoodHpLoss.h
+++ b/source/creaturemood/CreatureMoodHpLoss.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturemood/CreatureMoodHunger.cpp
+++ b/source/creaturemood/CreatureMoodHunger.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturemood/CreatureMoodHunger.h
+++ b/source/creaturemood/CreatureMoodHunger.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturemood/CreatureMoodManager.cpp
+++ b/source/creaturemood/CreatureMoodManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturemood/CreatureMoodManager.h
+++ b/source/creaturemood/CreatureMoodManager.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturemood/CreatureMoodTurnsWithoutFight.cpp
+++ b/source/creaturemood/CreatureMoodTurnsWithoutFight.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturemood/CreatureMoodTurnsWithoutFight.h
+++ b/source/creaturemood/CreatureMoodTurnsWithoutFight.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturemood/CreatureMoodWakefulness.cpp
+++ b/source/creaturemood/CreatureMoodWakefulness.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creaturemood/CreatureMoodWakefulness.h
+++ b/source/creaturemood/CreatureMoodWakefulness.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkill.cpp
+++ b/source/creatureskill/CreatureSkill.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkill.h
+++ b/source/creatureskill/CreatureSkill.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillDefenseSelf.cpp
+++ b/source/creatureskill/CreatureSkillDefenseSelf.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillDefenseSelf.h
+++ b/source/creatureskill/CreatureSkillDefenseSelf.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillExplosion.cpp
+++ b/source/creatureskill/CreatureSkillExplosion.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillExplosion.h
+++ b/source/creatureskill/CreatureSkillExplosion.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillHasteSelf.cpp
+++ b/source/creatureskill/CreatureSkillHasteSelf.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillHasteSelf.h
+++ b/source/creatureskill/CreatureSkillHasteSelf.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillHealSelf.cpp
+++ b/source/creatureskill/CreatureSkillHealSelf.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillHealSelf.h
+++ b/source/creatureskill/CreatureSkillHealSelf.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillManager.cpp
+++ b/source/creatureskill/CreatureSkillManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillManager.h
+++ b/source/creatureskill/CreatureSkillManager.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillMeleeFight.cpp
+++ b/source/creatureskill/CreatureSkillMeleeFight.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillMeleeFight.h
+++ b/source/creatureskill/CreatureSkillMeleeFight.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillMissileLaunch.cpp
+++ b/source/creatureskill/CreatureSkillMissileLaunch.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillMissileLaunch.h
+++ b/source/creatureskill/CreatureSkillMissileLaunch.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillSlow.cpp
+++ b/source/creatureskill/CreatureSkillSlow.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillSlow.h
+++ b/source/creatureskill/CreatureSkillSlow.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillStrengthSelf.cpp
+++ b/source/creatureskill/CreatureSkillStrengthSelf.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillStrengthSelf.h
+++ b/source/creatureskill/CreatureSkillStrengthSelf.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillWeak.cpp
+++ b/source/creatureskill/CreatureSkillWeak.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/creatureskill/CreatureSkillWeak.h
+++ b/source/creatureskill/CreatureSkillWeak.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/Building.cpp
+++ b/source/entities/Building.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/Building.h
+++ b/source/entities/Building.h
@@ -4,7 +4,7 @@
  * \author StefanP.MUC
  * \brief  Provides common methods and members for buildable objects, like rooms and traps
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/BuildingObject.cpp
+++ b/source/entities/BuildingObject.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/BuildingObject.h
+++ b/source/entities/BuildingObject.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/ChickenEntity.cpp
+++ b/source/entities/ChickenEntity.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/ChickenEntity.h
+++ b/source/entities/ChickenEntity.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/CraftedTrap.cpp
+++ b/source/entities/CraftedTrap.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/CraftedTrap.h
+++ b/source/entities/CraftedTrap.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/Creature.cpp
+++ b/source/entities/Creature.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/Creature.h
+++ b/source/entities/Creature.h
@@ -2,7 +2,7 @@
  * \file   Creature.h
  * \brief  Creature class
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/CreatureDefinition.cpp
+++ b/source/entities/CreatureDefinition.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/CreatureDefinition.h
+++ b/source/entities/CreatureDefinition.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/DoorEntity.cpp
+++ b/source/entities/DoorEntity.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/DoorEntity.h
+++ b/source/entities/DoorEntity.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/EntityLoading.cpp
+++ b/source/entities/EntityLoading.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/EntityLoading.h
+++ b/source/entities/EntityLoading.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/GameEntity.cpp
+++ b/source/entities/GameEntity.cpp
@@ -4,7 +4,7 @@
  * \author StefanP.MUC
  * \brief  Provides the GameEntity class, the base class for all ingame objects
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/GameEntity.h
+++ b/source/entities/GameEntity.h
@@ -4,7 +4,7 @@
  * \author StefanP.MUC
  * \brief  Provides the GameEntity class, the base class for all ingame objects
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/GameEntityType.cpp
+++ b/source/entities/GameEntityType.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/GameEntityType.h
+++ b/source/entities/GameEntityType.h
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/GiftBoxEntity.cpp
+++ b/source/entities/GiftBoxEntity.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/GiftBoxEntity.h
+++ b/source/entities/GiftBoxEntity.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/MapLight.cpp
+++ b/source/entities/MapLight.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/MapLight.h
+++ b/source/entities/MapLight.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/MissileBoulder.cpp
+++ b/source/entities/MissileBoulder.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/MissileBoulder.h
+++ b/source/entities/MissileBoulder.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/MissileObject.cpp
+++ b/source/entities/MissileObject.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/MissileObject.h
+++ b/source/entities/MissileObject.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/MissileOneHit.cpp
+++ b/source/entities/MissileOneHit.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/MissileOneHit.h
+++ b/source/entities/MissileOneHit.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/MovableGameEntity.cpp
+++ b/source/entities/MovableGameEntity.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/MovableGameEntity.h
+++ b/source/entities/MovableGameEntity.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/PersistentObject.cpp
+++ b/source/entities/PersistentObject.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/PersistentObject.h
+++ b/source/entities/PersistentObject.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/RenderedMovableEntity.cpp
+++ b/source/entities/RenderedMovableEntity.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/RenderedMovableEntity.h
+++ b/source/entities/RenderedMovableEntity.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/SkillEntity.cpp
+++ b/source/entities/SkillEntity.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/SkillEntity.h
+++ b/source/entities/SkillEntity.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/SmallSpiderEntity.cpp
+++ b/source/entities/SmallSpiderEntity.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/SmallSpiderEntity.h
+++ b/source/entities/SmallSpiderEntity.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/Tile.cpp
+++ b/source/entities/Tile.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/Tile.h
+++ b/source/entities/Tile.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/TrapEntity.cpp
+++ b/source/entities/TrapEntity.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/TrapEntity.h
+++ b/source/entities/TrapEntity.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/TreasuryObject.cpp
+++ b/source/entities/TreasuryObject.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/TreasuryObject.h
+++ b/source/entities/TreasuryObject.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/Weapon.cpp
+++ b/source/entities/Weapon.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/entities/Weapon.h
+++ b/source/entities/Weapon.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/game/Player.cpp
+++ b/source/game/Player.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/game/Player.h
+++ b/source/game/Player.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/game/PlayerSelection.cpp
+++ b/source/game/PlayerSelection.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/game/PlayerSelection.h
+++ b/source/game/PlayerSelection.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/game/Seat.cpp
+++ b/source/game/Seat.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/game/Seat.h
+++ b/source/game/Seat.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/game/SeatData.cpp
+++ b/source/game/SeatData.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/game/SeatData.h
+++ b/source/game/SeatData.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/game/Skill.cpp
+++ b/source/game/Skill.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/game/Skill.h
+++ b/source/game/Skill.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/game/SkillManager.cpp
+++ b/source/game/SkillManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/game/SkillManager.h
+++ b/source/game/SkillManager.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/game/SkillType.cpp
+++ b/source/game/SkillType.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/game/SkillType.h
+++ b/source/game/SkillType.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -2,7 +2,7 @@
  * \file   GameMap.cpp
  * \brief  The central object holding everything that is on the map
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/gamemap/GameMap.h
+++ b/source/gamemap/GameMap.h
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/gamemap/MapHandler.cpp
+++ b/source/gamemap/MapHandler.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/gamemap/MapHandler.h
+++ b/source/gamemap/MapHandler.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/gamemap/MiniMap.cpp
+++ b/source/gamemap/MiniMap.cpp
@@ -5,7 +5,7 @@
  * \brief  Contains everything that is related to the minimap
  *
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/gamemap/MiniMap.h
+++ b/source/gamemap/MiniMap.h
@@ -4,7 +4,7 @@
  * \author StefanP.MUC
  * \brief  header for the minimap
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/gamemap/MiniMapCamera.cpp
+++ b/source/gamemap/MiniMapCamera.cpp
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/gamemap/MiniMapCamera.h
+++ b/source/gamemap/MiniMapCamera.h
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/gamemap/Pathfinding.cpp
+++ b/source/gamemap/Pathfinding.cpp
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/gamemap/Pathfinding.h
+++ b/source/gamemap/Pathfinding.h
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/gamemap/TileContainer.cpp
+++ b/source/gamemap/TileContainer.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/gamemap/TileContainer.h
+++ b/source/gamemap/TileContainer.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/gamemap/TileSet.cpp
+++ b/source/gamemap/TileSet.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/gamemap/TileSet.h
+++ b/source/gamemap/TileSet.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/giftboxes/GiftBoxSkill.cpp
+++ b/source/giftboxes/GiftBoxSkill.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/giftboxes/GiftBoxSkill.h
+++ b/source/giftboxes/GiftBoxSkill.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/goals/AllGoals.h
+++ b/source/goals/AllGoals.h
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/goals/Goal.cpp
+++ b/source/goals/Goal.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/goals/Goal.h
+++ b/source/goals/Goal.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/goals/GoalClaimNTiles.cpp
+++ b/source/goals/GoalClaimNTiles.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/goals/GoalClaimNTiles.h
+++ b/source/goals/GoalClaimNTiles.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/goals/GoalKillAllEnemies.cpp
+++ b/source/goals/GoalKillAllEnemies.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/goals/GoalKillAllEnemies.h
+++ b/source/goals/GoalKillAllEnemies.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/goals/GoalLoading.cpp
+++ b/source/goals/GoalLoading.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/goals/GoalLoading.h
+++ b/source/goals/GoalLoading.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/goals/GoalMineNGold.cpp
+++ b/source/goals/GoalMineNGold.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/goals/GoalMineNGold.h
+++ b/source/goals/GoalMineNGold.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/goals/GoalProtectCreature.cpp
+++ b/source/goals/GoalProtectCreature.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/goals/GoalProtectCreature.h
+++ b/source/goals/GoalProtectCreature.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/goals/GoalProtectDungeonTemple.cpp
+++ b/source/goals/GoalProtectDungeonTemple.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/goals/GoalProtectDungeonTemple.h
+++ b/source/goals/GoalProtectDungeonTemple.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -3,7 +3,7 @@
  *  \date   Sun Jun 22 18:16:35 CEST 2014
  *  \brief  file containing the main function
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/AbstractApplicationMode.cpp
+++ b/source/modes/AbstractApplicationMode.cpp
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/AbstractApplicationMode.h
+++ b/source/modes/AbstractApplicationMode.h
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/AbstractModeManager.h
+++ b/source/modes/AbstractModeManager.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/Command.cpp
+++ b/source/modes/Command.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/Command.h
+++ b/source/modes/Command.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/ConsoleInterface.cpp
+++ b/source/modes/ConsoleInterface.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/ConsoleInterface.h
+++ b/source/modes/ConsoleInterface.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/EditorMode.h
+++ b/source/modes/EditorMode.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/GameEditorModeBase.cpp
+++ b/source/modes/GameEditorModeBase.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/GameEditorModeBase.h
+++ b/source/modes/GameEditorModeBase.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/GameEditorModeConsole.cpp
+++ b/source/modes/GameEditorModeConsole.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/GameEditorModeConsole.h
+++ b/source/modes/GameEditorModeConsole.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/GameMode.h
+++ b/source/modes/GameMode.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/InputCommand.h
+++ b/source/modes/InputCommand.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/InputManager.cpp
+++ b/source/modes/InputManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/InputManager.h
+++ b/source/modes/InputManager.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeConfigureSeats.cpp
+++ b/source/modes/MenuModeConfigureSeats.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeConfigureSeats.h
+++ b/source/modes/MenuModeConfigureSeats.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeEditorLoad.cpp
+++ b/source/modes/MenuModeEditorLoad.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeEditorLoad.h
+++ b/source/modes/MenuModeEditorLoad.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeEditorNew.cpp
+++ b/source/modes/MenuModeEditorNew.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeEditorNew.h
+++ b/source/modes/MenuModeEditorNew.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeLoad.cpp
+++ b/source/modes/MenuModeLoad.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeLoad.h
+++ b/source/modes/MenuModeLoad.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeMain.cpp
+++ b/source/modes/MenuModeMain.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeMain.h
+++ b/source/modes/MenuModeMain.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeMasterServerJoin.cpp
+++ b/source/modes/MenuModeMasterServerJoin.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeMasterServerJoin.h
+++ b/source/modes/MenuModeMasterServerJoin.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeMultiplayerClient.cpp
+++ b/source/modes/MenuModeMultiplayerClient.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeMultiplayerClient.h
+++ b/source/modes/MenuModeMultiplayerClient.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeMultiplayerServer.cpp
+++ b/source/modes/MenuModeMultiplayerServer.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeMultiplayerServer.h
+++ b/source/modes/MenuModeMultiplayerServer.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeReplay.cpp
+++ b/source/modes/MenuModeReplay.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeReplay.h
+++ b/source/modes/MenuModeReplay.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeSkirmish.cpp
+++ b/source/modes/MenuModeSkirmish.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/MenuModeSkirmish.h
+++ b/source/modes/MenuModeSkirmish.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/ModeManager.cpp
+++ b/source/modes/ModeManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/ModeManager.h
+++ b/source/modes/ModeManager.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/SettingsWindow.cpp
+++ b/source/modes/SettingsWindow.cpp
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/modes/SettingsWindow.h
+++ b/source/modes/SettingsWindow.h
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/network/ChatEventMessage.cpp
+++ b/source/network/ChatEventMessage.cpp
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/network/ChatEventMessage.h
+++ b/source/network/ChatEventMessage.h
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/network/ClientNotification.cpp
+++ b/source/network/ClientNotification.cpp
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/network/ClientNotification.h
+++ b/source/network/ClientNotification.h
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/network/ODClient.h
+++ b/source/network/ODClient.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/network/ODPacket.cpp
+++ b/source/network/ODPacket.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/network/ODPacket.h
+++ b/source/network/ODPacket.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/network/ODServer.h
+++ b/source/network/ODServer.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/network/ODSocketClient.cpp
+++ b/source/network/ODSocketClient.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/network/ODSocketClient.h
+++ b/source/network/ODSocketClient.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/network/ODSocketServer.cpp
+++ b/source/network/ODSocketServer.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/network/ODSocketServer.h
+++ b/source/network/ODSocketServer.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/network/ServerMode.cpp
+++ b/source/network/ServerMode.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/network/ServerMode.h
+++ b/source/network/ServerMode.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/network/ServerNotification.cpp
+++ b/source/network/ServerNotification.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/network/ServerNotification.h
+++ b/source/network/ServerNotification.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/render/CreatureOverlayStatus.cpp
+++ b/source/render/CreatureOverlayStatus.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/render/CreatureOverlayStatus.h
+++ b/source/render/CreatureOverlayStatus.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/render/Gui.cpp
+++ b/source/render/Gui.cpp
@@ -4,7 +4,7 @@
  * \author StefanP.MUC
  * \brief  Class Gui containing all the stuff for the GUI, including translation.
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/render/Gui.h
+++ b/source/render/Gui.h
@@ -5,7 +5,7 @@
  * \brief  Header for class Gui containing all the stuff for the GUI,
  *         including translation.
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/render/MovableTextOverlay.cpp
+++ b/source/render/MovableTextOverlay.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/render/MovableTextOverlay.h
+++ b/source/render/MovableTextOverlay.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/render/ODFrameListener.cpp
+++ b/source/render/ODFrameListener.cpp
@@ -4,7 +4,7 @@
  * \author Ogre team, andrewbuck, oln, StefanP.MUC
  * \brief  Handles the input and rendering request
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/render/ODFrameListener.h
+++ b/source/render/ODFrameListener.h
@@ -4,7 +4,7 @@
  * \auth	(require 'ecb)or Ogre team, andrewbuck, oln, StefanP.MUC
  * \brief  Handles the input and rendering request
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/render/RenderManager.cpp
+++ b/source/render/RenderManager.cpp
@@ -3,7 +3,7 @@
  *  \date   26 March 2001
  *  \author oln, paul424
  *  \brief  handles the render requests
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/render/RenderManager.h
+++ b/source/render/RenderManager.h
@@ -3,7 +3,7 @@
  *  \date   26 March 2011
  *  \author oln
  *  \brief  handles the render requests
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/render/TextRenderer.cpp
+++ b/source/render/TextRenderer.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/render/TextRenderer.h
+++ b/source/render/TextRenderer.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderScene.cpp
+++ b/source/renderscene/RenderScene.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderScene.h
+++ b/source/renderscene/RenderScene.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneAddEntity.cpp
+++ b/source/renderscene/RenderSceneAddEntity.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneAddEntity.h
+++ b/source/renderscene/RenderSceneAddEntity.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneAddParticleEffect.cpp
+++ b/source/renderscene/RenderSceneAddParticleEffect.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneAddParticleEffect.h
+++ b/source/renderscene/RenderSceneAddParticleEffect.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneAddParticleEffectBone.cpp
+++ b/source/renderscene/RenderSceneAddParticleEffectBone.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneAddParticleEffectBone.h
+++ b/source/renderscene/RenderSceneAddParticleEffectBone.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneAddPointLight.cpp
+++ b/source/renderscene/RenderSceneAddPointLight.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneAddPointLight.h
+++ b/source/renderscene/RenderSceneAddPointLight.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneAnimationOnce.cpp
+++ b/source/renderscene/RenderSceneAnimationOnce.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneAnimationOnce.h
+++ b/source/renderscene/RenderSceneAnimationOnce.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneAnimationTime.cpp
+++ b/source/renderscene/RenderSceneAnimationTime.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneAnimationTime.h
+++ b/source/renderscene/RenderSceneAnimationTime.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneCameraMove.cpp
+++ b/source/renderscene/RenderSceneCameraMove.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneCameraMove.h
+++ b/source/renderscene/RenderSceneCameraMove.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneGroup.cpp
+++ b/source/renderscene/RenderSceneGroup.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneGroup.h
+++ b/source/renderscene/RenderSceneGroup.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneManager.cpp
+++ b/source/renderscene/RenderSceneManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneManager.h
+++ b/source/renderscene/RenderSceneManager.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneMenu.cpp
+++ b/source/renderscene/RenderSceneMenu.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneMenu.h
+++ b/source/renderscene/RenderSceneMenu.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneMoveEntity.cpp
+++ b/source/renderscene/RenderSceneMoveEntity.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneMoveEntity.h
+++ b/source/renderscene/RenderSceneMoveEntity.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderScenePosEntity.cpp
+++ b/source/renderscene/RenderScenePosEntity.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderScenePosEntity.h
+++ b/source/renderscene/RenderScenePosEntity.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneSyncPost.cpp
+++ b/source/renderscene/RenderSceneSyncPost.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneSyncPost.h
+++ b/source/renderscene/RenderSceneSyncPost.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneSyncWait.cpp
+++ b/source/renderscene/RenderSceneSyncWait.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneSyncWait.h
+++ b/source/renderscene/RenderSceneSyncWait.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneSyncWaitAnimation.cpp
+++ b/source/renderscene/RenderSceneSyncWaitAnimation.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneSyncWaitAnimation.h
+++ b/source/renderscene/RenderSceneSyncWaitAnimation.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneTurnEntity.cpp
+++ b/source/renderscene/RenderSceneTurnEntity.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneTurnEntity.h
+++ b/source/renderscene/RenderSceneTurnEntity.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneWait.cpp
+++ b/source/renderscene/RenderSceneWait.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/renderscene/RenderSceneWait.h
+++ b/source/renderscene/RenderSceneWait.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/Room.cpp
+++ b/source/rooms/Room.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/Room.h
+++ b/source/rooms/Room.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomArena.cpp
+++ b/source/rooms/RoomArena.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomArena.h
+++ b/source/rooms/RoomArena.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomBridge.cpp
+++ b/source/rooms/RoomBridge.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomBridge.h
+++ b/source/rooms/RoomBridge.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomBridgeStone.cpp
+++ b/source/rooms/RoomBridgeStone.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomBridgeStone.h
+++ b/source/rooms/RoomBridgeStone.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomBridgeWooden.cpp
+++ b/source/rooms/RoomBridgeWooden.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomBridgeWooden.h
+++ b/source/rooms/RoomBridgeWooden.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomCasino.cpp
+++ b/source/rooms/RoomCasino.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomCasino.h
+++ b/source/rooms/RoomCasino.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomCrypt.cpp
+++ b/source/rooms/RoomCrypt.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomCrypt.h
+++ b/source/rooms/RoomCrypt.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomDormitory.cpp
+++ b/source/rooms/RoomDormitory.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomDormitory.h
+++ b/source/rooms/RoomDormitory.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomDungeonTemple.cpp
+++ b/source/rooms/RoomDungeonTemple.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomDungeonTemple.h
+++ b/source/rooms/RoomDungeonTemple.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomHatchery.cpp
+++ b/source/rooms/RoomHatchery.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomHatchery.h
+++ b/source/rooms/RoomHatchery.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomLibrary.cpp
+++ b/source/rooms/RoomLibrary.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomLibrary.h
+++ b/source/rooms/RoomLibrary.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomManager.cpp
+++ b/source/rooms/RoomManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomManager.h
+++ b/source/rooms/RoomManager.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomPortal.cpp
+++ b/source/rooms/RoomPortal.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomPortal.h
+++ b/source/rooms/RoomPortal.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomPortalWave.cpp
+++ b/source/rooms/RoomPortalWave.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomPortalWave.h
+++ b/source/rooms/RoomPortalWave.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomPrison.cpp
+++ b/source/rooms/RoomPrison.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomPrison.h
+++ b/source/rooms/RoomPrison.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomTorture.cpp
+++ b/source/rooms/RoomTorture.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomTorture.h
+++ b/source/rooms/RoomTorture.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomTrainingHall.cpp
+++ b/source/rooms/RoomTrainingHall.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomTrainingHall.h
+++ b/source/rooms/RoomTrainingHall.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomTreasury.cpp
+++ b/source/rooms/RoomTreasury.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomTreasury.h
+++ b/source/rooms/RoomTreasury.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomType.h
+++ b/source/rooms/RoomType.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomWorkshop.cpp
+++ b/source/rooms/RoomWorkshop.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/rooms/RoomWorkshop.h
+++ b/source/rooms/RoomWorkshop.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/scripting/ASWrapper.cpp
+++ b/source/scripting/ASWrapper.cpp
@@ -9,7 +9,7 @@
  * The Ogre-Angelscript binding project is something to keep an eye on:
  *  code.google.com/p/ogre-angelscript/
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/scripting/ASWrapper.h
+++ b/source/scripting/ASWrapper.h
@@ -4,7 +4,7 @@
  * \author StefanP.MUC
  * \brief  Initializes AngelScript and provides access to its functions
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/sound/MusicPlayer.cpp
+++ b/source/sound/MusicPlayer.cpp
@@ -4,7 +4,7 @@
  * \date   November 10 2010
  * \brief  Class "MusicPlayer" containing everything to play music tracks.
  *
- *  Copyright (C) 2010-2015  OpenDungeons Team
+ *  Copyright (C) 2010-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/sound/MusicPlayer.h
+++ b/source/sound/MusicPlayer.h
@@ -5,7 +5,7 @@
  * \brief  Header of class "MusicPlayer" containing everything to play
  *         music tracks.
  *
- *  Copyright (C) 2010-2015  OpenDungeons Team
+ *  Copyright (C) 2010-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/sound/SoundEffectsManager.cpp
+++ b/source/sound/SoundEffectsManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/sound/SoundEffectsManager.h
+++ b/source/sound/SoundEffectsManager.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spawnconditions/SpawnCondition.cpp
+++ b/source/spawnconditions/SpawnCondition.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spawnconditions/SpawnCondition.h
+++ b/source/spawnconditions/SpawnCondition.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spawnconditions/SpawnConditionCreature.cpp
+++ b/source/spawnconditions/SpawnConditionCreature.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spawnconditions/SpawnConditionCreature.h
+++ b/source/spawnconditions/SpawnConditionCreature.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spawnconditions/SpawnConditionGold.cpp
+++ b/source/spawnconditions/SpawnConditionGold.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spawnconditions/SpawnConditionGold.h
+++ b/source/spawnconditions/SpawnConditionGold.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spawnconditions/SpawnConditionRoom.cpp
+++ b/source/spawnconditions/SpawnConditionRoom.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spawnconditions/SpawnConditionRoom.h
+++ b/source/spawnconditions/SpawnConditionRoom.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/Spell.cpp
+++ b/source/spells/Spell.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/Spell.h
+++ b/source/spells/Spell.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellCallToWar.cpp
+++ b/source/spells/SpellCallToWar.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellCallToWar.h
+++ b/source/spells/SpellCallToWar.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellCreatureDefense.cpp
+++ b/source/spells/SpellCreatureDefense.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellCreatureDefense.h
+++ b/source/spells/SpellCreatureDefense.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellCreatureExplosion.cpp
+++ b/source/spells/SpellCreatureExplosion.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellCreatureExplosion.h
+++ b/source/spells/SpellCreatureExplosion.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellCreatureHaste.cpp
+++ b/source/spells/SpellCreatureHaste.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellCreatureHaste.h
+++ b/source/spells/SpellCreatureHaste.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellCreatureHeal.cpp
+++ b/source/spells/SpellCreatureHeal.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellCreatureHeal.h
+++ b/source/spells/SpellCreatureHeal.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellCreatureSlow.cpp
+++ b/source/spells/SpellCreatureSlow.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellCreatureSlow.h
+++ b/source/spells/SpellCreatureSlow.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellCreatureStrength.cpp
+++ b/source/spells/SpellCreatureStrength.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellCreatureStrength.h
+++ b/source/spells/SpellCreatureStrength.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellCreatureWeak.cpp
+++ b/source/spells/SpellCreatureWeak.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellCreatureWeak.h
+++ b/source/spells/SpellCreatureWeak.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellManager.cpp
+++ b/source/spells/SpellManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellManager.h
+++ b/source/spells/SpellManager.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellSummonWorker.cpp
+++ b/source/spells/SpellSummonWorker.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellSummonWorker.h
+++ b/source/spells/SpellSummonWorker.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/spells/SpellType.h
+++ b/source/spells/SpellType.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/tests/mocks/ODClientTest.cpp
+++ b/source/tests/mocks/ODClientTest.cpp
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/tests/mocks/ODClientTest.h
+++ b/source/tests/mocks/ODClientTest.h
@@ -1,6 +1,6 @@
 /*!
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/tests/test_ConsoleInterface.cpp
+++ b/source/tests/test_ConsoleInterface.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/tests/test_Creatures.cpp
+++ b/source/tests/test_Creatures.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/tests/test_Goal.cpp
+++ b/source/tests/test_Goal.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/tests/test_LaunchGame.cpp
+++ b/source/tests/test_LaunchGame.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/tests/test_ODPacket.cpp
+++ b/source/tests/test_ODPacket.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/tests/test_Pathfinding.cpp
+++ b/source/tests/test_Pathfinding.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/tests/test_Random.cpp
+++ b/source/tests/test_Random.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/tests/test_Rooms.cpp
+++ b/source/tests/test_Rooms.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/tests/test_Traps.cpp
+++ b/source/tests/test_Traps.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/traps/Trap.cpp
+++ b/source/traps/Trap.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/traps/Trap.h
+++ b/source/traps/Trap.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/traps/TrapBoulder.cpp
+++ b/source/traps/TrapBoulder.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/traps/TrapBoulder.h
+++ b/source/traps/TrapBoulder.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/traps/TrapCannon.cpp
+++ b/source/traps/TrapCannon.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/traps/TrapCannon.h
+++ b/source/traps/TrapCannon.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/traps/TrapDoor.cpp
+++ b/source/traps/TrapDoor.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/traps/TrapDoor.h
+++ b/source/traps/TrapDoor.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/traps/TrapManager.cpp
+++ b/source/traps/TrapManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/traps/TrapManager.h
+++ b/source/traps/TrapManager.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/traps/TrapSpike.cpp
+++ b/source/traps/TrapSpike.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/traps/TrapSpike.h
+++ b/source/traps/TrapSpike.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/traps/TrapType.cpp
+++ b/source/traps/TrapType.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/traps/TrapType.h
+++ b/source/traps/TrapType.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/utils/ConfigManager.cpp
+++ b/source/utils/ConfigManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/utils/ConfigManager.h
+++ b/source/utils/ConfigManager.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/utils/FrameRateLimiter.cpp
+++ b/source/utils/FrameRateLimiter.cpp
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/utils/FrameRateLimiter.h
+++ b/source/utils/FrameRateLimiter.h
@@ -1,5 +1,5 @@
 /*!
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/utils/Helper.cpp
+++ b/source/utils/Helper.cpp
@@ -4,7 +4,7 @@
  * \author StefanP.MUC, hwoarangmy, Bertram
  * \brief  Provides helper functions, constants and defines
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/utils/Helper.h
+++ b/source/utils/Helper.h
@@ -4,7 +4,7 @@
  * \author StefanP.MUC, hwoarangmy, Bertram
  * \brief  Provides helper functions, constants and defines
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/utils/LogManager.cpp
+++ b/source/utils/LogManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/utils/LogManager.h
+++ b/source/utils/LogManager.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/utils/LogMessageLevel.h
+++ b/source/utils/LogMessageLevel.h
@@ -1,5 +1,5 @@
 /*
-*  Copyright (C) 2011-2015  OpenDungeons Team
+*  Copyright (C) 2011-2016  OpenDungeons Team
 *
 *  This program is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/source/utils/LogSink.h
+++ b/source/utils/LogSink.h
@@ -1,5 +1,5 @@
 /*
-*  Copyright (C) 2011-2015  OpenDungeons Team
+*  Copyright (C) 2011-2016  OpenDungeons Team
 *
 *  This program is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/source/utils/LogSinkConsole.cpp
+++ b/source/utils/LogSinkConsole.cpp
@@ -1,5 +1,5 @@
 /*
-*  Copyright (C) 2011-2015  OpenDungeons Team
+*  Copyright (C) 2011-2016  OpenDungeons Team
 *
 *  This program is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/source/utils/LogSinkConsole.h
+++ b/source/utils/LogSinkConsole.h
@@ -1,5 +1,5 @@
 /*
-*  Copyright (C) 2011-2015  OpenDungeons Team
+*  Copyright (C) 2011-2016  OpenDungeons Team
 *
 *  This program is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/source/utils/LogSinkFile.cpp
+++ b/source/utils/LogSinkFile.cpp
@@ -1,5 +1,5 @@
 /*
-*  Copyright (C) 2011-2015  OpenDungeons Team
+*  Copyright (C) 2011-2016  OpenDungeons Team
 *
 *  This program is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/source/utils/LogSinkFile.h
+++ b/source/utils/LogSinkFile.h
@@ -1,5 +1,5 @@
 /*
-*  Copyright (C) 2011-2015  OpenDungeons Team
+*  Copyright (C) 2011-2016  OpenDungeons Team
 *
 *  This program is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/source/utils/LogSinkOgre.cpp
+++ b/source/utils/LogSinkOgre.cpp
@@ -1,5 +1,5 @@
 /*
-*  Copyright (C) 2011-2015  OpenDungeons Team
+*  Copyright (C) 2011-2016  OpenDungeons Team
 *
 *  This program is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/source/utils/LogSinkOgre.h
+++ b/source/utils/LogSinkOgre.h
@@ -1,5 +1,5 @@
 /*
-*  Copyright (C) 2011-2015  OpenDungeons Team
+*  Copyright (C) 2011-2016  OpenDungeons Team
 *
 *  This program is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/source/utils/MakeUnique.h
+++ b/source/utils/MakeUnique.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/utils/MasterServer.cpp
+++ b/source/utils/MasterServer.cpp
@@ -1,5 +1,5 @@
 /*
-*  Copyright (C) 2011-2015  OpenDungeons Team
+*  Copyright (C) 2011-2016  OpenDungeons Team
 *
 *  This program is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/source/utils/MasterServer.h
+++ b/source/utils/MasterServer.h
@@ -1,5 +1,5 @@
 /*
-*  Copyright (C) 2011-2015  OpenDungeons Team
+*  Copyright (C) 2011-2016  OpenDungeons Team
 *
 *  This program is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by

--- a/source/utils/Random.cpp
+++ b/source/utils/Random.cpp
@@ -4,7 +4,7 @@
  * \author andrewbuck, StefanP.MUC
  * \brief  Offers some random number generating functions
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/utils/Random.h
+++ b/source/utils/Random.h
@@ -4,7 +4,7 @@
  * \author andrewbuck, StefanP.MUC
  * \brief  Offers some random number generating functions
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/utils/ResourceManager.cpp
+++ b/source/utils/ResourceManager.cpp
@@ -5,7 +5,7 @@
  * \brief  This class handles all the resources (paths, files) needed by the
  *         sound and graphics facilities.
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/utils/ResourceManager.h
+++ b/source/utils/ResourceManager.h
@@ -4,7 +4,7 @@
  * \author StefanP.MUC
  * \brief  Header for the ResourceManager
  *
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/utils/StackTracePrint.h
+++ b/source/utils/StackTracePrint.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/utils/StackTraceStub.cpp
+++ b/source/utils/StackTraceStub.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/utils/StackTraceUnix.cpp
+++ b/source/utils/StackTraceUnix.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/utils/StackTraceWinMSVC.cpp
+++ b/source/utils/StackTraceWinMSVC.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/source/utils/StackTraceWinMinGW.cpp
+++ b/source/utils/StackTraceWinMinGW.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2015  OpenDungeons Team
+ *  Copyright (C) 2011-2016  OpenDungeons Team
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
I noticed that two files are using 2010-2016 instead of 2011-2016 like the rest, I don't know if that's something to fix or if it's not relevant:

```
$ ack 2010-
source/sound/MusicPlayer.cpp
7: *  Copyright (C) 2010-2016  OpenDungeons Team

source/sound/MusicPlayer.h
8: *  Copyright (C) 2010-2016  OpenDungeons Team
```
