### PR TITLE
creatures catch and drop at the point pointed by the "hand" fingers

### DIFF
--- a/source/camera/CameraManager.cpp
+++ b/source/camera/CameraManager.cpp
@@ -201,7 +201,6 @@ void CameraManager::createViewport(Ogre::RenderWindow* renderWindow)
 {
     mViewport = renderWindow->addViewport(nullptr);
     mViewport->setBackgroundColour(Ogre::ColourValue(0, 0, 0));
-
 // TODO: Update registered camera if needed.
 //    for(set<string>::iterator m_itr = mRegisteredCameraNames.begin(); m_itr != mRegisteredCameraNames.end() ; ++m_itr){
 //        Ogre::Camera* tmpCamera = getCamera(*m_itr);

--- a/source/modes/EditorMode.cpp
+++ b/source/modes/EditorMode.cpp
@@ -222,7 +222,8 @@ bool EditorMode::mouseMoved(const OIS::MouseEvent &arg)
     // Since this is a tile selection query we loop over the result set
     // and look for the first object which is actually a tile.
     Ogre::Vector3 keeperHandPos;
-    if(!ODFrameListener::getSingleton().findWorldPositionFromMouse(arg, keeperHandPos))
+    Ogre::Vector3 keeperHandGround;
+    if(!ODFrameListener::getSingleton().findWorldPositionFromMouse(arg, keeperHandPos, keeperHandGround))
         return true;
 
     RenderManager::getSingleton().moveWorldCoords(keeperHandPos.x, keeperHandPos.y);
@@ -353,7 +354,8 @@ bool EditorMode::mousePressed(const OIS::MouseEvent &arg, OIS::MouseButtonID id)
     }
 
     Ogre::Vector3 keeperHandPos;
-    if(!ODFrameListener::getSingleton().findWorldPositionFromMouse(arg, keeperHandPos))
+    Ogre::Vector3 keeperGroundPos;
+    if(!ODFrameListener::getSingleton().findWorldPositionFromMouse(arg, keeperHandPos, keeperGroundPos))
         return true;
 
     RenderManager::getSingleton().moveWorldCoords(keeperHandPos.x, keeperHandPos.y);

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -402,8 +402,8 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
     ODFrameListener::getSingleton().findWorldPositionFromMouse(arg, inputManager.mKeeperHandPos, inputManager.mKeeperHandGroundPos);
     RenderManager::getSingleton().moveWorldCoords(inputManager.mKeeperHandPos.x, inputManager.mKeeperHandPos.y);
 
-    int tileX = Helper::round(inputManager.mKeeperHandPos.x);
-    int tileY = Helper::round(inputManager.mKeeperHandPos.y);
+    int tileX = Helper::round(inputManager.mKeeperHandGroundPos.x);
+    int tileY = Helper::round(inputManager.mKeeperHandGroundPos.y);
     Tile* tileClicked = mGameMap->getTile(tileX, tileY);
     if(tileClicked == nullptr)
         return true;
@@ -440,8 +440,8 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
     if(closestCreature != nullptr)
         RenderManager::getSingleton().rrTemporaryDisplayCreaturesTextOverlay(closestCreature, 0.5f);
 
