### PR TITLE
Patch for 64 bit systems, where toString(uint64_t d) and toString(siz…

### DIFF
--- a/source/utils/Helper.cpp
+++ b/source/utils/Helper.cpp
@@ -274,10 +274,12 @@ namespace Helper
     {
         return TTostring(d);
     }
+    #ifndef __x86_64
     std::string toString(size_t d)
     {
         return TTostring(d);
     }
+    #endif
     std::string toString(const Ogre::Vector3& v)
     {
         return "(" + TTostring(v.x)

--- a/source/utils/Helper.h
+++ b/source/utils/Helper.h
@@ -138,7 +138,9 @@ namespace Helper
     std::string toString(uint32_t d);
     std::string toString(int64_t d);
     std::string toString(uint64_t d);
+    #ifndef __x86_64
     std::string toString(size_t d);
+    #endif
     std::string toString(const Ogre::Vector3& v);
     std::string toStringWithoutZ(const Ogre::Vector3& v);
     std::string toString(const Ogre::ColourValue& c);


### PR DESCRIPTION
…e_t d) were overlapping declarations (and definitions), breaking the build.

I remove these definitions from the 64 bit build.  There's probably a cleaner way to do this, but this should leave 32 bit builds alone while fixing 64 bit builds.