### PR TITLE
Unbreak build on 32bit platforms

### DIFF
--- a/source/utils/Helper.cpp
+++ b/source/utils/Helper.cpp
@@ -274,7 +274,7 @@ namespace Helper
     {
         return TTostring(d);
     }
-    #ifndef __x86_64
+    #if defined(__OpenBSD__) && defined(__LP64__)
     std::string toString(size_t d)
     {
         return TTostring(d);

--- a/source/utils/Helper.h
+++ b/source/utils/Helper.h
@@ -138,7 +138,7 @@ namespace Helper
     std::string toString(uint32_t d);
     std::string toString(int64_t d);
     std::string toString(uint64_t d);
-    #ifndef __x86_64
+    #if defined(__OpenBSD__) && defined(__LP64__)
     std::string toString(size_t d);
     #endif
     std::string toString(const Ogre::Vector3& v);


### PR DESCRIPTION
#1283 fixed only x86_64 but x86 is still broken:
```c++
source/utils/Helper.cpp:278:17: error: redefinition of 'toString'
    std::string toString(size_t d)
                ^
source/utils/Helper.cpp:265:17: note: previous definition is here
    std::string toString(uint32_t d)
                ^
1 error generated.
```

@devnexen, can you check this PR doesn't break OpenBSD build?