-    inputManager.mXPos = tileClicked->getX();
-    inputManager.mYPos = tileClicked->getY();
+    inputManager.mXPos = Helper::round(inputManager.mKeeperHandPos.x);
+    inputManager.mYPos = Helper::round(inputManager.mKeeperHandPos.y);
     if (!inputManager.mLMouseDown)
     {
         inputManager.mLStartDragX = inputManager.mXPos;
@@ -554,7 +554,7 @@ bool GameMode::mousePressed(const OIS::MouseEvent& arg, OIS::MouseButtonID id)
     if(mGameMap->getGamePaused())
         return true;
 
-    if(!ODFrameListener::getSingleton().findWorldPositionFromMouse(arg, inputManager.mKeeperHandPos,  inputManager.mKeeperHandPos ))
+    if(!ODFrameListener::getSingleton().findWorldPositionFromMouse(arg, inputManager.mKeeperHandPos,  inputManager.mKeeperHandGroundPos ))
         return true;
 
     RenderManager::getSingleton().moveWorldCoords(inputManager.mKeeperHandPos.x, inputManager.mKeeperHandPos.y);
@@ -611,8 +611,8 @@ bool GameMode::mousePressed(const OIS::MouseEvent& arg, OIS::MouseButtonID id)
     {
         inputManager.mRMouseDown = true;
         // Stop creating rooms, traps, etc.
-        inputManager.mLStartDragX = inputManager.mXPos;
-        inputManager.mLStartDragY = inputManager.mYPos;
+        inputManager.mRStartDragX = inputManager.mXPos;
+        inputManager.mRStartDragY = inputManager.mYPos;
         unselectAllTiles();
         TextRenderer::getSingleton().setText(ODApplication::POINTER_INFO_STRING, "");
         // If we have a currently selected action, we cancel it and don't try to slap or
@@ -736,9 +736,15 @@ bool GameMode::mousePressed(const OIS::MouseEvent& arg, OIS::MouseButtonID id)
     if(mPlayerSelection.getCurrentAction() == SelectedAction::none)
         mPlayerSelection.setCurrentAction(SelectedAction::selectTile);
 
+
+    inputManager.mLStartDragX = Helper::round(inputManager.mKeeperHandPos.x);
+    inputManager.mLStartDragY = Helper::round(inputManager.mKeeperHandPos.y);
+    inputManager.mXPos = inputManager.mLStartDragX ;
+    inputManager.mYPos = inputManager.mLStartDragY ;
+    
     // If we are in a game we store the opposite of whether this tile is marked for digging or not, this allows us to mark tiles
     // by dragging out a selection starting from an unmarcked tile, or unmark them by starting the drag from a marked one.
-    mDigSetBool = !(tileClicked->getMarkedForDigging(mGameMap->getLocalPlayer()));
+    mDigSetBool = !(mGameMap->getTile(inputManager.mLStartDragX,inputManager.mLStartDragY)->getMarkedForDigging(mGameMap->getLocalPlayer()));
 
     return true;
 }

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -399,7 +399,7 @@ bool GameMode::mouseMoved(const OIS::MouseEvent &arg)
 
     // Since this is a tile selection query we loop over the result set
     // and look for the first object which is actually a tile.
-    ODFrameListener::getSingleton().findWorldPositionFromMouse(arg, inputManager.mKeeperHandPos);
+    ODFrameListener::getSingleton().findWorldPositionFromMouse(arg, inputManager.mKeeperHandPos, inputManager.mKeeperHandGroundPos);
     RenderManager::getSingleton().moveWorldCoords(inputManager.mKeeperHandPos.x, inputManager.mKeeperHandPos.y);
 
     int tileX = Helper::round(inputManager.mKeeperHandPos.x);
@@ -554,7 +554,7 @@ bool GameMode::mousePressed(const OIS::MouseEvent& arg, OIS::MouseButtonID id)
     if(mGameMap->getGamePaused())
         return true;
 
-    if(!ODFrameListener::getSingleton().findWorldPositionFromMouse(arg, inputManager.mKeeperHandPos))
+    if(!ODFrameListener::getSingleton().findWorldPositionFromMouse(arg, inputManager.mKeeperHandPos,  inputManager.mKeeperHandPos ))
         return true;
 
     RenderManager::getSingleton().moveWorldCoords(inputManager.mKeeperHandPos.x, inputManager.mKeeperHandPos.y);
@@ -626,7 +626,7 @@ bool GameMode::mousePressed(const OIS::MouseEvent& arg, OIS::MouseButtonID id)
         if(mGameMap->getLocalPlayer()->numObjectsInHand() > 0)
         {
             // If we right clicked with the mouse over a valid map tile, try to drop what we have in hand on the map.
-            Tile *curTile = mGameMap->getTile(inputManager.mXPos, inputManager.mYPos);
+            Tile *curTile = mGameMap->getTile(inputManager.mKeeperHandGroundPos.x, inputManager.mKeeperHandGroundPos.y);
 
             if (curTile == nullptr)
                 return true;
@@ -659,7 +659,7 @@ bool GameMode::mousePressed(const OIS::MouseEvent& arg, OIS::MouseButtonID id)
                     continue;
 
                 const Ogre::Vector3& entityPos = entity->getPosition();
-                double dist = Pathfinding::squaredDistance(entityPos.x, inputManager.mKeeperHandPos.x, entityPos.y, inputManager.mKeeperHandPos.y);
+                double dist = Pathfinding::squaredDistance(entityPos.x, inputManager.mKeeperHandGroundPos.x, entityPos.y, inputManager.mKeeperHandGroundPos.y);
                 if(closestEntity == nullptr)
                 {
                     closestDist = dist;
@@ -707,7 +707,7 @@ bool GameMode::mousePressed(const OIS::MouseEvent& arg, OIS::MouseButtonID id)
                 continue;
 
             const Ogre::Vector3& entityPos = entity->getPosition();
-            double dist = Pathfinding::squaredDistance(entityPos.x, inputManager.mKeeperHandPos.x, entityPos.y, inputManager.mKeeperHandPos.y);
+            double dist = Pathfinding::squaredDistance(entityPos.x, inputManager.mKeeperHandGroundPos.x, entityPos.y, inputManager.mKeeperHandGroundPos.y);
             if(closestEntity == nullptr)
             {
                 closestDist = dist;

--- a/source/modes/GameMode.cpp
+++ b/source/modes/GameMode.cpp
@@ -1752,9 +1752,6 @@ void GameMode::handlePlayerActionNone()
         unselectAllTiles();
         return;
     }
-
-    selectSquaredTiles(inputManager.mXPos, inputManager.mYPos, inputManager.mXPos,
-        inputManager.mYPos);
 }
 
 void GameMode::handlePlayerActionSelectTile()

--- a/source/modes/InputManager.h
+++ b/source/modes/InputManager.h
@@ -73,6 +73,7 @@ public:
     bool                mMouseDownOnCEGUIWindow;
 
     Ogre::Vector3       mKeeperHandPos;
+    Ogre::Vector3       mKeeperHandGroundPos;
     int                 mXPos, mYPos;
     int                 mLStartDragX, mLStartDragY;
     int                 mRStartDragX, mRStartDragY;

--- a/source/render/ODFrameListener.cpp
+++ b/source/render/ODFrameListener.cpp
@@ -66,6 +66,8 @@ namespace
     const unsigned int DEFAULT_FRAME_RATE = 60;
 }
 
+const double ODFrameListener::TILE_HIGH_WORLD_Z  = 1.50;
+
 /*! \brief This constructor is where the OGRE rendering system is initialized and started.
  *
  * The primary function of this routine is to initialize variables, and start
@@ -245,21 +247,28 @@ bool ODFrameListener::quit(const CEGUI::EventArgs &)
     return true;
 }
 
-bool ODFrameListener::findWorldPositionFromMouse(const OIS::MouseEvent &arg, Ogre::Vector3& keeperHand3DPos)
+bool ODFrameListener::findWorldPositionFromMouse(const OIS::MouseEvent &arg, Ogre::Vector3& keeperHand3DPos,  Ogre::Vector3& keeperHand3DGround)
 {
     // Setup the ray scene query, use CEGUI's mouse position
     CEGUI::Vector2<float> mousePos = CEGUI::System::getSingleton().getDefaultGUIContext().getMouseCursor().getPosition();// * mMouseScale;
     Ogre::Ray mouseRay = mCameraManager.getActiveCamera()->getCameraToViewportRay(mousePos.d_x / float(
             arg.state.width), mousePos.d_y / float(arg.state.height));
 
+    Ogre::Plane handPlane(Ogre::Vector3::UNIT_Z, TILE_HIGH_WORLD_Z) ;
     Ogre::Plane groundPlane(Ogre::Vector3::UNIT_Z, 0.0);
-    std::pair<bool, Ogre::Real> p = mouseRay.intersects(groundPlane);
-    if(p.first)
+    std::pair<bool, Ogre::Real> pp = mouseRay.intersects(handPlane);
+    std::pair<bool, Ogre::Real> qq = mouseRay.intersects(groundPlane);
+    
+    if(pp.first && qq.first )
     {
-        keeperHand3DPos = mouseRay.getPoint(p.second);
+        keeperHand3DPos = mouseRay.getPoint(pp.second);
+        keeperHand3DGround = mouseRay.getPoint(qq.second);
         return true;
     }
 
+
+
+    
     return false;
 
 }

--- a/source/render/ODFrameListener.cpp
+++ b/source/render/ODFrameListener.cpp
@@ -252,7 +252,7 @@ bool ODFrameListener::findWorldPositionFromMouse(const OIS::MouseEvent &arg, Ogr
     Ogre::Ray mouseRay = mCameraManager.getActiveCamera()->getCameraToViewportRay(mousePos.d_x / float(
             arg.state.width), mousePos.d_y / float(arg.state.height));
 
-    Ogre::Plane groundPlane(Ogre::Vector3::UNIT_Z, RenderManager::KEEPER_HAND_WORLD_Z);
+    Ogre::Plane groundPlane(Ogre::Vector3::UNIT_Z, 0.0);
     std::pair<bool, Ogre::Real> p = mouseRay.intersects(groundPlane);
     if(p.first)
     {

--- a/source/render/ODFrameListener.h
+++ b/source/render/ODFrameListener.h
@@ -81,6 +81,8 @@ public:
 
     void requestExit();
 
+    static const double TILE_HIGH_WORLD_Z ;
+    
     inline float getEventMaxTimeDisplay() const
     { return mEventMaxTimeDisplay; }
 
@@ -117,7 +119,7 @@ public:
     //! \brief This permits to get the keeperHand world coordinates from the cursor position
     //! returns true if the keeper hand position was successfully computed and false otherwise.
     //! If it returns false, keeperHand3DPos will stay unchanged
-    bool findWorldPositionFromMouse(const OIS::MouseEvent &arg, Ogre::Vector3& keeperHand3DPos);
+    bool findWorldPositionFromMouse(const OIS::MouseEvent &arg, Ogre::Vector3& keeperHand3DPos, Ogre::Vector3& keeperHand3DGround);
 
     /*! \brief Print a string in the upper right corner of the screen.
      *  Usually used for system or debug info


### PR DESCRIPTION
We now can pickup and drop creatures by the point pointed by hand fingers, before it was pretty messed up, the game took the plane of highness 1,5 instead of 0,0 found the intersection and then claimed it was intersection with the Ground ( x = 0 . y = 0 ) .....