### PR TITLE
Fixes for build on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ else()
     # Set binary and data install locations if we want to use the installer
     set(OD_BIN_PATH ${CMAKE_INSTALL_PREFIX}/games CACHE PATH "Absolute path to the game binary directory")
     set(OD_DATA_PATH ${CMAKE_INSTALL_PREFIX}/share/games/${PROJECT_NAME} CACHE PATH "Absolute path to the game data directory")
+    set(OD_MAN_PATH ${CMAKE_INSTALL_PREFIX}/share CACHE PATH "Absolute path to the manpages directory")
     set(OD_SHARE_PATH ${CMAKE_INSTALL_PREFIX}/share CACHE PATH "Absolute path to the shared data directory (desktop file, icons, etc.)")
     # Set the plugins.cfg file path to a common but architecture-dependent location.
     # Because the plugins.cfg Ogre plugins path path may vary depending on the architecture used.
@@ -629,6 +630,11 @@ target_link_libraries(
     ${EXTRA_LIBRARIES}
 )
 
+# backtrace functions are not part of libc like on Linux platform
+if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    target_link_libraries(${PROJECT_BINARY_NAME} execinfo)
+endif()
+
 # Set linker options in MSVC
 if(WIN32 AND MSVC)
     # We need to force output because of the boost lib used, defining two times the
@@ -776,7 +782,7 @@ if(UNIX)
     install(FILES ${CMAKE_BINARY_DIR}/opendungeons.desktop
             DESTINATION ${OD_SHARE_PATH}/applications)
     install(FILES ${CMAKE_BINARY_DIR}/opendungeons.6
-            DESTINATION ${OD_SHARE_PATH}/man/man6)
+	    DESTINATION ${OD_MAN_PATH}/man/man6)
     install(FILES ${OD_DOC}
             DESTINATION ${OD_SHARE_PATH}/doc/${PROJECT_NAME})
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/dist/hicolor

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,8 @@ else()
     # Set binary and data install locations if we want to use the installer
     set(OD_BIN_PATH ${CMAKE_INSTALL_PREFIX}/games CACHE PATH "Absolute path to the game binary directory")
     set(OD_DATA_PATH ${CMAKE_INSTALL_PREFIX}/share/games/${PROJECT_NAME} CACHE PATH "Absolute path to the game data directory")
-    set(OD_MAN_PATH ${CMAKE_INSTALL_PREFIX}/share CACHE PATH "Absolute path to the manpages directory")
     set(OD_SHARE_PATH ${CMAKE_INSTALL_PREFIX}/share CACHE PATH "Absolute path to the shared data directory (desktop file, icons, etc.)")
+    set(OD_MAN_PATH ${OD_SHARE_PATH}/man CACHE PATH "Absolute path to the manpages directory")
     # Set the plugins.cfg file path to a common but architecture-dependent location.
     # Because the plugins.cfg Ogre plugins path path may vary depending on the architecture used.
     set(OD_PLUGINS_CFG_PATH /etc/${PROJECT_NAME} CACHE PATH "Absolute path to the Ogre plugins.cfg file")
@@ -782,7 +782,7 @@ if(UNIX)
     install(FILES ${CMAKE_BINARY_DIR}/opendungeons.desktop
             DESTINATION ${OD_SHARE_PATH}/applications)
     install(FILES ${CMAKE_BINARY_DIR}/opendungeons.6
-	    DESTINATION ${OD_MAN_PATH}/man/man6)
+            DESTINATION ${OD_MAN_PATH}/man6)
     install(FILES ${OD_DOC}
             DESTINATION ${OD_SHARE_PATH}/doc/${PROJECT_NAME})
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/dist/hicolor

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,11 +630,6 @@ target_link_libraries(
     ${EXTRA_LIBRARIES}
 )
 
-# backtrace functions are not part of libc like on Linux platform
-if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
-    target_link_libraries(${PROJECT_BINARY_NAME} execinfo)
-endif()
-
 # Set linker options in MSVC
 if(WIN32 AND MSVC)
     # We need to force output because of the boost lib used, defining two times the

--- a/source/utils/StackTraceUnix.cpp
+++ b/source/utils/StackTraceUnix.cpp
@@ -107,13 +107,13 @@ void StackTracePrintPrivateData::critErrHandler(int sig_num, siginfo_t* info, vo
     sig_ucontext_t* uc = static_cast<sig_ucontext_t*>(ucontext);
 
 #if defined(__i386__) // gcc specific
-#if !defined(__OpenBSD__)
+#if !defined(__FreeBSD__) && !defined(__OpenBSD__)
     caller_address = reinterpret_cast<void*>(uc->uc_mcontext.eip); // EIP: x86 specific
 #else
     caller_address = reinterpret_cast<void*>(uc->uc_mcontext.sc_eip); // EIP: x86 specific
 #endif
 #elif defined(__x86_64__) // gcc specific
-#if !defined(__OpenBSD__)
+#if !defined(__FreeBSD__) && !defined(__OpenBSD__)
     caller_address = reinterpret_cast<void*>(uc->uc_mcontext.rip); // RIP: x86_64 specific
 #else
     caller_address = reinterpret_cast<void*>(uc->uc_mcontext.sc_rip); // RIP: x86_64 specific


### PR DESCRIPTION
- Add OD_MAN_PATH variable allowing customization of manpages install prefix
- Link with libexecinfo needed for backtrace functions
- Patch StackTraceUnix.cpp similar to OpenBSD