### PR TITLE
Fix -Wrange-loop-construct error with GCC 11

### DIFF
--- a/source/entities/Building.cpp
+++ b/source/entities/Building.cpp
@@ -133,10 +133,9 @@ bool Building::canBuildingBeRemoved()
     if(mBuildingObjects.empty())
         return ret;
 
-    for (const std::pair<Tile* const, RenderedMovableEntity*>& p : mBuildingObjects)
+    for (auto& p : mBuildingObjects)
     {
-        RenderedMovableEntity* obj = p.second;
-        if(!obj->notifyRemoveAsked())
+        if(!p.second->notifyRemoveAsked())
             ret = false;
     }
 


### PR DESCRIPTION
```
/home/akien/Projects/mageia/Checkout/opendungeons/BUILD/opendungeons-0.7.1/source/entities/Building.cpp: In member function 'bool Building::canBuildingBeRemoved()':
/home/akien/Projects/mageia/Checkout/opendungeons/BUILD/opendungeons-0.7.1/source/entities/Building.cpp:128:64: error: loop variable 'p' of type 'const std::pair<Tile* const, RenderedMovableEntity*>&' binds to a temporary constructed from type 'std::pair<Tile* const, BuildingObject*>' [-Werror=range-loop-construct]
  128 |     for (const std::pair<Tile* const, RenderedMovableEntity*>& p : mBuildingObjects)
      |                                                                ^
```