### PR TITLE
Fix resources being loaded twice + fix some issues reported by gcc sanitizer

### DIFF
--- a/source/creatureeffect/CreatureEffectSpeedChange.cpp
+++ b/source/creatureeffect/CreatureEffectSpeedChange.cpp
@@ -59,6 +59,7 @@ void CreatureEffectSpeedChange::applyEffect(Creature& creature)
 
 void CreatureEffectSpeedChange::releaseEffect(Creature& creature)
 {
+    //FIXME: sanitizer reports that this is called at least once on something that is not a creature.
     if(!creature.isAlive())
         return;
 

--- a/source/entities/Building.cpp
+++ b/source/entities/Building.cpp
@@ -426,6 +426,7 @@ bool Building::importFromStream(std::istream& is)
             continue;
         }
 
+        //FIXME: Some of these are not deleted. Maybe use smart pointers here?
         TileData* tileData = createTileData(tile);
         mTileData[tile] = tileData;
         tileData->mSeatsVision = alliedSeats;

--- a/source/entities/GameEntity.cpp
+++ b/source/entities/GameEntity.cpp
@@ -103,6 +103,14 @@ GameEntity::GameEntity(
     assert(mGameMap != nullptr);
 }
 
+GameEntity::~GameEntity()
+{
+    for (auto* e : mEntityParticleEffects)
+    {
+        delete e;
+    };
+}
+
 void GameEntity::deleteYourself()
 {
     destroyMesh();

--- a/source/entities/GameEntity.h
+++ b/source/entities/GameEntity.h
@@ -160,7 +160,7 @@ class GameEntity
           Seat*           seat        = nullptr
           );
 
-    virtual ~GameEntity() {}
+    virtual ~GameEntity();
 
     std::string getOgreNamePrefix() const;
 

--- a/source/network/ODClient.cpp
+++ b/source/network/ODClient.cpp
@@ -1000,6 +1000,7 @@ void ODClient::addEventMessage(EventMessage* event)
         }
         // Note: Later, we can handle other modes here.
         default:
+            delete event;
             break;
     }
 }

--- a/source/spells/SpellCallToWar.cpp
+++ b/source/spells/SpellCallToWar.cpp
@@ -69,7 +69,7 @@ static SpellRegister reg(new SpellCallToWarFactory);
 }
 
 SpellCallToWar::SpellCallToWar(GameMap* gameMap) :
-    Spell(gameMap, SpellManager::getSpellNameFromSpellType(getSpellType()), "WarBanner", 0.0,
+    Spell(gameMap, SpellManager::getSpellNameFromSpellType(SpellType::callToWar), "WarBanner", 0.0,
         ConfigManager::getSingleton().getSpellConfigInt32("CallToWarNbTurnsMax"))
 {
     mPrevAnimationState = "Loop";

--- a/source/utils/ResourceManager.cpp
+++ b/source/utils/ResourceManager.cpp
@@ -481,10 +481,10 @@ void ResourceManager::setupOgreResources(uint16_t shaderLanguageVersion)
             // for locating your configuration files and resources.
 
             Ogre::ResourceGroupManager::getSingleton().addResourceLocation(
-                    Ogre::String(std::string(mMacBundlePath) + archName), typeName, secName, true);
+                    Ogre::String(std::string(mMacBundlePath) + archName), typeName, secName, false);
 #else
             Ogre::ResourceGroupManager::getSingleton().addResourceLocation(
-                    archName, typeName, secName, true);
+                    archName, typeName, secName, false);
 #endif
         }
     }


### PR DESCRIPTION
fixes #1271

Additional sanitizer complaints: 

