### PR TITLE
Added a timeout to chat messages

### DIFF
--- a/source/modes/GameEditorModeBase.h
+++ b/source/modes/GameEditorModeBase.h
@@ -23,6 +23,15 @@
 #include "game/PlayerSelection.h"
 #include "gamemap/MiniMapCamera.h"
 
+//! \brief Enum to check if the chat message box should be displayed or not
+//! It is used as a bit array
+enum ChatMessageBoxDisplay
+{
+    hide                    = 0x00,
+    showChatInput           = 0x01,
+    showMessageReceived     = 0x02
+};
+
 class GameEditorModeConsole;
 
 namespace CEGUI
@@ -128,6 +137,15 @@ protected:
     //! \brief A reference to the game map used by the game mode
     //! For now, handled by the frame listener, don't delete it from here.
     GameMap* mGameMap;
+
+    //! \brief Show or hide the chat message box depending on mChatMessageBoxDisplay
+    void refreshChatDisplay();
+
+    //! \brief Counter to hide chat message box after some time with no
+    //! new message
+    Ogre::Real mChatMessageDisplayTime;
+    //! \brief bit array to know if the chat display should be hiden or not
+    uint32_t mChatMessageBoxDisplay;
 
     //! \brief The minimap used in this mode
     MiniMapCamera mMiniMap;

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -913,6 +913,8 @@ bool GameMode::keyPressedNormal(const OIS::KeyEvent &arg)
         CEGUI::Window* chatEditBox = mRootWindow->getChild("GameChatWindow/GameChatEditBox");
         chatEditBox->show();
         chatEditBox->activate();
+        mChatMessageBoxDisplay |= ChatMessageBoxDisplay::showChatInput;
+        refreshChatDisplay();
         break;
     }
 
@@ -945,6 +947,8 @@ bool GameMode::keyPressedChat(const OIS::KeyEvent &arg)
         mCurrentInputMode = InputModeNormal;
         chatEditBox->setText("");
         chatEditBox->hide();
+        mChatMessageBoxDisplay &= ~ChatMessageBoxDisplay::showChatInput;
+        refreshChatDisplay();
         return true;
     }
 
@@ -953,6 +957,8 @@ bool GameMode::keyPressedChat(const OIS::KeyEvent &arg)
 
     mCurrentInputMode = InputModeNormal;
     chatEditBox->hide();
+    mChatMessageBoxDisplay &= ~ChatMessageBoxDisplay::showChatInput;
+    refreshChatDisplay();
 
     // Check whether something was actually typed.
     if (chatEditBox->getText().empty())


### PR DESCRIPTION
The chat message box will be displayed:
- for 30 seconds after receiving a message (harcoded, easy to move where we want later)
- When the edit box to write a chat message is displayed (when enter is pressed)

The chat messages are only removed at game start. That means that history can be browse during the whole game
