### PR TITLE
CMake: Enable C++14 by default, needed by boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,21 +132,22 @@ endif()
 # This makes it possible to have them explicitly displayed in CMake GUI
 # CMAKE_CXX_FLAGS can still be used to override our default defintions
 set(OD_OPT_FLAGS CACHE STRING "Optimization and optional compilation flags")
-set(OD_CXX11_FLAGS CACHE STRING "Compilation flags to enable C++11 support")
+set(OD_CXXSTD_FLAGS CACHE STRING "Compilation flags to enable a given C++ standard")
 
 if(MSVC)
-    # C++11 compilation flag is activated by default
+    # C++14 compilation flag is activated by default
     # Optimisation flags can be added if deemed useful
 else()
     include(CheckCXXCompilerFlag)
-    if(NOT OD_CXX11_FLAGS)
-        CHECK_CXX_COMPILER_FLAG("-std=c++11" OD_CXX11_FLAG_SUPPORTED)
-        CHECK_CXX_COMPILER_FLAG("-std=gnu++11" OD_CXXGNU11_FLAG_SUPPORTED)
-        # MinGW supports CXX11 flag but do not compile with it. However, it works with gnu++11
-        if(OD_CXX11_FLAG_SUPPORTED AND NOT MINGW)
-            set(OD_CXX11_FLAGS "-std=c++11" CACHE STRING "Compilation flags to enable C++11 support" FORCE)
-        elseif(OD_CXX11_FLAG_SUPPORTED)
-            set(OD_CXX11_FLAGS "-std=gnu++11" CACHE STRING "Compilation flags to enable C++11 support" FORCE)
+    if(NOT OD_CXXSTD_FLAGS)
+        CHECK_CXX_COMPILER_FLAG("-std=c++14" OD_CXX14_FLAG_SUPPORTED)
+        CHECK_CXX_COMPILER_FLAG("-std=gnu++14" OD_CXXGNU14_FLAG_SUPPORTED)
+        # FIXME: Apparently MinGW used not to support c++11 back in the days.
+        # See if it's still relevant with c++14 and recent MinGW (probably not).
+        if(OD_CXX14_FLAG_SUPPORTED AND NOT MINGW)
+            set(OD_CXXSTD_FLAGS "-std=c++14" CACHE STRING "Compilation flags to enable C++14 support" FORCE)
+        elseif(OD_CXXGNU14_FLAG_SUPPORTED)
+            set(OD_CXXSTD_FLAGS "-std=gnu++14" CACHE STRING "Compilation flags to enable C++14 support" FORCE)
         endif()
     endif()
     if(OD_ENABLE_WARNINGS)
@@ -207,7 +208,7 @@ if(OD_USE_SFML_WINDOW)
     add_definitions(-DOD_USE_SFML_WINDOW)
 endif()
 
-set(CMAKE_CXX_FLAGS "${OD_CXX11_FLAGS} ${OD_OPT_FLAGS} ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${OD_CXXSTD_FLAGS} ${OD_OPT_FLAGS} ${CMAKE_CXX_FLAGS}")
 message(STATUS "CMake CXX Flags: " ${CMAKE_CXX_FLAGS})
 
 set(EXTRA_LIBRARIES "")


### PR DESCRIPTION
Recent boost versions (at least 1.76.0 but also a few before that) require
C++14 to use lambdas and other modern features.

OD code itself doesn't need it per se but it doesn't hurt, is the default on
most compilers (though that's changing to C++17 now), and fixes compilation
with recent boost.

Our logic to check flags is a bit overkill if you ask me but well, I wanted to
keep changes minimal.