### PR TITLE
Camera sliding

### DIFF
--- a/source/camera/CameraManager.cpp
+++ b/source/camera/CameraManager.cpp
@@ -320,6 +320,7 @@ void CameraManager::updateCameraFrameTime(const Ogre::Real frameTime)
             getActiveCameraNode()->getChild(0)->rotate(Ogre::Vector3::UNIT_X,
                                         Ogre::Degree(mRotateLocalVector.x * frameTime),
                                         Ogre::Node::TS_LOCAL);
+            mRotateLocalVector.x = 0;
         }
 
     }
@@ -329,6 +330,7 @@ void CameraManager::updateCameraFrameTime(const Ogre::Real frameTime)
         getActiveCameraNode()->rotate(Ogre::Vector3::UNIT_Z,
                                       Ogre::Degree(mRotateLocalVector.y * frameTime),
                                       Ogre::Node::TS_LOCAL);
+        mRotateLocalVector.y = 0;
     }
 
     // Swivel the camera to the left or right, while maintaining the same

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -348,8 +348,6 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
 
     auto mouseEvent = toSFMLMouseMove(arg);
     auto mouseDelta = MouseMoveEvent{mPreviousMousePosition.x - mouseEvent.x, mPreviousMousePosition.y - mouseEvent.y};
-    ODFrameListener::getSingleton().printDebugInfoTail.str(std::string());
-    ODFrameListener::getSingleton().printDebugInfoTail << "mouseDelta x:" << mouseDelta.x << " y:" << mouseDelta.y << " " << std::endl;
     mPreviousMousePosition = mouseEvent;
 
     if (!isConnected())

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -348,6 +348,8 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
 
     auto mouseEvent = toSFMLMouseMove(arg);
     auto mouseDelta = MouseMoveEvent{mPreviousMousePosition.x - mouseEvent.x, mPreviousMousePosition.y - mouseEvent.y};
+    ODFrameListener::getSingleton().printDebugInfoTail.str(std::string());
+    ODFrameListener::getSingleton().printDebugInfoTail << "mouseDelta x:" << mouseDelta.x << " y:" << mouseDelta.y << " " << std::endl;
     mPreviousMousePosition = mouseEvent;
 
     if (!isConnected())

--- a/source/render/ODFrameListener.cpp
+++ b/source/render/ODFrameListener.cpp
@@ -277,7 +277,8 @@ void ODFrameListener::printDebugInfo()
         infoSS << "\ntriangleCount: " << mWindow->getStatistics().triangleCount;
         infoSS << "\nBatches: " << mWindow->getStatistics().batchCount;
         infoSS << "\nTurn number:  " << mGameMap->getTurnNumber();
-        infoSS << "\nCursor:  " << mModeManager->getInputManager().mXPos << ", " << mModeManager->getInputManager().mYPos;
+        infoSS << "\nCursor:  " << mModeManager->getInputManager().mXPos << ", " << mModeManager->getInputManager().mYPos << std::endl;
+        infoSS << printDebugInfoTail.str() << std::endl;
         if(ODClient::getSingleton().isConnected())
         {
             int32_t gameTime = ODClient::getSingleton().getGameTimeMillis() / 1000;

--- a/source/render/ODFrameListener.h
+++ b/source/render/ODFrameListener.h
@@ -33,6 +33,7 @@
 #include <OgreRenderQueueListener.h>
 #include <OgreWindowEventUtilities.h>
 
+#include <sstream>
 #include <memory>
 
 class ChatMessage;
@@ -170,7 +171,8 @@ public:
     {
         return mFpsLimiter.getFrameRate();
     }
-
+    std::stringstream printDebugInfoTail;
+    
 private:
     //! \brief Tells whether the frame listener is initialized.
     bool mInitialized;


### PR DESCRIPTION
This PR removes the bug of constant camera sliding even when no mouse button was pressed. Now you can randomly look around the scene with middle-mouse button without causing the camera to slide. 