### PR TITLE
Fix build with OGRE >= 1.11.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,7 +514,7 @@ if(OD_USE_SFML_WINDOW)
 else()
     find_package(SFML 2 REQUIRED COMPONENTS Audio System Network)
 endif()
-if((OGRE_VERSION_MAJOR LESS 1) AND (OGRE_VERSION_MINOR LESS 9))
+if("${OGRE_VERSION}" VERSION_LESS "1.9.0")
     message(FATAL_ERROR "OGRE version >= 1.9.0 required")
 endif()
 
@@ -702,7 +702,14 @@ else()
     message(STATUS "Plugin path dbg: " ${OD_OGRE_PLUGIN_DIR_DBG})
 endif()
 
-#Do the configuration
+# Do the configuration
+# Convoluted check because old CMake has no VERSION_GREATER_EQUAL,
+# we want this true for 1.11 or later since plugins have to be declared manually.
+if("${OGRE_VERSION}" VERSION_LESS "1.11")
+    set(OD_OGRE_VERSION_SPECIFIC_PLUGINS "")
+else()
+    set(OD_OGRE_VERSION_SPECIFIC_PLUGINS "Plugin=Codec_FreeImage")
+endif()
 configure_file(${CMAKE_CONFIG_DIR}/plugins.cfg.in ${CMAKE_BINARY_DIR}/plugins.cfg)
 if(WIN32)
     configure_file(${CMAKE_CONFIG_DIR}/plugins_d.cfg.in ${CMAKE_BINARY_DIR}/plugins_d.cfg)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -626,6 +626,7 @@ target_link_libraries(
 
     #libraries
     ${OGRE_LIBRARIES}
+    ${OGRE_Bites_LIBRARIES}
     ${OGRE_RTShaderSystem_LIBRARIES}
     ${OIS_LIBRARIES}
     ${CEGUI_LIBRARIES}

--- a/cmake/config/plugins.cfg.in
+++ b/cmake/config/plugins.cfg.in
@@ -7,6 +7,9 @@ PluginFolder=@OD_OGRE_PLUGIN_DIR_REL@
 Plugin=RenderSystem_GL
 Plugin=Plugin_ParticleFX
 
+# Version-specific plugins (e.g. codecs for 1.11+)
+@OD_OGRE_VERSION_SPECIFIC_PLUGINS@
+
 #This is a card specific library, installed on some systems but not on others
 #Cg is also obsolete and nonfree
 #Plugin=Plugin_CgProgramManager

--- a/cmake/config/plugins_d.cfg.in
+++ b/cmake/config/plugins_d.cfg.in
@@ -7,6 +7,9 @@ PluginFolder=@OD_OGRE_PLUGIN_DIR_DBG@
 Plugin=RenderSystem_GL_d
 Plugin=Plugin_ParticleFX_d
 
+# Version-specific plugins (e.g. codecs for 1.11+)
+@OD_OGRE_VERSION_SPECIFIC_PLUGINS@
+
 #This is a card specific library, installed on some systems but not on others
 #Cg is also obsolete and nonfree
 #Plugin=Plugin_CgProgramManager_d

--- a/cmake/modules/FindOGRE.cmake
+++ b/cmake/modules/FindOGRE.cmake
@@ -148,7 +148,7 @@ else()
 endif ()
 
 # redo search if any of the environmental hints changed
-set(OGRE_COMPONENTS Paging Terrain Volume Overlay 
+set(OGRE_COMPONENTS Paging Terrain Volume Overlay Bites
   Plugin_BSPSceneManager Plugin_CgProgramManager Plugin_OctreeSceneManager
   Plugin_OctreeZone Plugin_PCZSceneManager Plugin_ParticleFX
   RenderSystem_Direct3D11 RenderSystem_Direct3D9 RenderSystem_GL RenderSystem_GL3Plus RenderSystem_GLES RenderSystem_GLES2)
@@ -422,6 +422,8 @@ ogre_find_component(RTShaderSystem OgreRTShaderSystem.h)
 ogre_find_component(Volume OgreVolumePrerequisites.h)
 # look for Overlay component
 ogre_find_component(Overlay OgreOverlaySystem.h)
+# look for Bites component
+ogre_find_component(Bites OgreBitesPrerequisites.h)
 
 #########################################################
 # Find Ogre plugins

--- a/gui/ODSkin.scheme
+++ b/gui/ODSkin.scheme
@@ -5,9 +5,9 @@
     <Imageset filename="ODBackgrounds.imageset" name="ODBackgrounds" />
     <Imageset filename="ODMainMenuButtons.imageset" name="ODMainMenuButtons" />
     <Imageset filename="ODMainMenuBackground.imageset" name="ODMainMenuBackground" />
-    <Font filename="fonts/LiberationSans-10.font" name="LiberationSans-10" />
-    <Font filename="fonts/MedievalSharp-10.font" name="MedievalSharp-10" />
-    <Font filename="fonts/MedievalSharp-12.font" name="MedievalSharp-12" />
+    <Font filename="LiberationSans-10.font" name="LiberationSans-10" />
+    <Font filename="MedievalSharp-10.font" name="MedievalSharp-10" />
+    <Font filename="MedievalSharp-12.font" name="MedievalSharp-12" />
     <LookNFeel filename="OD.looknfeel" />
     <WindowRendererSet filename="CEGUICoreWindowRendererSet" />
     <FalagardMapping lookNFeel="OD/Button" renderer="Core/Button" targetType="CEGUI/PushButton" windowType="OD/Button" />

--- a/source/ODApplication.cpp
+++ b/source/ODApplication.cpp
@@ -37,7 +37,6 @@
 #include "utils/Random.h"
 #include "utils/ResourceManager.h"
 
-#include <OgreErrorDialog.h>
 #include <OgreRenderWindow.h>
 #include <OgreRoot.h>
 #include <Overlay/OgreOverlaySystem.h>

--- a/source/render/MovableTextOverlay.cpp
+++ b/source/render/MovableTextOverlay.cpp
@@ -38,7 +38,8 @@ ChildOverlay::ChildOverlay(const Ogre::String& fontName, Ogre::Real charHeight,
     mForcedHeight(-1),
     mCharHeight(charHeight),
     mTimeToDisplay(0),
-    mFont(Ogre::FontManager::getSingleton().getByName(fontName))
+    // FIXME: Move FontManager usage to ResourceManager somehow and dehardcode "GUI"?
+    mFont(Ogre::FontManager::getSingleton().getByName(fontName, "GUI"))
 {
 #if defined(OGRE_VERSION) && OGRE_VERSION < 0x10A00
     if (mFont.isNull())

--- a/source/render/ODFrameListener.h
+++ b/source/render/ODFrameListener.h
@@ -28,9 +28,14 @@
 
 #include <OgreFrameListener.h>
 #include <OgreSceneQuery.h>
-#include <OgreRenderQueueListener.h>
 #include <OgreSingleton.h>
+#include <OgrePrerequisites.h>
+#include <OgreRenderQueueListener.h>
+#if defined(OGRE_VERSION) && OGRE_VERSION < 0x10B00 // before 1.11
 #include <OgreWindowEventUtilities.h>
+#else
+#include <Bites/OgreWindowEventUtilities.h>
+#endif
 
 #include <memory>
 


### PR DESCRIPTION
Initial patch by @wally-mageia to fix build against OGRE >= 1.11.0, I have yet to test it myself (building the new OGRE locally on Mageia 6).

Wally just told me:

> \<wally_\> Akien: actually we cheat a bit as we're using -Wno-deprecated-declarations in CXXFLAGS
\<wally_\> so my patch isn't complete

But I'm putting it up nevertheless to start the process of porting OD to OGRE 1.11.
@oyvindln mentioned he had started some work on this too and might already be some steps further, we'll see.

Travis and AppVeyor should both fail as they're still building against OGRE 1.11.

Part of #1280.