```
/usr/local/include/OGRE/OgreSingleton.h:83:23: runtime error: downcast of address 0x7ffc83e19d60 which does not point to an object of type 'MusicPlayer'
0x7ffc83e19d60: note: object has invalid vptr
 60 61 00 00  00 00 00 00 00 00 00 00  64 cf 8d 5b 27 7f 00 00  80 c6 00 00 60 61 00 00  83 71 81 5b
              ^~~~~~~~~~~~~~~~~~~~~~~
              invalid vptr
/usr/local/include/OGRE/OgreSharedPtr.h:365:13: runtime error: member call on address 0x6030015343f0 which does not point to an object of type 'SharedPtrInfo'
0x6030015343f0: note: object is of type 'Ogre::SharedPtrInfoDeleteT<std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >'
 c8 00 00 71  08 67 7c 5b 27 7f 00 00  00 00 00 00 be be be be  20 44 53 01 30 60 00 00  00 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'Ogre::SharedPtrInfoDeleteT<std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >'
/usr/local/include/OGRE/OgreSingleton.h:83:23: runtime error: downcast of address 0x7ffc83e19800 which does not point to an object of type 'SoundEffectsManager'
0x7ffc83e19800: note: object has invalid vptr
 fc 7f 00 00  00 00 00 00 00 00 00 00  01 00 00 00 00 00 00 00  81 90 8b 5b 27 7f 00 00  81 61 81 5b
              ^~~~~~~~~~~~~~~~~~~~~~~
              invalid vptr
/usr/local/include/OGRE/OgreSingleton.h:83:23: runtime error: downcast of address 0x7ffc83e19ee0 which does not point to an object of type 'ODServer'
0x7ffc83e19ee0: note: object has invalid vptr
 60 60 00 00  00 00 00 00 00 00 00 00  f8 ff ff ff ff ff ff ff  00 70 94 5c 27 7f 00 00  c0 cb 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              invalid vptr
/usr/local/include/OGRE/OgreSingleton.h:83:23: runtime error: downcast of address 0x7ffc83e1a9e0 which does not point to an object of type 'ODClient'
0x7ffc83e1a9e0: note: object has invalid vptr
 34 59 7a ff  00 00 00 00 00 00 00 00  30 b4 e1 83 fc 7f 00 00  30 ae e1 83 fc 7f 00 00  4e 35 7c 90
              ^~~~~~~~~~~~~~~~~~~~~~~
              invalid vptr
/usr/local/include/OGRE/OgreSingleton.h:83:23: runtime error: downcast of address 0x7ffc83e198e0 which does not point to an object of type 'ODFrameListener'
0x7ffc83e198e0: note: object has invalid vptr
 27 7f 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  1a ad 79 5c
              ^~~~~~~~~~~~~~~~~~~~~~~
              invalid vptr
/<deleted>/OpenDungeons/source/gamemap/GameMap.cpp:124:14: runtime error: load of value 208, which is not a valid value for type 'bool'
/<deleted>/OpenDungeons/source/entities/MovableGameEntity.cpp:347:11: runtime error: load of value 190, which is not a valid value for type 'bool'
/<deleted>/OpenDungeons/source/creatureeffect/CreatureEffectSpeedChange.cpp:62:25: runtime error: member call on address 0x619000aab480 which does not point to an object of type 'Creature'
0x619000aab480: note: object is of type 'GameEntity'
 67 01 00 4b  c0 73 a7 35 0c 56 00 00  00 00 3c 42 ff 54 57 42  00 00 00 00 be be be be  a8 b4 aa 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'GameEntity'
/<deleted>/OpenDungeons/source/entities/Creature.cpp:654:12: runtime error: member access within address 0x619000aab480 which does not point to an object of type 'Creature'
0x619000aab480: note: object is of type 'GameEntity'
 67 01 00 4b  c0 73 a7 35 0c 56 00 00  00 00 3c 42 ff 54 57 42  00 00 00 00 be be be be  a8 b4 aa 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'GameEntity'
/<deleted>/OpenDungeons/source/creatureeffect/CreatureEffectSpeedChange.cpp:65:36: runtime error: member call on address 0x619000aab480 which does not point to an object of type 'Creature'
0x619000aab480: note: object is of type 'GameEntity'
 67 01 00 4b  c0 73 a7 35 0c 56 00 00  00 00 3c 42 ff 54 57 42  00 00 00 00 be be be be  a8 b4 aa 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'GameEntity'
/<deleted>/OpenDungeons/source/entities/Creature.cpp:3130:25: runtime error: member call on address 0x619000aab480 which does not point to an object of type 'Creature'
0x619000aab480: note: object is of type 'GameEntity'
 67 01 00 4b  c0 73 a7 35 0c 56 00 00  00 00 3c 42 ff 54 57 42  00 00 00 00 be be be be  a8 b4 aa 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'GameEntity'
/<deleted>/OpenDungeons/source/entities/Creature.cpp:3108:5: runtime error: member access within address 0x619000aab480 which does not point to an object of type 'Creature'
0x619000aab480: note: object is of type 'GameEntity'
 67 01 00 4b  c0 73 a7 35 0c 56 00 00  00 00 3c 42 ff 54 57 42  00 00 00 00 be be be be  a8 b4 aa 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'GameEntity'

=================================================================
==19151==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 672 byte(s) in 12 object(s) allocated from:
    #0 0x7f275b8b9270 in __interceptor_realloc (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xc7270)
    #1 0x7f2758ee7fd3  (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0x91fd3)

Direct leak of 448 byte(s) in 8 object(s) allocated from:
    #0 0x7f275b8b9f00 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xc7f00)
    #1 0x7f275a358954 in CEGUI::OgreTexture::loadFromMemory(void const*, CEGUI::Size<float> const&, CEGUI::Texture::PixelFormat) (/usr/local/lib/libCEGUIOgreRenderer-0.so.2+0x21954)

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f275b8b8ec0 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xc6ec0)
    #1 0x7f27543bbf4d in XextCreateExtension (/usr/lib/x86_64-linux-gnu/libXext.so.6+0xcf4d)

Indirect leak of 6184808 byte(s) in 8 object(s) allocated from:
    #0 0x7f275b8ba0a0 in operator new[](unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xc80a0)
    #1 0x7f275a35892f in CEGUI::OgreTexture::loadFromMemory(void const*, CEGUI::Size<float> const&, CEGUI::Texture::PixelFormat) (/usr/local/lib/libCEGUIOgreRenderer-0.so.2+0x2192f)

SUMMARY: AddressSanitizer: 6185952 byte(s) leaked in 29 allocation(s).
```