### PR TITLE
Refresh entities at end of turn instead of the beginning of next turn

### DIFF
--- a/source/gamemap/GameMap.cpp
+++ b/source/gamemap/GameMap.cpp
@@ -2747,7 +2747,10 @@ void GameMap::updateVisibleEntities()
             tile->notifyEntitiesSeatsWithVision();
         }
     }
+}
 
+void GameMap::fireRefreshEntities()
+{
     // Notify changes on visible tiles
     for(Seat* seat : mSeats)
         seat->notifyChangedVisibleTiles();

--- a/source/gamemap/GameMap.h
+++ b/source/gamemap/GameMap.h
@@ -493,6 +493,8 @@ public:
 
     void updateVisibleEntities();
 
+    void fireRefreshEntities();
+
     inline const std::vector<RenderedMovableEntity*>& getRenderedMovableEntities() const
     { return mRenderedMovableEntities; }
 

--- a/source/network/ODServer.cpp
+++ b/source/network/ODServer.cpp
@@ -386,6 +386,7 @@ void ODServer::startNewTurn(double timeSinceLastTurn)
             break;
     }
 
+    gameMap->fireRefreshEntities();
     gameMap->processDeletionQueues();
 }
 


### PR DESCRIPTION
@akien-mga This should be merged before making the release as there is a visual glitch in the current dev repo
